### PR TITLE
Update FH header structure and basket preview

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -1,4 +1,4 @@
-<header class="fh-header" style="max-width:1600px;width:100%;margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;position:relative;z-index:1000;">
+<div class="fh-header" data-header-root style="max-width:1600px;width:100%;margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;position:relative;z-index:1000;">
   <div style="display:flex;align-items:center;justify-content:space-between;background-color:#f7f7f7;padding:8px 32px;font-size:14px;letter-spacing:0.2px;">
     <div style="flex:1;text-align:left;">4,88 auf Trusted Shops</div>
     <div style="flex:1;text-align:center;">Schneller Versand</div>
@@ -42,7 +42,7 @@
         </nav>
       </div>
     </div>
-    <a href="#" class="toggle-basket-preview" aria-label="Warenkorb" style="display:flex;align-items:center;justify-content:center;width:48px;height:48px;border-radius:50%;background-color:#31a5f0;color:#ffffff;text-decoration:none;justify-self:end;">
+    <a href="#basket-preview" class="toggle-basket-preview" aria-label="Warenkorb" aria-haspopup="true" aria-expanded="false" aria-controls="basket-preview" data-basket-preview-toggle style="display:flex;align-items:center;justify-content:center;width:48px;height:48px;border-radius:50%;background-color:#31a5f0;color:#ffffff;text-decoration:none;justify-self:end;">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="width:22px;height:22px;">
         <circle cx="9" cy="20" r="1.5" fill="currentColor"></circle>
         <circle cx="18" cy="20" r="1.5" fill="currentColor"></circle>
@@ -329,4 +329,26 @@
       </ul>
     </div>
   </nav>
-</header>
+  <div id="basket-preview" class="fh-basket-preview" data-basket-preview style="position:absolute;top:100%;right:32px;width:360px;display:none;padding-top:24px;">
+    <div data-basket-preview-overlay style="position:fixed;inset:0;background-color:rgba(17,24,39,0.45);z-index:10;display:none;"></div>
+    <div data-basket-preview-panel style="position:relative;z-index:20;background-color:#ffffff;border-radius:16px;box-shadow:0 24px 48px rgba(15,23,42,0.18);overflow:hidden;">
+      <div style="display:flex;align-items:center;justify-content:space-between;padding:18px 20px;border-bottom:1px solid #f1f1f1;">
+        <span style="font-size:16px;font-weight:700;color:#111827;">Warenkorb</span>
+        <button type="button" class="fh-basket-preview-close" data-basket-preview-close aria-label="Warenkorb schließen" style="border:none;background:none;padding:4px;cursor:pointer;color:#6b7280;font-size:22px;line-height:1;">&times;</button>
+      </div>
+      <div data-basket-preview-viewport style="max-height:320px;overflow-y:auto;padding:16px 20px;">
+        <div data-basket-preview-list style="display:flex;flex-direction:column;gap:12px;">
+          <p style="margin:0;font-size:14px;color:#6b7280;">Ihr Warenkorb ist derzeit leer.</p>
+        </div>
+      </div>
+      <div style="padding:16px 20px;border-top:1px solid #f1f1f1;display:flex;flex-direction:column;gap:8px;">
+        <div style="display:flex;align-items:center;justify-content:space-between;font-size:15px;font-weight:600;color:#111827;">
+          <span>Zwischensumme</span>
+          <span data-basket-preview-sum style="font-size:16px;">0,00&nbsp;€</span>
+        </div>
+        <a href="/basket" style="display:block;text-align:center;padding:12px 16px;background-color:#1f2937;color:#ffffff;text-decoration:none;border-radius:10px;font-weight:600;font-size:15px;">Zum Warenkorb</a>
+        <a href="/checkout" style="display:block;text-align:center;padding:12px 16px;background-color:#31a5f0;color:#ffffff;text-decoration:none;border-radius:10px;font-weight:600;font-size:15px;">Zur Kasse</a>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- replace the custom `<header>` wrapper with a div to avoid nested headers and add header root metadata
- extend the cart icon with accessibility attributes and basket-preview toggle hook used by plentyShop LTS
- embed a basket preview container inside the header so the standard toggle logic has markup to control

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d5497c21f083318bdb90bbeb3b7209