### PR TITLE
refactor: reapply shipping icons on checkout updates

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -112,30 +112,48 @@
 // End Section: Bestell-Versand Countdown Code
 
 // Section: Versand Icons ändern & einfügen (läuft auf ALLEN Seiten inkl. Checkout)
-document.addEventListener('DOMContentLoaded', function () {
-  const shippingIcons = {
-    'ShippingProfileID1531': 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/DHLVersand_Icon_D1.png',
-    'ShippingProfileID1545': 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/GO_Express_Versand_Icon_D1.1.png',
-    'ShippingProfileID1510': 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Selbstabholung_Lager_Versand_Icon_D1.1.png'
-  };
+const shippingIcons = {
+  'ShippingProfileID1531': 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/DHLVersand_Icon_D1.png',
+  'ShippingProfileID1545': 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/GO_Express_Versand_Icon_D1.1.png',
+  'ShippingProfileID1510': 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Selbstabholung_Lager_Versand_Icon_D1.1.png'
+};
 
+function applyShippingIcons() {
   Object.entries(shippingIcons).forEach(([profileId, iconUrl]) => {
     const label = document.querySelector(`label[for="${profileId}"]`);
-    if (label) {
-      const iconContainer = label.querySelector('.icon');
+    if (!label) return;
 
-      if (iconContainer) {
-        // Bestehendes leeren
-        iconContainer.innerHTML = '';
+    const iconContainer = label.querySelector('.icon');
+    if (!iconContainer) return;
 
-        // Neues Icon einfügen
-        const img = document.createElement('img');
-        img.src = iconUrl;
-        img.alt = 'Versandart Icon';
-        img.className = 'shipping-icon';
-        iconContainer.appendChild(img);
-      }
+    // Bestehendes leeren, um doppelte Icons zu vermeiden
+    iconContainer.innerHTML = '';
+
+    // Neues Icon einfügen
+    const img = document.createElement('img');
+    img.src = iconUrl;
+    img.alt = 'Versandart Icon';
+    img.className = 'shipping-icon';
+    iconContainer.appendChild(img);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  applyShippingIcons();
+
+  // Delegierter Listener für Zahlartenwechsel
+  document.addEventListener('change', function (e) {
+    if (e.target.matches('input[name="paymentId"]')) {
+      setTimeout(applyShippingIcons, 0);
     }
+  });
+
+  // Beobachtet dynamische Änderungen der Versandarten
+  document.querySelectorAll('.shipping-method-select').forEach(function (el) {
+    const observer = new MutationObserver(function () {
+      applyShippingIcons();
+    });
+    observer.observe(el, { childList: true, subtree: true });
   });
 });
 // End Section: Versand Icons ändern & einfügen

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -150,33 +150,51 @@
 // End Section: Bestell-Versand Countdown Code
 
 // Section: Versand Icons ändern & einfügen (läuft auf ALLEN Seiten inkl. Checkout)
-document.addEventListener("DOMContentLoaded", function () {
-  const shippingIcons = {
-    ShippingProfileID1331:
-      "https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/DHLVersand_Icon_D1.png",
-    ShippingProfileID1345:
-      "https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/GO_Express_Versand_Icon_D1.1.png",
-    ShippingProfileID1310:
-      "https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Selbstabholung_Lager_Versand_Icon_D1.1.png",
-  };
+const shippingIcons = {
+  'ShippingProfileID1331':
+    'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/DHLVersand_Icon_D1.png',
+  'ShippingProfileID1345':
+    'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/GO_Express_Versand_Icon_D1.1.png',
+  'ShippingProfileID1310':
+    'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Selbstabholung_Lager_Versand_Icon_D1.1.png',
+};
 
+function applyShippingIcons() {
   Object.entries(shippingIcons).forEach(([profileId, iconUrl]) => {
     const label = document.querySelector(`label[for="${profileId}"]`);
-    if (label) {
-      const iconContainer = label.querySelector(".icon");
+    if (!label) return;
 
-      if (iconContainer) {
-        // Bestehendes leeren
-        iconContainer.innerHTML = "";
+    const iconContainer = label.querySelector('.icon');
+    if (!iconContainer) return;
 
-        // Neues Icon einfügen
-        const img = document.createElement("img");
-        img.src = iconUrl;
-        img.alt = "Versandart Icon";
-        img.className = "shipping-icon";
-        iconContainer.appendChild(img);
-      }
+    // Bestehendes leeren, um doppelte Icons zu vermeiden
+    iconContainer.innerHTML = '';
+
+    // Neues Icon einfügen
+    const img = document.createElement('img');
+    img.src = iconUrl;
+    img.alt = 'Versandart Icon';
+    img.className = 'shipping-icon';
+    iconContainer.appendChild(img);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  applyShippingIcons();
+
+  // Delegierter Listener für Zahlartenwechsel
+  document.addEventListener('change', function (e) {
+    if (e.target.matches('input[name="paymentId"]')) {
+      setTimeout(applyShippingIcons, 0);
     }
+  });
+
+  // Beobachtet dynamische Änderungen der Versandarten
+  document.querySelectorAll('.shipping-method-select').forEach(function (el) {
+    const observer = new MutationObserver(function () {
+      applyShippingIcons();
+    });
+    observer.observe(el, { childList: true, subtree: true });
   });
 });
 // End Section: Versand Icons ändern & einfügen


### PR DESCRIPTION
## Summary
- wrap shipping icon injection in `applyShippingIcons`
- reapply icons on DOMContentLoaded, payment method changes, and shipping method mutations

## Testing
- `node --check Javascript/FH - Javascript am Ende der Seite.js`
- `node --check Javascript/SH - Javascript am Ende der Seite.js`
- `npm test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a31509a6b08331851ec0cc31fd1a64