### PR TITLE
Show free shipping bar on confirmation only when free shipping reached

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -232,9 +232,12 @@ document.addEventListener('DOMContentLoaded', function () {
     const bar = document.getElementById('free-shipping-bar');
     const pickup = document.getElementById('ShippingProfileID1510');
     if (!bar) return;
+    const path = window.location.pathname;
+    const total = parseEuro(document.querySelector('dd[data-testing="item-sum"]'));
     const hide =
       (pickup && pickup.checked) ||
-      (isCheckoutPage() && !isGermanySelected());
+      (isCheckoutPage() && !isGermanySelected()) ||
+      (path.includes('/bestellbestaetigung') && total < THRESHOLD);
     bar.style.display = hide ? 'none' : '';
   }
 

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -281,9 +281,12 @@ document.addEventListener("DOMContentLoaded", function () {
       const bar = document.getElementById('free-shipping-bar');
       const pickup = document.getElementById('ShippingProfileID1310');
       if (!bar) return;
+      const path = window.location.pathname;
+      const total = parseEuro(document.querySelector('dd[data-testing="item-sum"]'));
       const hide =
         (pickup && pickup.checked) ||
-        (isCheckoutPage() && !isGermanySelected());
+        (isCheckoutPage() && !isGermanySelected()) ||
+        (path.includes('/bestellbestaetigung') && total < THRESHOLD);
       bar.style.display = hide ? 'none' : '';
     }
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Changing the selection to a different country hides the bar, and switching back
 to Germany shows it again. To support additional country selectors, add the
 relevant ID fragment to the `COUNTRY_SELECT_ID_FRAGMENTS` array in the
 JavaScript. Selecting the self-pickup shipping profile hides the bar regardless
-of country.
+of country. On the order confirmation page (`/bestellbestaetigung`), the bar is
+displayed only if the free-shipping threshold has been reached.
 
 #### Animated search placeholder
 Cycles through a set of suggestion texts in the search field placeholder when


### PR DESCRIPTION
## Summary
- Hide free shipping bar on order confirmation page unless order total meets free-shipping threshold
- Document new confirmation-page behavior

## Testing
- `node --check "Javascript/FH - Javascript am Ende der Seite.js"`
- `node --check "Javascript/SH - Javascript am Ende der Seite.js"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b83d47632883318680c6606fe20890