### PR TITLE
Hide free shipping bar when pickup option selected

### DIFF
--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -255,6 +255,12 @@ document.addEventListener('DOMContentLoaded', function () {
       text.textContent = 'Gratisversand erreicht!';
     }
   }
+  function toggleFreeShippingBar() {
+    const bar = document.getElementById('free-shipping-bar');
+    const pickup = document.getElementById('ShippingProfileID1310');
+    if (!bar || !pickup) return;
+    bar.style.display = pickup.checked ? 'none' : '';
+  }
 
   const observer = new MutationObserver(() => {
     const totals = document.querySelector('.cmp-totals');
@@ -264,8 +270,15 @@ document.addEventListener('DOMContentLoaded', function () {
       update(bar, text);
       setInterval(() => update(bar, text), 1000);
     }
+    toggleFreeShippingBar();
   });
   observer.observe(document.body, { childList: true, subtree: true });
+
+  document.body.addEventListener('change', function (e) {
+    if (e.target.matches('input[type="radio"][id^="ShippingProfileID"]')) {
+      toggleFreeShippingBar();
+    }
+  });
 });
 // End Section: Gratisversand Fortschritt Balken
 


### PR DESCRIPTION
## Summary
- Hide free shipping progress bar when the self-pickup shipping profile is chosen
- Restore the bar when any other shipping option is selected

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3022c24c48331ae9805e2ae280988