### PR TITLE
Toggle free shipping bar by shipping country

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -144,10 +144,16 @@ document.addEventListener('DOMContentLoaded', function () {
 document.addEventListener('DOMContentLoaded', function () {
   const THRESHOLD = 150;
 
-  function isGermanAddress() {
-    return Array.from(document.querySelectorAll('.address-country')).some((el) => {
-      const t = el.textContent.trim().toLowerCase();
-      return t === 'deutschland' || t === 'germany';
+  const COUNTRY_SELECT_ID_FRAGMENTS = [
+    'shipping-country-select',
+    'invoice-country-select',
+    'country-id-select'
+  ];
+
+  function isGermanySelected() {
+    return COUNTRY_SELECT_ID_FRAGMENTS.some((fragment) => {
+      const select = document.querySelector(`select[id*="${fragment}"]`);
+      return select && select.value === '1';
     });
   }
 
@@ -228,7 +234,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (!bar) return;
     const hide =
       (pickup && pickup.checked) ||
-      (isCheckoutPage() && !isGermanAddress());
+      (isCheckoutPage() && !isGermanySelected());
     bar.style.display = hide ? 'none' : '';
   }
 
@@ -244,12 +250,19 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   observer.observe(document.body, { childList: true, subtree: true });
 
-  document.body.addEventListener('change', function (e) {
-    if (e.target.matches('input[type="radio"][id^="ShippingProfileID"]')) {
-      toggleFreeShippingBar();
-    }
+    const countrySelectors = COUNTRY_SELECT_ID_FRAGMENTS.map(
+      (frag) => `select[id*="${frag}"]`
+    ).join(', ');
+
+    document.body.addEventListener('change', function (e) {
+      if (
+        e.target.matches('input[type="radio"][id^="ShippingProfileID"]') ||
+        e.target.matches(countrySelectors)
+      ) {
+        toggleFreeShippingBar();
+      }
+    });
   });
-});
 // End Section: Gratisversand Fortschritt Balken
 
 // ===============================

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -182,17 +182,21 @@ document.addEventListener("DOMContentLoaded", function () {
 // End Section: Versand Icons ändern & einfügen
 
 // Section: Gratisversand Fortschritt Balken
-document.addEventListener('DOMContentLoaded', function () {
-  const THRESHOLD = 150;
+  document.addEventListener('DOMContentLoaded', function () {
+    const THRESHOLD = 150;
 
-  function isGermanAddress() {
-    return Array.from(document.querySelectorAll('.address-country')).some(
-      (el) => {
-        const t = el.textContent.trim().toLowerCase();
-        return t === 'deutschland' || t === 'germany';
-      },
-    );
-  }
+    const COUNTRY_SELECT_ID_FRAGMENTS = [
+      'shipping-country-select',
+      'invoice-country-select',
+      'country-id-select'
+    ];
+
+    function isGermanySelected() {
+      return COUNTRY_SELECT_ID_FRAGMENTS.some((fragment) => {
+        const select = document.querySelector(`select[id*="${fragment}"]`);
+        return select && select.value === '1';
+      });
+    }
 
   function isCheckoutPage() {
     const path = window.location.pathname;
@@ -273,15 +277,15 @@ document.addEventListener('DOMContentLoaded', function () {
       text.textContent = 'Gratisversand erreicht!';
     }
   }
-  function toggleFreeShippingBar() {
-    const bar = document.getElementById('free-shipping-bar');
-    const pickup = document.getElementById('ShippingProfileID1310');
-    if (!bar) return;
-    const hide =
-      (pickup && pickup.checked) ||
-      (isCheckoutPage() && !isGermanAddress());
-    bar.style.display = hide ? 'none' : '';
-  }
+    function toggleFreeShippingBar() {
+      const bar = document.getElementById('free-shipping-bar');
+      const pickup = document.getElementById('ShippingProfileID1310');
+      if (!bar) return;
+      const hide =
+        (pickup && pickup.checked) ||
+        (isCheckoutPage() && !isGermanySelected());
+      bar.style.display = hide ? 'none' : '';
+    }
 
   const observer = new MutationObserver(() => {
     const totals = document.querySelector('.cmp-totals');
@@ -295,11 +299,18 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   observer.observe(document.body, { childList: true, subtree: true });
 
-  document.body.addEventListener('change', function (e) {
-    if (e.target.matches('input[type="radio"][id^="ShippingProfileID"]')) {
-      toggleFreeShippingBar();
-    }
-  });
+    const countrySelectors = COUNTRY_SELECT_ID_FRAGMENTS.map(
+      (frag) => `select[id*="${frag}"]`
+    ).join(', ');
+
+    document.body.addEventListener('change', function (e) {
+      if (
+        e.target.matches('input[type="radio"][id^="ShippingProfileID"]') ||
+        e.target.matches(countrySelectors)
+      ) {
+        toggleFreeShippingBar();
+      }
+    });
 });
 // End Section: Gratisversand Fortschritt Balken
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,15 @@ graphics. The icons are applied wherever the corresponding shipping profiles are
 
 #### Free shipping progress bar
 Displays a progress bar toward the €150 free-shipping threshold near the order
-totals. It is always visible outside the checkout. On checkout-related pages
-(`/checkout`, `/kaufabwicklung`, `/kasse`) the bar is shown only when an
-`.address-country` element contains “Deutschland” or “Germany”; otherwise the
-bar stays hidden. Selecting the self-pickup shipping profile hides it as well.
+totals. Outside checkout it is always visible. During checkout (`/checkout`,
+`/kaufabwicklung`, `/kasse`) the bar appears only when one of the country
+`<select>` elements with an ID containing `shipping-country-select`,
+`invoice-country-select`, or `country-id-select` has the value `1` (Germany).
+Changing the selection to a different country hides the bar, and switching back
+to Germany shows it again. To support additional country selectors, add the
+relevant ID fragment to the `COUNTRY_SELECT_ID_FRAGMENTS` array in the
+JavaScript. Selecting the self-pickup shipping profile hides the bar regardless
+of country.
 
 #### Animated search placeholder
 Cycles through a set of suggestion texts in the search field placeholder when


### PR DESCRIPTION
## Summary
- show free shipping progress only when Germany is selected
- monitor dynamic country selects for ID fragments `shipping-country-select` and `country-id-select`
- document how to maintain country selector list in README

## Testing
- `node --check 'Javascript/SH - Javascript am Ende der Seite.js'`
- `node --check 'Javascript/FH - Javascript am Ende der Seite.js'`
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b596009e7083319b3639486278ed23