### PR TITLE
Fix icon margins in basket preview for both shops

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -244,6 +244,12 @@ button[data-testing="quantity-btn-decrease"] {
 
 /* End Section: Warenkorb->Weiter einkaufen Button Styling */
 
+/* Section: Warenkorb Vorschau Icon Margin Fix */
+#controlsList .fa  {
+  margin: none !important;
+}
+/* End Section: Warenkorb Vorschau Icon Margin Fix */
+
 /* Section: doppleten PayPal Express Button Checkout ausblenden */
 
 .paypal-buttons paypal-buttons-context-iframe

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -343,3 +343,9 @@ button[data-testing="quantity-btn-decrease"] {
 }
 
 /* End Section: Warenkorb->Weiter einkaufen Button Styling */
+
+/* Section: Warenkorb Vorschau Icon Margin Fix */
+#controlsList .fa  {
+  margin: none !important;
+}
+/* End Section: Warenkorb Vorschau Icon Margin Fix */


### PR DESCRIPTION
## Summary
- Remove margin from font-awesome icons in basket preview for FH shop
- Remove margin from font-awesome icons in basket preview for SH shop

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4452761a483319279ff3e8ea60a7d