### PR TITLE
Use item-sum value for free shipping bar

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -168,7 +168,7 @@ document.addEventListener('DOMContentLoaded', function () {
   function createBar(id) {
     const wrapper = document.createElement('div');
     wrapper.id = id;
-    wrapper.style.margin = '1rem 0';
+    wrapper.style.margin = '0 0 30px 0';
 
     const text = document.createElement('div');
     text.style.fontSize = '0.9rem';
@@ -195,9 +195,7 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function update(bar, text) {
-    const net = parseEuro(document.querySelector('dd[data-testing="item-sum-net"]'));
-    const vat = parseEuro(document.querySelector('dd[data-testing="vat-amount"]'));
-    const total = net + vat;
+    const total = parseEuro(document.querySelector('dd[data-testing="item-sum"]'));
     const ratio = Math.min(total / THRESHOLD, 1);
     bar.style.width = (ratio * 100) + '%';
     if (total < THRESHOLD) {


### PR DESCRIPTION
## Summary
- Compute free-shipping progress using `dd[data-testing="item-sum"]` instead of net and VAT values
- Adjust progress bar margins to top 0px and bottom 30px

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e06c18148331a12a2a0806374b4a