### PR TITLE
Update header navigation links for FH header

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -53,280 +53,215 @@
   <nav style="background-color:#ffffff;">
     <div style="max-width:1600px;width:100%;margin:0 auto;position:relative;">
       <ul class="nav" style="display:flex;list-style:none;margin:0;padding:0 32px;justify-content:space-between;font-size:15px;font-weight:600;letter-spacing:0.4px;text-transform:uppercase;">
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="/schloesser" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">SCHLÖSSER</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:32px;">
-            <div>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Einsteckschlösser für Metalltore</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">elektrische Türöffner</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">FH-Schlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Garagentorschlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Haustürschlösser</a>
-            </div>
-            <div>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Kastenschlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Korridortürschlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Rohrrahmenschlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Rosetten und Schilder</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Schließbleche</a>
-            </div>
-            <div>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">WC-Tür-Schlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Wohnungstürschlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Zimmertürschlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Zubehör für Schloss und Tor</a>
-            </div>
-            <div>
-              <p style="margin:0;color:#4b5563;font-size:14px;line-height:1.6;">Ob Haus-, Wohnungs-, Zimmer- oder Garagentür – hier findest du das passende Schloss für jede Anwendung. Von Einsteck- bis Rohrrahmenschlössern und elektrischen Türöffnern bieten wir geprüfte Qualität und hohe Sicherheit. Ergänzt durch Profilzylinder, Schließbleche und Türdrücker erhältst du alles aus einer Hand für eine sichere Türlösung.</p>
-            </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="/schloesser" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">See all "SCHLÖSSER"</a>
-            </div>
-          </div>
-        </div>
-      </li>
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Beschläge</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">See all "Beschläge"</a>
+        <li class="nav-item" style="flex:1;text-align:center;">
+          <a class="nav-link" href="/fensterleisten" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Fensterleisten</a>
+        </li>
+        <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
+          <a class="nav-link" href="/schloesser" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Schlösser</a>
+          <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
+            <div style="display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:32px;">
+              <div>
+                <a href="/schloesser/einsteckschloesser-fuer-metalltore" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Einsteckschlösser für Metalltore</a>
+                <a href="/schloesser/elektrische-tueroeffner" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Elektrische Türöffner</a>
+                <a href="/schloesser/fh-schloesser" style="display:block;color:#555;text-decoration:none;padding:6px 0;">FH-Schlösser</a>
+                <a href="/schloesser/haustuerschloesser" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Haustürschlösser</a>
+              </div>
+              <div>
+                <a href="/schloesser/kastenschloesser" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Kastenschlösser</a>
+                <a href="/schloesser/korridortuerschloesser" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Korridortürschlösser</a>
+                <a href="/schloesser/rohrrahmenschloesser" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Rohrrahmenschlösser</a>
+                <a href="/schloesser/rosetten-und-schilder" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Rosetten und Schilder</a>
+              </div>
+              <div>
+                <a href="/schloesser/schliessbleche" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Schließbleche</a>
+                <a href="/schloesser/wc-tuer-schloesser" style="display:block;color:#555;text-decoration:none;padding:6px 0;">WC-Tür-Schlösser</a>
+                <a href="/schloesser/wohnungstuerschloesser" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Wohnungstürschlösser</a>
+                <a href="/schloesser/zimmertuerschloesser" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Zimmertürschlösser</a>
+              </div>
+              <div>
+                <a href="/schloesser/garagentorschloesser" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Garagentorschlösser</a>
+                <div style="margin-left:12px;margin-top:6px;display:flex;flex-direction:column;gap:4px;font-size:13px;font-weight:500;text-transform:none;">
+                  <a href="/schloesser/garagentorschloesser/garagentorschloesser-oben-und-unten-schliessend" style="color:#6b7280;text-decoration:none;">Garagentorschlösser oben und unten schließend</a>
+                  <a href="/schloesser/garagentorschloesser/garagentorschloesser-unten-schliessend" style="color:#6b7280;text-decoration:none;">Garagentorschlösser unten schließend</a>
+                  <a href="/schloesser/garagentorschloesser/griffe-und-schilder" style="color:#6b7280;text-decoration:none;">Griffe und Schilder</a>
+                  <a href="/schloesser/garagentorschloesser/garagentorschloesser-oben-schliessend" style="color:#6b7280;text-decoration:none;">Garagentorschlösser oben schließend</a>
+                  <a href="/schloesser/garagentorschloesser/garagentorschloesser-seitlich-schliessend" style="color:#6b7280;text-decoration:none;">Garagentorschlösser seitlich schließend</a>
+                  <a href="/schloesser/garagentorschloesser" style="color:#31a5f0;text-decoration:none;font-weight:600;">Alle aus Garagentorschlösser</a>
+                </div>
+                <a href="/schloesser/zubehoer-fuer-schloss-und-tor" style="display:block;color:#555;text-decoration:none;padding:12px 0 6px;">Zubehör für Schloss und Tor</a>
+              </div>
+              <div style="grid-column:1 / -1;display:grid;grid-template-columns:2fr 1fr;gap:24px;margin-top:24px;padding-top:24px;border-top:1px solid #eaeaea;text-transform:none;">
+                <p style="margin:0;color:#4b5563;font-size:14px;line-height:1.6;">Ob Haus-, Wohnungs-, Zimmer- oder Garagentür – hier findest du das passende Schloss für jede Anwendung. Von Einsteck- bis Rohrrahmenschlössern und elektrischen Türöffnern bieten wir geprüfte Qualität und hohe Sicherheit. Ergänzt durch Profilzylinder, Schließbleche und Türdrücker erhältst du alles aus einer Hand für eine sichere Türlösung.</p>
+                <img src="/documents/category/360/Zimmertuerschloss-Icon-David-1-grau-kleiner-png.png" alt="Schlösser" style="width:100%;height:auto;border-radius:12px;">
+              </div>
+              <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;text-transform:none;">
+                <a href="/schloesser" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle aus Schlösser</a>
+              </div>
             </div>
           </div>
