### PR TITLE
feat: add global REST add-to-cart handler

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -1,5 +1,55 @@
 // Section: Global scripts for all pages
 
+// Section: REST Add-To-Cart Buttons
+(function () {
+  async function addToCartREST(variationId, quantity) {
+    const res = await fetch('/rest/io/basket/items', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      body: JSON.stringify({ variationId, quantity })
+    });
+    if (!res.ok) throw new Error('Basket API ' + res.status);
+    return res.json();
+  }
+
+  function refreshMiniCart() {
+    fetch('/rest/io/basket')
+      .then(r => r.json())
+      .then(b => {
+        const badge = document.querySelector('[data-basket-count]');
+        if (badge) badge.textContent = b?.itemQuantityTotal ?? 0;
+      })
+      .catch(() => {});
+  }
+
+  document.addEventListener('click', async (e) => {
+    const btn = e.target.closest('.df-add-to-cart');
+    if (!btn) return;
+
+    e.preventDefault();
+    const variationId = Number(btn.getAttribute('data-id'));
+    const quantity = 1;
+    if (!variationId || Number.isNaN(variationId)) return;
+
+    btn.disabled = true; btn.setAttribute('aria-busy', 'true');
+    try {
+      await addToCartREST(variationId, quantity);
+      // TODO: toast/snackbar here
+      refreshMiniCart();
+    } catch (err) {
+      console.error(err);
+      // TODO: error toast
+    } finally {
+      btn.disabled = false; btn.removeAttribute('aria-busy');
+    }
+  });
+})();
+// End Section: REST Add-To-Cart Buttons
+
+
 // Section: Bestell-Versand Countdown Code
 (function(){
   function getBerlinTime() {

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -1,5 +1,55 @@
 // Section: Global scripts for all pages
 
+// Section: REST Add-To-Cart Buttons
+(function () {
+  async function addToCartREST(variationId, quantity) {
+    const res = await fetch('/rest/io/basket/items', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      body: JSON.stringify({ variationId, quantity })
+    });
+    if (!res.ok) throw new Error('Basket API ' + res.status);
+    return res.json();
+  }
+
+  function refreshMiniCart() {
+    fetch('/rest/io/basket')
+      .then(r => r.json())
+      .then(b => {
+        const badge = document.querySelector('[data-basket-count]');
+        if (badge) badge.textContent = b?.itemQuantityTotal ?? 0;
+      })
+      .catch(() => {});
+  }
+
+  document.addEventListener('click', async (e) => {
+    const btn = e.target.closest('.df-add-to-cart');
+    if (!btn) return;
+
+    e.preventDefault();
+    const variationId = Number(btn.getAttribute('data-id'));
+    const quantity = 1;
+    if (!variationId || Number.isNaN(variationId)) return;
+
+    btn.disabled = true; btn.setAttribute('aria-busy', 'true');
+    try {
+      await addToCartREST(variationId, quantity);
+      // TODO: toast/snackbar here
+      refreshMiniCart();
+    } catch (err) {
+      console.error(err);
+      // TODO: error toast
+    } finally {
+      btn.disabled = false; btn.removeAttribute('aria-busy');
+    }
+  });
+})();
+// End Section: REST Add-To-Cart Buttons
+
+
 // Section: Bestell-Versand Countdown Code
 (function () {
   function getBerlinTime() {


### PR DESCRIPTION
## Summary
- enable `.df-add-to-cart` buttons on all pages using REST API
- refresh mini cart badge after adding items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4233e5d8c8331961356000886e089