### PR TITLE
Show free shipping bar only for German shipping

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -210,7 +210,18 @@ document.addEventListener('DOMContentLoaded', function () {
     const bar = document.getElementById('free-shipping-bar');
     const pickup = document.getElementById('ShippingProfileID1510');
     if (!bar || !pickup) return;
-    bar.style.display = pickup.checked ? 'none' : '';
+
+    const countrySelects = document.querySelectorAll(
+      'select[id*="shipping-country-select"], select[id*="country-id-select"]'
+    );
+    let show = true;
+    countrySelects.forEach((sel) => {
+      if (sel.value && sel.value !== '1') {
+        show = false;
+      }
+    });
+
+    bar.style.display = pickup.checked || !show ? 'none' : '';
   }
 
   const observer = new MutationObserver(() => {
@@ -226,7 +237,11 @@ document.addEventListener('DOMContentLoaded', function () {
   observer.observe(document.body, { childList: true, subtree: true });
 
   document.body.addEventListener('change', function (e) {
-    if (e.target.matches('input[type="radio"][id^="ShippingProfileID"]')) {
+    if (
+      e.target.matches(
+        'input[type="radio"][id^="ShippingProfileID"], select[id*="shipping-country-select"], select[id*="country-id-select"]'
+      )
+    ) {
       toggleFreeShippingBar();
     }
   });

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -259,7 +259,18 @@ document.addEventListener('DOMContentLoaded', function () {
     const bar = document.getElementById('free-shipping-bar');
     const pickup = document.getElementById('ShippingProfileID1310');
     if (!bar || !pickup) return;
-    bar.style.display = pickup.checked ? 'none' : '';
+
+    const countrySelects = document.querySelectorAll(
+      'select[id*="shipping-country-select"], select[id*="country-id-select"]'
+    );
+    let show = true;
+    countrySelects.forEach((sel) => {
+      if (sel.value && sel.value !== '1') {
+        show = false;
+      }
+    });
+
+    bar.style.display = pickup.checked || !show ? 'none' : '';
   }
 
   const observer = new MutationObserver(() => {
@@ -275,7 +286,11 @@ document.addEventListener('DOMContentLoaded', function () {
   observer.observe(document.body, { childList: true, subtree: true });
 
   document.body.addEventListener('change', function (e) {
-    if (e.target.matches('input[type="radio"][id^="ShippingProfileID"]')) {
+    if (
+      e.target.matches(
+        'input[type="radio"][id^="ShippingProfileID"], select[id*="shipping-country-select"], select[id*="country-id-select"]'
+      )
+    ) {
       toggleFreeShippingBar();
     }
   });

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 ### Makeshift solutions for our Shop Design
 
-All included styling and functions should ideally eventually be created into standalone plugins for Plentymarkets that then can be more resource effiencent, easier configurable and better to maintain then having all pack in a set of text blocks to copy-paste. 
+All included styling and functions should ideally eventually be created into standalone plugins for Plentymarkets that then can be more resource effiencent, easier configurable and better to maintain then having all pack in a set of text blocks to copy-paste.
+
+### Free shipping progress bar
+
+The progress bar for free shipping is only shown when the selected shipping country is Germany (value `1`).
+To keep the script maintainable, the country select elements are located with attribute selectors such as
+`select[id*="shipping-country-select"]` and `select[id*="country-id-select"]`. These match any element whose `id`
+contains those fragments, so the code continues to work even when shop updates change the numeric suffixes of the IDs.


### PR DESCRIPTION
## Summary
- hide free shipping progress bar unless shipping country select chooses Germany
- react to dynamic country select IDs for easy maintenance
- document country-based bar toggle in README

## Testing
- `node --check "Javascript/FH - Javascript am Ende der Seite.js"`
- `node --check "Javascript/SH - Javascript am Ende der Seite.js"`


------
https://chatgpt.com/codex/tasks/task_e_68b596009e7083319b3639486278ed23