### PR TITLE
Ensure arrow icon persists on basket preview button

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -477,9 +477,12 @@ function patchBasketButton() {
       spinner.remove();
     });
 
-    if (!weiterEinkaufenBtn.classList.contains('weiter-einkaufen-patched')) {
-      // Button-Text und Custom-Icon setzen (ohne Spinner!)
+    // Button-Text und Custom-Icon setzen, falls Icon fehlt (ohne Spinner!)
+    if (!weiterEinkaufenBtn.querySelector('i.fa-arrow-left')) {
       weiterEinkaufenBtn.innerHTML = '<i class="fa fa-arrow-left" aria-hidden="true" style="margin-right:8px"></i>Weiter einkaufen';
+    }
+
+    if (!weiterEinkaufenBtn.classList.contains('weiter-einkaufen-patched')) {
       weiterEinkaufenBtn.addEventListener('click', function(e) {
         e.preventDefault();
         // Spinner sofort entfernen!

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -515,12 +515,14 @@ document.addEventListener("DOMContentLoaded", function () {
           spinner.remove();
         });
 
-      // Nur einmal patchen, solange der Button lebt
-      if (!weiterEinkaufenBtn.classList.contains("weiter-einkaufen-patched")) {
-        // Button-Text und Arrow setzen (kein Spinner!)
+      // Button-Text und Arrow setzen, falls Icon fehlt (kein Spinner!)
+      if (!weiterEinkaufenBtn.querySelector("i.fa-arrow-left")) {
         weiterEinkaufenBtn.innerHTML =
           '<i class="fa fa-arrow-left" aria-hidden="true" style="margin-right:8px"></i>Weiter einkaufen';
+      }
 
+      // Eventlistener nur einmal hinzufügen
+      if (!weiterEinkaufenBtn.classList.contains("weiter-einkaufen-patched")) {
         weiterEinkaufenBtn.addEventListener("click", function (e) {
           e.preventDefault();
 


### PR DESCRIPTION
## Summary
- restore and maintain arrow icon in "Weiter einkaufen" button for SH and FH by reapplying icon when missing and avoiding duplicate listeners

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5af244ecc83318d085095f0090e01