-        </div>
-      </li>
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Sicherungen</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">See all "Sicherungen"</a>
+        </li>
+        <li class="nav-item" style="flex:1;text-align:center;">
+          <a class="nav-link" href="/profilzylinder" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Profilzylinder</a>
+        </li>
+        <li class="nav-item" style="flex:1;text-align:center;">
+          <a class="nav-link" href="/griffe-und-tuerdruecker" style="display:flex;align-items:center;justify-content:center;gap:8px;padding:18px 12px;color:#1a1a1a;text-decoration:none;">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/img/Icons/tuerdruecker-icon.svg" alt="" style="width:20px;height:12px;">
+            Griffe und Türdrücker
+          </a>
+        </li>
+        <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
+          <a class="nav-link" href="/klemmen" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Klemmen</a>
+          <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
+            <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:32px;">
+              <div>
+                <a href="/klemmen/glasklemmen" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Glasklemmen</a>
+              </div>
+              <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;text-transform:none;">
+                <a href="/klemmen" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle aus Klemmen</a>
+              </div>
             </div>
           </div>
-        </div>
-      </li>
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Sichtschutz</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">See all "Sichtschutz"</a>
+        </li>
+        <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
+          <a class="nav-link" href="/fenstersicherungen" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Fenstersicherungen</a>
+          <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
+            <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:32px;">
+              <div>
+                <a href="/fenstersicherungen/abus" style="display:block;color:#555;text-decoration:none;padding:6px 0;">ABUS</a>
+                <a href="/fenstersicherungen/bsl" style="display:block;color:#555;text-decoration:none;padding:6px 0;">BSL</a>
+              </div>
+              <div>
+                <a href="/fenstersicherungen/em3" style="display:block;color:#555;text-decoration:none;padding:6px 0;">EM3</a>
+                <a href="/fenstersicherungen/stuco-safe" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Stuco Safe</a>
+              </div>
+              <div style="grid-column:1 / -1;display:grid;grid-template-columns:2fr 1fr;gap:24px;margin-top:24px;padding-top:24px;border-top:1px solid #eaeaea;text-transform:none;">
+                <p style="margin:0;color:#4b5563;font-size:14px;line-height:1.6;">Fenstersicherungen schützen Ihr Zuhause vor Einbrüchen und unbefugtem Zugang. Einfach zu installieren, bieten sie eine effektive Barriere und erhöhen die Sicherheit sowohl für private Haushalte als auch gewerbliche Anwendungen.</p>
+              </div>
+              <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;text-transform:none;">
+                <a href="/fenstersicherungen" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle aus Fenstersicherungen</a>
+              </div>
             </div>
           </div>
