### PR TITLE
Ensure header dropdown menus overlay page content

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -1,4 +1,4 @@
-<header class="fh-header" style="max-width:1600px;width:100%;margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;">
+<header class="fh-header" style="max-width:1600px;width:100%;margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;position:relative;z-index:1000;">
   <div style="display:flex;align-items:center;justify-content:space-between;background-color:#f7f7f7;padding:8px 32px;font-size:14px;letter-spacing:0.2px;">
     <div style="flex:1;text-align:left;">4,88 auf Trusted Shops</div>
     <div style="flex:1;text-align:center;">Schneller Versand</div>
@@ -55,7 +55,7 @@
       <ul class="nav" style="display:flex;list-style:none;margin:0;padding:0 32px;justify-content:space-between;font-size:15px;font-weight:600;letter-spacing:0.4px;text-transform:uppercase;">
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
         <a class="nav-link" href="/schloesser" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">SCHLÖSSER</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
           <div style="display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:32px;">
             <div>
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Einsteckschlösser für Metalltore</a>
@@ -88,7 +88,7 @@
       </li>
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
         <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Beschläge</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
           <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
             <div>
               <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 2</h6>
@@ -128,7 +128,7 @@
       </li>
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
         <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Sicherungen</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
           <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
             <div>
               <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 3</h6>
@@ -168,7 +168,7 @@
       </li>
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
         <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Sichtschutz</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
           <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
             <div>
               <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 4</h6>
@@ -208,7 +208,7 @@
       </li>
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
         <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Fenstermontage</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
           <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
             <div>
               <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 5</h6>
@@ -248,7 +248,7 @@
       </li>
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
         <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Chemische Befestigung</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
           <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
             <div>
               <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 6</h6>
@@ -288,7 +288,7 @@
       </li>
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
         <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#31a5f0;text-decoration:none;">Aktionen</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:20;">
+        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
           <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
             <div>
               <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 7</h6>


### PR DESCRIPTION
## Summary
- set the header container to create a higher z-index stacking context
- raise each dropdown menu's z-index so hover menus render above underlying cards

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc3b04408c8331b0a3e5511daa2fcd