### PR TITLE
Fix disappearing "Weiter einkaufen" arrow icon

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -447,9 +447,12 @@ function patchBasketButton() {
       spinner.remove();
     });
 
-    if (!weiterEinkaufenBtn.classList.contains('weiter-einkaufen-patched')) {
-      // Button-Text und Custom-Icon setzen (ohne Spinner!)
+    // Arrow-Icon und Text sicherstellen
+    if (!weiterEinkaufenBtn.querySelector('i.fa-arrow-left')) {
       weiterEinkaufenBtn.innerHTML = '<i class="fa fa-arrow-left" aria-hidden="true" style="margin-right:8px"></i>Weiter einkaufen';
+    }
+
+    if (!weiterEinkaufenBtn.classList.contains('weiter-einkaufen-patched')) {
       weiterEinkaufenBtn.addEventListener('click', function(e) {
         e.preventDefault();
         // Spinner sofort entfernen!

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -485,12 +485,14 @@ document.addEventListener('DOMContentLoaded', function () {
           spinner.remove();
         });
 
-      // Nur einmal patchen, solange der Button lebt
-      if (!weiterEinkaufenBtn.classList.contains("weiter-einkaufen-patched")) {
-        // Button-Text und Arrow setzen (kein Spinner!)
+      // Arrow-Icon und Text sicherstellen
+      if (!weiterEinkaufenBtn.querySelector("i.fa-arrow-left")) {
         weiterEinkaufenBtn.innerHTML =
           '<i class="fa fa-arrow-left" aria-hidden="true" style="margin-right:8px"></i>Weiter einkaufen';
+      }
 
+      // Nur einmal patchen, solange der Button lebt
+      if (!weiterEinkaufenBtn.classList.contains("weiter-einkaufen-patched")) {
         weiterEinkaufenBtn.addEventListener("click", function (e) {
           e.preventDefault();
 


### PR DESCRIPTION
## Summary
- ensure `Weiter einkaufen` button always includes left-arrow icon in FH and SH shops
- reapply icon when missing while still only attaching click handler once

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a45770f2a88331bd8843d6198ce846