### PR TITLE
Fix duplicate checkout progress bar

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -143,6 +143,11 @@ document.addEventListener('DOMContentLoaded', function () {
 // Section: Gratisversand Fortschritt Balken
 document.addEventListener('DOMContentLoaded', function () {
   const THRESHOLD = 150;
+  const path = window.location.pathname;
+  const isCheckout =
+    path.includes('/checkout') ||
+    path.includes('/kaufabwicklung') ||
+    path.includes('/kasse');
 
   function getPrimaryColor() {
     const styles = getComputedStyle(document.documentElement);
@@ -208,25 +213,26 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   // Warenkorbvorschau (Cart preview)
-  const previewObserver = new MutationObserver(() => {
-    const totals = document.querySelector('.cmp-totals');
-    if (totals && !document.getElementById('free-shipping-bar-preview')) {
-      const { wrapper, bar, text } = createBar('free-shipping-bar-preview');
-      totals.parentNode.insertBefore(wrapper, totals);
-      update(bar, text);
-      setInterval(() => update(bar, text), 1000);
-    }
-  });
-  previewObserver.observe(document.body, { childList: true, subtree: true });
+  if (!isCheckout) {
+    const previewObserver = new MutationObserver(() => {
+      const totals = document.querySelector('.cmp-totals');
+      if (totals && !document.getElementById('free-shipping-bar-preview')) {
+        const { wrapper, bar, text } = createBar('free-shipping-bar-preview');
+        totals.parentNode.insertBefore(wrapper, totals);
+        update(bar, text);
+        setInterval(() => update(bar, text), 1000);
+      }
+    });
+    previewObserver.observe(document.body, { childList: true, subtree: true });
+  }
 
   // Checkout
-  const path = window.location.pathname;
-  if (path.includes('/checkout') || path.includes('/kaufabwicklung') || path.includes('/kasse')) {
+  if (isCheckout) {
     const checkoutObserver = new MutationObserver(() => {
-      const cmp = document.querySelector('.cmp');
-      if (cmp && !document.getElementById('free-shipping-bar-checkout')) {
+      const rightContainer = document.querySelector('.fc-container_right');
+      if (rightContainer && !document.getElementById('free-shipping-bar-checkout')) {
         const { wrapper, bar, text } = createBar('free-shipping-bar-checkout');
-        cmp.parentNode.insertBefore(wrapper, cmp.nextSibling);
+        rightContainer.insertBefore(wrapper, rightContainer.firstChild);
         update(bar, text);
         setInterval(() => update(bar, text), 1000);
         checkoutObserver.disconnect();


### PR DESCRIPTION
## Summary
- show free shipping bar only in `.fc-container_right`
- skip cart preview progress bar on checkout to avoid duplicates

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f2af6bd58833191e1a0be43aaa0e2