### PR TITLE
Add free shipping progress bar

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -140,6 +140,103 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 // End Section: Versand Icons ändern & einfügen
 
+// Section: Gratisversand Fortschritt Balken
+document.addEventListener('DOMContentLoaded', function () {
+  const THRESHOLD = 150;
+
+  function getPrimaryColor() {
+    const styles = getComputedStyle(document.documentElement);
+    return (styles.getPropertyValue('--primary') ||
+            styles.getPropertyValue('--color-primary') ||
+            styles.getPropertyValue('--bs-primary') ||
+            '#31a5f0').trim();
+  }
+
+  const primaryColor = getPrimaryColor();
+
+  function parseEuro(el) {
+    if (!el) return 0;
+    return parseFloat(
+      el.textContent.replace(/[^0-9,.-]/g, '').replace('.', '').replace(',', '.')
+    ) || 0;
+  }
+
+  function formatEuro(val) {
+    return val.toLocaleString('de-DE', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + '\u00a0€';
+  }
+
+  function createBar(id) {
+    const wrapper = document.createElement('div');
+    wrapper.id = id;
+    wrapper.style.margin = '1rem 0';
+
+    const text = document.createElement('div');
+    text.style.fontSize = '0.9rem';
+    text.style.fontWeight = '600';
+    text.style.marginBottom = '0.5rem';
+    wrapper.appendChild(text);
+
+    const bg = document.createElement('div');
+    bg.style.width = '100%';
+    bg.style.height = '8px';
+    bg.style.background = '#e0e0e0';
+    bg.style.borderRadius = '4px';
+    bg.style.overflow = 'hidden';
+    wrapper.appendChild(bg);
+
+    const bar = document.createElement('div');
+    bar.style.height = '100%';
+    bar.style.width = '0%';
+    bar.style.background = primaryColor;
+    bar.style.transition = 'width 0.3s ease';
+    bg.appendChild(bar);
+
+    return { wrapper, bar, text };
+  }
+
+  function update(bar, text) {
+    const net = parseEuro(document.querySelector('dd[data-testing="item-sum-net"]'));
+    const vat = parseEuro(document.querySelector('dd[data-testing="vat-amount"]'));
+    const total = net + vat;
+    const ratio = Math.min(total / THRESHOLD, 1);
+    bar.style.width = (ratio * 100) + '%';
+    if (total < THRESHOLD) {
+      text.textContent = `Noch ${formatEuro(THRESHOLD - total)} bis zum Gratisversand`;
+    } else {
+      text.textContent = 'Gratisversand erreicht!';
+    }
+  }
+
+  // Warenkorbvorschau (Cart preview)
+  const previewObserver = new MutationObserver(() => {
+    const totals = document.querySelector('.cmp-totals');
+    if (totals && !document.getElementById('free-shipping-bar-preview')) {
+      const { wrapper, bar, text } = createBar('free-shipping-bar-preview');
+      totals.parentNode.insertBefore(wrapper, totals);
+      update(bar, text);
+      setInterval(() => update(bar, text), 1000);
+    }
+  });
+  previewObserver.observe(document.body, { childList: true, subtree: true });
+
+  // Checkout
+  const path = window.location.pathname;
+  if (path.includes('/checkout') || path.includes('/kaufabwicklung') || path.includes('/kasse')) {
+    const checkoutObserver = new MutationObserver(() => {
+      const cmp = document.querySelector('.cmp');
+      if (cmp && !document.getElementById('free-shipping-bar-checkout')) {
+        const { wrapper, bar, text } = createBar('free-shipping-bar-checkout');
+        cmp.parentNode.insertBefore(wrapper, cmp.nextSibling);
+        update(bar, text);
+        setInterval(() => update(bar, text), 1000);
+        checkoutObserver.disconnect();
+      }
+    });
+    checkoutObserver.observe(document.body, { childList: true, subtree: true });
+  }
+});
+// End Section: Gratisversand Fortschritt Balken
+
 // ===============================
 // RESTLICHER JS-Code (ausgeblendet auf Checkout/Kaufabwicklung/Kasse)
 // ===============================


### PR DESCRIPTION
## Summary
- add JS to calculate cart total and display free shipping progress bar in cart preview and checkout
- fix checkout injection logic to wait for `.cmp` and update without blocking other elements

## Testing
- `npm test` *(fails: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689f221c39708331aad9fc9cacb58445