### PR TITLE
Refine quantity control styling for FH and SH

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -183,12 +183,20 @@ div.widget.widget-grid.widget-two-col.row.mt-5 {
 #basketListContainer52 {
     padding-top: 10px;
 }
-#basketListContainer52 > div > div > div > div.meta-container-wrapper > div > div.basket-item-container-right > div.qty-box-container > div > div > button:nth-child(1) {
-    border-top-right-radius: 5px !important;
+/* Section: Quantity Input Styling */
+.qty-input {
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
 }
-#basketListContainer52 > div > div > div > div.meta-container-wrapper > div > div.basket-item-container-right > div.qty-box-container > div > div > button.btn.qty-btn.flex-fill.d-flex.justify-content-center.p-0.disabled {
-    border-bottom-right-radius: 5px !important;
+
+button[data-testing="quantity-btn-increase"] {
+  border-top-right-radius: 6px;
 }
+
+button[data-testing="quantity-btn-decrease"] {
+  border-bottom-right-radius: 6px;
+}
+/* End Section: Quantity Input Styling */
 
 /* End Section: Fast Checkout CSS Anpassungen */
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -243,32 +243,20 @@ div.widget.widget-grid.widget-two-col.row.mt-5 {
 #basketListContainer50 {
   padding-top: 10px;
 }
-#basketListContainer50
-  > div
-  > div
-  > div
-  > div.meta-container-wrapper
-  > div
-  > div.basket-item-container-right
-  > div.qty-box-container
-  > div
-  > div
-  > button:nth-child(1) {
-  border-top-right-radius: 5px !important;
+/* Section: Quantity Input Styling */
+.qty-input {
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
 }
-#basketListContainer50
-  > div
-  > div
-  > div
-  > div.meta-container-wrapper
-  > div
-  > div.basket-item-container-right
-  > div.qty-box-container
-  > div
-  > div
-  > button.btn.qty-btn.flex-fill.d-flex.justify-content-center.p-0.disabled {
-  border-bottom-right-radius: 5px !important;
+
+button[data-testing="quantity-btn-increase"] {
+  border-top-right-radius: 6px;
 }
+
+button[data-testing="quantity-btn-decrease"] {
+  border-bottom-right-radius: 6px;
+}
+/* End Section: Quantity Input Styling */
 #page-body
   > div
   > div


### PR DESCRIPTION
## Summary
- Add rounded corners to quantity input and buttons for Shop and Fast Checkout
- Remove overly specific quantity button selectors to avoid duplicate styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a31d79efa083318542550a0634f882