### PR TITLE
Update FH header navigation hover menus

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -19,6 +19,35 @@
 
 /* End Section: Custom Schriftarten + Preis Text Stylings */
 
+/* Section: FH Header Navigation Hover Behaviour */
+.fh-header .nav {
+  position: relative;
+}
+
+.fh-header .dropdown-menu {
+  display: none;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(12px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.fh-header .nav-item:hover > .dropdown-menu,
+.fh-header .nav-item:focus-within > .dropdown-menu {
+  display: block;
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.fh-header .dropdown-menu {
+  width: 100%;
+  max-width: 1600px;
+}
+/* End Section: FH Header Navigation Hover Behaviour */
+
 /* Section: Trustbadge ausblenden */
 .basket-open .widget_container_overlay,
 .basket-open #trustami-mobile-view,

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -1,4 +1,4 @@
-<header style="max-width:1600px;width:100%;margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;">
+<header class="fh-header" style="max-width:1600px;width:100%;margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;">
   <div style="display:flex;align-items:center;justify-content:space-between;background-color:#f7f7f7;padding:8px 32px;font-size:14px;letter-spacing:0.2px;">
     <div style="flex:1;text-align:left;">4,88 auf Trusted Shops</div>
     <div style="flex:1;text-align:center;">Schneller Versand</div>
@@ -32,7 +32,7 @@
         <a class="dropdown-item" href="#" style="display:block;padding:10px 0;color:#1a1a1a;text-decoration:none;font-size:15px;">Einstellungen</a>
       </div>
     </div>
-    <a href="#" class="toggle-basket-preview" aria-label="Warenkorb" style="display:flex;align-items:center;justify-content:center;width:48px;height:48px;border-radius:50%;background-color:#ff7f32;color:#ffffff;text-decoration:none;justify-self:end;">
+    <a href="#" class="toggle-basket-preview" aria-label="Warenkorb" style="display:flex;align-items:center;justify-content:center;width:48px;height:48px;border-radius:50%;background-color:#31a5f0;color:#ffffff;text-decoration:none;justify-self:end;">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="width:22px;height:22px;">
         <circle cx="9" cy="20" r="1.5" fill="currentColor"></circle>
         <circle cx="18" cy="20" r="1.5" fill="currentColor"></circle>
@@ -44,11 +44,11 @@
     <div style="max-width:1600px;width:100%;margin:0 auto;position:relative;">
       <ul class="nav" style="display:flex;list-style:none;margin:0;padding:0 32px;justify-content:space-between;font-size:15px;font-weight:600;letter-spacing:0.4px;text-transform:uppercase;">
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" data-toggle="dropdown" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Schützen</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:1600px;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Schlösser</a>
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
           <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
             <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 1</h6>
+              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 1</h6>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
@@ -81,11 +81,11 @@
         </div>
       </li>
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" data-toggle="dropdown" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Pistolenjäger</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:1600px;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Beschläge</a>
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
           <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
             <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 1</h6>
+              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 2</h6>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
@@ -118,11 +118,11 @@
         </div>
       </li>
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" data-toggle="dropdown" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Waffen</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:1600px;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Sicherungen</a>
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
           <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
             <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 1</h6>
+              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 3</h6>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
@@ -155,11 +155,11 @@
         </div>
       </li>
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" data-toggle="dropdown" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Zubehör</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:1600px;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Sichtschutz</a>
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
           <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
             <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 1</h6>
+              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 4</h6>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
@@ -192,11 +192,11 @@
         </div>
       </li>
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" data-toggle="dropdown" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Werkstatt</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:1600px;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Fenstermontage</a>
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
           <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
             <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 1</h6>
+              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 5</h6>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
@@ -229,11 +229,48 @@
         </div>
       </li>
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" data-toggle="dropdown" style="display:block;padding:18px 12px;color:#ff7f32;text-decoration:none;">Sale</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:1600px;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Chemische Befestigung</a>
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
           <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
             <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 1</h6>
+              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 6</h6>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            </div>
+            <div>
+              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 2</h6>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            </div>
+            <div>
+              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 3</h6>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            </div>
+            <div>
+              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 4</h6>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            </div>
+            <div>
+              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 5</h6>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
+        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#31a5f0;text-decoration:none;">Aktionen</a>
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+          <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
+            <div>
+              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 7</h6>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>


### PR DESCRIPTION
## Summary
- replace the FH header navigation items with the requested labels and seven dedicated mega menus that include "Platzhalter Menu X" headings
- adjust the basket and Aktionen colors to #31a5f0 and ensure each dropdown stretches to the header width
- add scoped CSS so the dropdown mega menus open on hover/focus with smooth visibility transitions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbf06001e48331bdd6c915729ec9a4