### PR TITLE
style: refine input-unit and method list styles

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -344,3 +344,15 @@ button[data-testing="quantity-btn-decrease"],
   font-weight: 600;
 }
 /* End Section: Retourenformular Styling */
+
+/* Section: Input Unit Border Radius */
+.input-unit {
+  border-radius: 6px;
+}
+/* End Section: Input Unit Border Radius */
+
+/* Section: Method list item label padding */
+.cmp-method-list .method-list-item label {
+  padding-right: 0px;
+}
+/* End Section: Method list item label padding */

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -347,3 +347,15 @@ button[data-testing="quantity-btn-decrease"],
   font-weight: 600;
 }
 /* End Section: Retourenformular Styling */
+
+/* Section: Input Unit Border Radius */
+.input-unit {
+  border-radius: 6px;
+}
+/* End Section: Input Unit Border Radius */
+
+/* Section: Method list item label padding */
+.cmp-method-list .method-list-item label {
+  padding-right: 0px;
+}
+/* End Section: Method list item label padding */


### PR DESCRIPTION
## Summary
- add 6px border radius to .input-unit class in FH and SH stylesheets
- remove right padding from .cmp-method-list .method-list-item label to align method rows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b100ad1c83319f7cdf892e23045f