-        </div>
-      </li>
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Fenstermontage</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">See all "Fenstermontage"</a>
+        </li>
+        <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
+          <a class="nav-link" href="/terrasse" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Terrasse</a>
+          <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
+            <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:32px;">
+              <div>
+                <a href="/terrasse/c1-edelstahlschrauben" style="display:block;color:#555;text-decoration:none;padding:6px 0;">C1 Edelstahlschrauben</a>
+                <a href="/terrasse/a2-edelstahlschrauben" style="display:block;color:#555;text-decoration:none;padding:6px 0;">A2 Edelstahlschrauben</a>
+              </div>
+              <div>
+                <a href="/terrasse/a4-edelstahlschrauben" style="display:block;color:#555;text-decoration:none;padding:6px 0;">A4 Edelstahlschrauben</a>
+                <a href="/terrasse/holzschutzband" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Holzschutzband</a>
+              </div>
+              <div>
+                <a href="/terrasse/terrassen-unterkonstruktion" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Terrassen-Unterkonstruktion</a>
+              </div>
+              <div style="grid-column:1 / -1;display:grid;grid-template-columns:2fr 1fr;gap:24px;margin-top:24px;padding-top:24px;border-top:1px solid #eaeaea;text-transform:none;">
+                <h3 style="margin:0;color:#4b5563;font-size:16px;line-height:1.6;font-weight:700;">Befestigungsmaterial für Terrassen umfasst Schrauben, Terrassenholzschutzband und weitere Komponenten, die für eine stabile und langlebige Terrassenkonstruktion sorgen. Wählen Sie aus robusten Schrauben und Schutzbändern, um Ihre Terrasse optimal zu verankern und vor Witterungseinflüssen zu schützen.</h3>
+              </div>
+              <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;text-transform:none;">
+                <a href="/terrasse" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle aus Terrasse</a>
+              </div>
             </div>
           </div>
-        </div>
-      </li>
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Chemische Befestigung</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 6</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">See all "Chemische Befestigung"</a>
+        </li>
+        <li class="nav-item" style="flex:1;text-align:center;">
+          <a class="nav-link" href="/sichtschutz" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Sichtschutz</a>
+        </li>
+        <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
+          <a class="nav-link" href="/fenstermontage" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Fenstermontage</a>
+          <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
+            <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:32px;">
+              <div>
+                <a href="/fenstermontage/fensterbankschrauben" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Fensterbankschrauben</a>
+                <a href="/fenstermontage/fenstergriffe" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Fenstergriffe</a>
+              </div>
+              <div>
+                <a href="/fenstermontage/fenstermontageschrauben" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Fenstermontageschrauben</a>
+                <a href="/fenstermontage/keile" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Keile</a>
+              </div>
+              <div>
+                <a href="/fenstermontage/kompriband-fugendichtband" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Kompriband - Fugendichtband</a>
+              </div>
+              <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;text-transform:none;">
+                <a href="/fenstermontage" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle aus Fenstermontage</a>
+              </div>
             </div>
           </div>
-        </div>
-      </li>
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#31a5f0;text-decoration:none;">Aktionen</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 7</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">See all "Aktionen"</a>
+        </li>
+        <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
+          <a class="nav-link" href="/chemische-befestigung" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Chemische Befestigung</a>
+          <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
+            <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:32px;">
+              <div>
+                <a href="/chemische-befestigung/kleben-dichten" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Kleben-Dichten</a>
+                <a href="/chemische-befestigung/schaum" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Schaum</a>
+              </div>
+              <div>
+                <a href="/chemische-befestigung/zubehoer-chemische-befestigung" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Zubehör Chemische Befestigung</a>
+              </div>
+              <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;text-transform:none;">
+                <a href="/chemische-befestigung" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle aus Chemische Befestigung</a>
+              </div>
             </div>
           </div>
