### PR TITLE
Use item-sum for free shipping bar

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -168,7 +168,8 @@ document.addEventListener('DOMContentLoaded', function () {
   function createBar(id) {
     const wrapper = document.createElement('div');
     wrapper.id = id;
-    wrapper.style.margin = '1rem 0';
+    wrapper.style.marginTop = '0px';
+    wrapper.style.marginBottom = '30px';
 
     const text = document.createElement('div');
     text.style.fontSize = '0.9rem';
@@ -195,9 +196,7 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function update(bar, text) {
-    const net = parseEuro(document.querySelector('dd[data-testing="item-sum-net"]'));
-    const vat = parseEuro(document.querySelector('dd[data-testing="vat-amount"]'));
-    const total = net + vat;
+    const total = parseEuro(document.querySelector('dd[data-testing="item-sum"]'));
     const ratio = Math.min(total / THRESHOLD, 1);
     bar.style.width = (ratio * 100) + '%';
     if (total < THRESHOLD) {


### PR DESCRIPTION
## Summary
- calculate free shipping bar from dd[data-testing="item-sum"] instead of net and vat
- adjust free shipping bar margins (top 0, bottom 30px)

## Testing
- `node --check Javascript/FH - Javascript am Ende der Seite.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2f32c508083318cbf323071e08fcf