### PR TITLE
Fix basket preview totals visibility

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -53,7 +53,7 @@
         <span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00</span>
         <span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00</span>
       </a>
-      <basket-preview v-if="$store.state.lazyComponent.components['basket-preview']" :show-net-prices="$store.state.basket.showNetPrices" :visible-fields="['basketValueNet','basketValueGross','shippingCostsNet','shippingCostsGross','subAmount','totalSumNet','totalSumGross']"></basket-preview>
+      <basket-preview v-if="$store.state.lazyComponent.components['basket-preview']" :show-net-prices="$store.state.basket.showNetPrices" :visible-fields="['basketValueGross','shippingCostsGross','totalSumNet','totalSumGross']"></basket-preview>
     </div>
   </div>
   <nav style="background-color:#ffffff;">


### PR DESCRIPTION
## Summary
- align the basket-preview visible field configuration with the Ceres component defaults so the totals render again

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d54d15e0dc8331a02f9bd752ce517f