### PR TITLE
Ensure free shipping bar initializes immediately

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -207,7 +207,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   }
 
-  const observer = new MutationObserver(() => {
+  function initBar() {
     const totals = document.querySelector('.cmp-totals');
     if (totals && !document.getElementById('free-shipping-bar')) {
       const { wrapper, bar, text } = createBar('free-shipping-bar');
@@ -215,8 +215,11 @@ document.addEventListener('DOMContentLoaded', function () {
       update(bar, text);
       setInterval(() => update(bar, text), 1000);
     }
-  });
+  }
+
+  const observer = new MutationObserver(initBar);
   observer.observe(document.body, { childList: true, subtree: true });
+  initBar();
 });
 // End Section: Gratisversand Fortschritt Balken
 


### PR DESCRIPTION
## Summary
- extract MutationObserver callback into reusable `initBar`
- invoke `initBar` after starting observer so bar always rendered

## Testing
- `node --check "Javascript/FH - Javascript am Ende der Seite.js"`
- `node test snippet via jsdom to verify bar insertion`

------
https://chatgpt.com/codex/tasks/task_e_68a2ed107dac8331bb542a368f47062c