### PR TITLE
Hide free shipping bar for express shipping

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -209,8 +209,10 @@ document.addEventListener('DOMContentLoaded', function () {
   function toggleFreeShippingBar() {
     const bar = document.getElementById('free-shipping-bar');
     const pickup = document.getElementById('ShippingProfileID1510');
-    if (!bar || !pickup) return;
-    bar.style.display = pickup.checked ? 'none' : '';
+    const express = document.getElementById('ShippingProfileID1545');
+    if (!bar) return;
+    const hide = (pickup && pickup.checked) || (express && express.checked);
+    bar.style.display = hide ? 'none' : '';
   }
 
   const observer = new MutationObserver(() => {

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -258,8 +258,10 @@ document.addEventListener('DOMContentLoaded', function () {
   function toggleFreeShippingBar() {
     const bar = document.getElementById('free-shipping-bar');
     const pickup = document.getElementById('ShippingProfileID1310');
-    if (!bar || !pickup) return;
-    bar.style.display = pickup.checked ? 'none' : '';
+    const express = document.getElementById('ShippingProfileID1345');
+    if (!bar) return;
+    const hide = (pickup && pickup.checked) || (express && express.checked);
+    bar.style.display = hide ? 'none' : '';
   }
 
   const observer = new MutationObserver(() => {


### PR DESCRIPTION
## Summary
- Hide free shipping progress bar when express or pickup shipping is chosen in FH checkout
- Hide free shipping progress bar when express or pickup shipping is chosen in SH checkout

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a42ec435488331a6b3c94f1eda8c3f