### PR TITLE
Versandbalken für SH und Entfernen veralteter Candy-Styles

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -139,44 +139,7 @@ div.widget.widget-grid.widget-two-col.row.mt-5 {
 }
 /* End Section: Mobile Full Width Navbar */
 
-#versandfrei-progress-bar-candy {
-    height: 20px;
-    width: 0;
-    background: repeating-linear-gradient(
-        45deg,
-        rgb(49,165,240) 0px,
-        rgb(49,165,240) 16px,
-        rgb(139,203,255) 16px,
-        rgb(139,203,255) 32px,
-        #f0f0f0 32px,
-        #f0f0f0 40px
-    );
-    background-size: 56px 56px;
-    animation: candystripe-move 1.4s linear infinite;
-    transition: width 0.7s cubic-bezier(.4,2,.4,1);
-    box-shadow: 0 1px 8px #d8e8f6cc;
-    border: none;
-}
-@keyframes candystripe-move {
-    0% { background-position: 0 0; }
-    100% { background-position: 56px 0; }
-}
-#versandfrei-progress-label-candy {
-    font-size: 1em;
-    color: #1a2936;
-    position: absolute;
-    width: 100%;
-    left: 0;
-    top: 0;
-    line-height: 20px;
-    text-align: center;
-    letter-spacing: 0.01em;
-    font-weight: 500;
-    pointer-events: none;
-    user-select: none;
-}
 
-/*Ende Versandbalken Styling*/
 
 /* Section: Versand Icons ändern & einfügen */
 

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -181,6 +181,94 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 // End Section: Versand Icons ändern & einfügen
 
+// Section: Gratisversand Fortschritt Balken
+document.addEventListener('DOMContentLoaded', function () {
+  const THRESHOLD = 150;
+
+  function getPrimaryColor() {
+    const styles = getComputedStyle(document.documentElement);
+    return (
+      styles.getPropertyValue('--primary') ||
+      styles.getPropertyValue('--color-primary') ||
+      styles.getPropertyValue('--bs-primary') ||
+      '#f20000'
+    ).trim();
+  }
+
+  const primaryColor = getPrimaryColor();
+
+  function parseEuro(el) {
+    if (!el) return 0;
+    return (
+      parseFloat(
+        el.textContent.replace(/[^0-9,.-]/g, '').replace('.', '').replace(',', '.')
+      ) || 0
+    );
+  }
+
+  function formatEuro(val) {
+    return (
+      val.toLocaleString('de-DE', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }) + '\u00a0€'
+    );
+  }
+
+  function createBar(id) {
+    const wrapper = document.createElement('div');
+    wrapper.id = id;
+    wrapper.style.marginTop = '0px';
+    wrapper.style.marginBottom = '30px';
+
+    const text = document.createElement('div');
+    text.style.fontSize = '0.9rem';
+    text.style.fontWeight = '600';
+    text.style.marginBottom = '0.5rem';
+    wrapper.appendChild(text);
+
+    const bg = document.createElement('div');
+    bg.style.width = '100%';
+    bg.style.height = '8px';
+    bg.style.background = '#e0e0e0';
+    bg.style.borderRadius = '4px';
+    bg.style.overflow = 'hidden';
+    wrapper.appendChild(bg);
+
+    const bar = document.createElement('div');
+    bar.style.height = '100%';
+    bar.style.width = '0%';
+    bar.style.background = primaryColor;
+    bar.style.transition = 'width 0.3s ease';
+    bg.appendChild(bar);
+
+    return { wrapper, bar, text };
+  }
+
+  function update(bar, text) {
+    const total = parseEuro(document.querySelector('dd[data-testing="item-sum"]'));
+    const ratio = Math.min(total / THRESHOLD, 1);
+    bar.style.width = ratio * 100 + '%';
+    if (total < THRESHOLD) {
+      text.textContent = `Noch ${formatEuro(THRESHOLD - total)} bis zum Gratisversand`;
+    } else {
+      text.textContent = 'Gratisversand erreicht!';
+    }
+  }
+
+  const observer = new MutationObserver(() => {
+    const totals = document.querySelector('.cmp-totals');
+    if (totals && !document.getElementById('free-shipping-bar')) {
+      const { wrapper, bar, text } = createBar('free-shipping-bar');
+      totals.parentNode.insertBefore(wrapper, totals);
+      update(bar, text);
+      setInterval(() => update(bar, text), 1000);
+    }
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+});
+// End Section: Gratisversand Fortschritt Balken
+
 // ===============================
 // RESTLICHER JS-Code (ausgeblendet auf Checkout/Kaufabwicklung/Kasse)
 // ===============================


### PR DESCRIPTION
## Zusammenfassung
- Entfernt veralteten Versandbalken-Candy-Code aus dem FH-Stylesheet.
- Fügt für SH einen Gratisversand-Fortschrittsbalken hinzu, der auf die rote Primärfarbe des Shops setzt.

## Testing
- `npm test` (fehlt: package.json)
- `node --check 'Javascript/SH - Javascript am Ende der Seite.js'`


------
https://chatgpt.com/codex/tasks/task_e_68a2f98b02888331b266eece3044a8b1