### PR TITLE
Refresh header styling and cart badges

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -1,9 +1,9 @@
 <div class="fh-header" data-fh-header-root style="max-width:1600px;width:100%;margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;position:relative;z-index:1000;">
   <div style="display:flex;align-items:center;justify-content:center;gap:48px;padding:10px 32px;background:linear-gradient(90deg,#1f2937,#0f172a);color:#ffffff;font-size:13px;letter-spacing:0.3px;text-transform:uppercase;">
-    <span style="display:flex;align-items:center;gap:8px;">
+    <a href="https://www.trustedshops.de/bewertung/info_XDCA531410FCCAB88C0D491294FA17294.html" style="display:flex;align-items:center;gap:8px;color:inherit;text-decoration:none;">
       <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
-      4,88 auf Trusted Shops
-    </span>
+      4,88 Sterne auf Trusted Shops
+    </a>
     <span style="display:flex;align-items:center;gap:8px;">
       <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
       Schneller Versand
@@ -55,15 +55,15 @@
       </div>
     </div>
     <div class="fh-basket-preview" style="position:relative;justify-self:end;display:flex;align-items:center;justify-content:center;">
-      <a v-toggle-basket-preview href="#" class="toggle-basket-preview" aria-label="Warenkorb" style="display:flex;align-items:center;justify-content:center;width:54px;height:54px;border-radius:18px;background:linear-gradient(135deg,#0f172a,#1f2937);color:#ffffff;text-decoration:none;position:relative;box-shadow:0 12px 24px rgba(15,23,42,0.22);">
-        <span style="position:absolute;top:-8px;right:-8px;display:flex;align-items:center;justify-content:center;min-width:22px;height:22px;padding:0 6px;border-radius:999px;background-color:#000000;color:#ffffff;font-size:11px;font-weight:700;letter-spacing:0.3px;" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="width:22px;height:22px;">
+      <a v-toggle-basket-preview href="#" class="toggle-basket-preview" aria-label="Warenkorb" style="display:flex;align-items:center;gap:14px;justify-content:center;padding:0 28px;height:62px;border-radius:20px;background:linear-gradient(135deg,#0f172a,#1f2937);color:#ffffff;text-decoration:none;position:relative;box-shadow:0 12px 24px rgba(15,23,42,0.22);">
+        <span style="position:absolute;top:-10px;right:-10px;display:flex;align-items:center;justify-content:center;min-width:24px;height:24px;padding:0 7px;border-radius:999px;background-color:#000000;color:#ffffff;font-size:11px;font-weight:700;letter-spacing:0.3px;" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="width:24px;height:24px;">
           <circle cx="9" cy="20" r="1.5" fill="currentColor"></circle>
           <circle cx="18" cy="20" r="1.5" fill="currentColor"></circle>
           <path d="M2.5 3h2l2.4 12.6a1.5 1.5 0 0 0 1.5 1.2H18a1.5 1.5 0 0 0 1.5-1.2L21 7H6"></path>
         </svg>
-        <span style="position:absolute;bottom:-12px;right:-18px;display:flex;align-items:center;justify-content:center;padding:0 10px;height:24px;border-radius:999px;background-color:#000000;color:#ffffff;font-size:12px;font-weight:700;white-space:nowrap;box-shadow:0 6px 16px rgba(15,23,42,0.28);" aria-hidden="true" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
-        <span style="position:absolute;bottom:-12px;right:-18px;display:flex;align-items:center;justify-content:center;padding:0 10px;height:24px;border-radius:999px;background-color:#000000;color:#ffffff;font-size:12px;font-weight:700;white-space:nowrap;box-shadow:0 6px 16px rgba(15,23,42,0.28);" aria-hidden="true" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
+        <span style="display:inline-flex;align-items:center;font-size:16px;font-weight:700;white-space:nowrap;" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
+        <span style="display:inline-flex;align-items:center;font-size:16px;font-weight:700;white-space:nowrap;" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
         <span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
         <span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
       </a>


### PR DESCRIPTION
## Summary
- restyle the header info strip, icon buttons, and basket badges for a cleaner layout
- drop the trailing “sehen” from the mega-menu call-to-action links

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d55430c7108331bb2d9fbd4caf2f8b