### PR TITLE
Update header markup for basket preview compatibility

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -1,4 +1,4 @@
-<header class="fh-header" style="max-width:1600px;width:100%;margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;position:relative;z-index:1000;">
+<div class="fh-header" data-fh-header-root style="max-width:1600px;width:100%;margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;position:relative;z-index:1000;">
   <div style="display:flex;align-items:center;justify-content:space-between;background-color:#f7f7f7;padding:8px 32px;font-size:14px;letter-spacing:0.2px;">
     <div style="flex:1;text-align:left;">4,88 auf Trusted Shops</div>
     <div style="flex:1;text-align:center;">Schneller Versand</div>
@@ -42,13 +42,19 @@
         </nav>
       </div>
     </div>
-    <a href="#" class="toggle-basket-preview" aria-label="Warenkorb" style="display:flex;align-items:center;justify-content:center;width:48px;height:48px;border-radius:50%;background-color:#31a5f0;color:#ffffff;text-decoration:none;justify-self:end;">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="width:22px;height:22px;">
-        <circle cx="9" cy="20" r="1.5" fill="currentColor"></circle>
-        <circle cx="18" cy="20" r="1.5" fill="currentColor"></circle>
-        <path d="M2.5 3h2l2.4 12.6a1.5 1.5 0 0 0 1.5 1.2H18a1.5 1.5 0 0 0 1.5-1.2L21 7H6"></path>
-      </svg>
-    </a>
+    <div class="fh-basket-preview" style="position:relative;justify-self:end;display:flex;align-items:center;justify-content:center;">
+      <a v-toggle-basket-preview href="#" class="toggle-basket-preview" aria-label="Warenkorb" style="display:flex;align-items:center;justify-content:center;width:48px;height:48px;border-radius:50%;background-color:#31a5f0;color:#ffffff;text-decoration:none;position:relative;">
+        <span style="position:absolute;top:-6px;right:-6px;display:flex;align-items:center;justify-content:center;width:20px;height:20px;border-radius:50%;background-color:#ffffff;color:#31a5f0;font-size:11px;font-weight:700;" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="width:22px;height:22px;">
+          <circle cx="9" cy="20" r="1.5" fill="currentColor"></circle>
+          <circle cx="18" cy="20" r="1.5" fill="currentColor"></circle>
+          <path d="M2.5 3h2l2.4 12.6a1.5 1.5 0 0 0 1.5 1.2H18a1.5 1.5 0 0 0 1.5-1.2L21 7H6"></path>
+        </svg>
+        <span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00</span>
+        <span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00</span>
+      </a>
+      <basket-preview v-if="$store.state.lazyComponent.components['basket-preview']" :show-net-prices="$store.state.basket.showNetPrices" :visible-fields="['image','name','quantity','itemSum','totalSum']"></basket-preview>
+    </div>
   </div>
   <nav style="background-color:#ffffff;">
     <div style="max-width:1600px;width:100%;margin:0 auto;position:relative;">
@@ -329,4 +335,4 @@
       </ul>
     </div>
   </nav>
-</header>
+</div>


### PR DESCRIPTION
## Summary
- replace the custom header wrapper with a neutral div to avoid duplicate <header> tags
- wrap the basket icon with Vue-compatible markup and add lazy basket preview component markup for Plenty LTS compatibility

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5497c21f083318bdb90bbeb3b7209