-        </div>
-      </li>
+        </li>
+        <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
+          <a class="nav-link" href="/zubehoer" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Zubehör</a>
+          <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
+            <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:32px;">
+              <div>
+                <a href="/zubehoer/bit" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Bits</a>
+                <a href="/zubehoer/dampfbremsen" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Dampfbremsen</a>
+              </div>
+              <div>
+                <a href="/zubehoer/klebebaender" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Klebebänder</a>
+                <a href="/zubehoer/werkzeug" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Werkzeug</a>
+              </div>
+              <div style="grid-column:1 / -1;display:grid;grid-template-columns:2fr 1fr;gap:24px;margin-top:24px;padding-top:24px;border-top:1px solid #eaeaea;text-transform:none;">
+                <p style="margin:0;color:#4b5563;font-size:14px;line-height:1.6;">Zubehör für Fenster, Montage &amp; Ausbau: Entdecken Sie unsere Auswahl an Bits, Dampfbremsen, Klebebändern und Werkzeugen – ideal für Fachbetriebe und Heimwerker, die auf Qualität und Kompatibilität achten.</p>
+              </div>
+              <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;text-transform:none;">
+                <a href="/zubehoer" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle aus Zubehör</a>
+              </div>
+            </div>
+          </div>
+        </li>
+        <li class="nav-item" style="flex:1;text-align:center;">
+          <a class="nav-link" href="/aktion" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Aktion</a>
+        </li>
+        <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
+          <a class="nav-link" href="/top-marken" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Top Marken</a>
+          <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
+            <div style="display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:32px;">
+              <div>
+                <a href="/top-marken/abus" style="display:block;color:#555;text-decoration:none;padding:6px 0;">ABUS</a>
+                <a href="/top-marken/bever" style="display:block;color:#555;text-decoration:none;padding:6px 0;">BEVER</a>
+                <a href="/top-marken/eff-eff" style="display:block;color:#555;text-decoration:none;padding:6px 0;">EFF EFF</a>
+              </div>
+              <div>
+                <a href="/top-marken/index" style="display:block;color:#555;text-decoration:none;padding:6px 0;">INDEX</a>
+                <a href="/top-marken/intra-tec" style="display:block;color:#555;text-decoration:none;padding:6px 0;">INTRA-TEC</a>
+                <a href="/top-marken/pica" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Pica</a>
+              </div>
+              <div>
+                <a href="/top-marken/screwrebel" style="display:block;color:#555;text-decoration:none;padding:6px 0;">SCREWREBEL</a>
+                <a href="/top-marken/wera" style="display:block;color:#555;text-decoration:none;padding:6px 0;">WERA</a>
+              </div>
+              <div style="display:flex;flex-direction:column;gap:12px;text-transform:none;">
+                <img src="/documents/category/630/Top-Marken-Kategorie-Vorschaubild-2-png.png" alt="Top Marken" style="width:100%;height:auto;border-radius:12px;">
+                <p style="margin:0;color:#4b5563;font-size:14px;line-height:1.6;">Starke Marken - Von hochwertiger Sicherheitstechnik von ABUS bis hin zu den praktischen Werkzeugen von WERA finden Sie Marken mit Produkten von hoher Qualität zu einem guten Preis.</p>
+              </div>
+              <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;text-transform:none;">
+                <a href="/top-marken" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle aus Top Marken</a>
+              </div>
+            </div>
+          </div>
+        </li>
       </ul>
+
     </div>
   </nav>
 </header>


### PR DESCRIPTION
## Summary
- replace the header navigation menu with the real Fenster-HAMMER category structure and URLs
- add mega menu content for Schlösser, Fenstersicherungen, Terrasse, Zubehör, and other dropdowns including imagery and descriptions
- ensure simple categories such as Fensterleisten, Profilzylinder, Sichtschutz, Aktion link directly without placeholder content

## Testing
- not run (static HTML update)


------
https://chatgpt.com/codex/tasks/task_e_68d3ddc116048331b87941e73adeaea1