### PR TITLE
Use cmp-totals for shipping progress bar on all pages

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -143,7 +143,6 @@ document.addEventListener('DOMContentLoaded', function () {
 // Section: Gratisversand Fortschritt Balken
 document.addEventListener('DOMContentLoaded', function () {
   const THRESHOLD = 150;
-  const path = window.location.pathname;
 
   function getPrimaryColor() {
     const styles = getComputedStyle(document.documentElement);
@@ -208,36 +207,16 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 
-  // Warenkorbvorschau (Cart preview)
-  if (!path.includes('/checkout') &&
-      !path.includes('/kaufabwicklung') &&
-      !path.includes('/kasse')) {
-    const previewObserver = new MutationObserver(() => {
-      const totals = document.querySelector('.cmp-totals');
-      if (totals && !document.getElementById('free-shipping-bar-preview')) {
-        const { wrapper, bar, text } = createBar('free-shipping-bar-preview');
-        totals.parentNode.insertBefore(wrapper, totals);
-        update(bar, text);
-        setInterval(() => update(bar, text), 1000);
-      }
-    });
-    previewObserver.observe(document.body, { childList: true, subtree: true });
-  }
-
-  // Checkout
-  if (path.includes('/checkout') || path.includes('/kaufabwicklung') || path.includes('/kasse')) {
-    const checkoutObserver = new MutationObserver(() => {
-      const cmp = document.querySelector('.cmp');
-      if (cmp && !document.getElementById('free-shipping-bar-checkout')) {
-        const { wrapper, bar, text } = createBar('free-shipping-bar-checkout');
-        cmp.parentNode.insertBefore(wrapper, cmp.nextSibling);
-        update(bar, text);
-        setInterval(() => update(bar, text), 1000);
-        checkoutObserver.disconnect();
-      }
-    });
-    checkoutObserver.observe(document.body, { childList: true, subtree: true });
-  }
+  const observer = new MutationObserver(() => {
+    const totals = document.querySelector('.cmp-totals');
+    if (totals && !document.getElementById('free-shipping-bar')) {
+      const { wrapper, bar, text } = createBar('free-shipping-bar');
+      totals.parentNode.insertBefore(wrapper, totals);
+      update(bar, text);
+      setInterval(() => update(bar, text), 1000);
+    }
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
 });
 // End Section: Gratisversand Fortschritt Balken
 


### PR DESCRIPTION
## Summary
- Simplify free shipping progress bar initialization
- Use `.cmp-totals` observer on checkout and cart preview

## Testing
- `node --check "Javascript/FH - Javascript am Ende der Seite.js" && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_689f33ce3558833187e90110928d3b21