### PR TITLE
Add clear button behaviour to header search

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -22,7 +22,12 @@
       <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Logo_neu/FH_Icon_big_Profile_Image_transparent_385x200px.png" alt="FENSTER-HAMMER" style="height:64px;width:auto;">
     </a>
     <form action="#" method="get" style="width:100%;display:flex;align-items:center;">
-      <input type="search" name="q" class="search-input" placeholder="Suchbegriff eingeben" aria-label="Suche" style="width:100%;padding:14px 52px 14px 24px;border:1px solid #d5d5d5;border-radius:18px;font-size:15px;line-height:1.4;color:#1f2937;background-color:#f8fafc;box-shadow:inset 0 1px 2px rgba(15,23,42,0.08);">
+      <div style="position:relative;width:100%;display:flex;align-items:center;">
+        <input type="search" name="q" class="search-input" placeholder="Suchbegriff eingeben" aria-label="Suche" data-fh-search-input style="width:100%;padding:14px 44px 14px 24px;border:1px solid #d5d5d5;border-radius:18px;font-size:15px;line-height:1.4;color:#1f2937;background-color:#f8fafc;box-shadow:inset 0 1px 2px rgba(15,23,42,0.08);">
+        <button type="button" aria-label="Suche zurücksetzen" data-fh-search-clear style="position:absolute;right:16px;top:50%;transform:translateY(-50%);display:none;align-items:center;justify-content:center;width:24px;height:24px;border:none;border-radius:50%;background-color:transparent;color:#94a3b8;font-size:20px;line-height:1;cursor:pointer;padding:0;transition:color .2s ease;">
+          &times;
+        </button>
+      </div>
     </form>
     <a href="/wish-list" aria-label="Merkzettel" style="display:flex;align-items:center;justify-content:center;width:46px;height:46px;border:1px solid #d9d9d9;border-radius:14px;color:#1a1a1a;text-decoration:none;justify-self:end;transition:all .2s ease;background-color:#ffffff;">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" style="width:22px;height:22px;">
@@ -101,7 +106,7 @@
               <p style="margin:0;color:#4b5563;font-size:14px;line-height:1.6;">Ob Haus-, Wohnungs-, Zimmer- oder Garagentür – hier findest du das passende Schloss für jede Anwendung. Von Einsteck- bis Rohrrahmenschlössern und elektrischen Türöffnern bieten wir geprüfte Qualität und hohe Sicherheit. Ergänzt durch Profilzylinder, Schließbleche und Türdrücker erhältst du alles aus einer Hand für eine sichere Türlösung.</p>
             </div>
             <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="/schloesser" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle SCHLÖSSER sehen</a>
+              <a href="/schloesser" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle SCHLÖSSER</a>
             </div>
           </div>
         </div>
@@ -141,7 +146,7 @@
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
             </div>
             <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Beschläge sehen</a>
+              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Beschläge</a>
             </div>
           </div>
         </div>
@@ -181,7 +186,7 @@
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
             </div>
             <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Sicherungen sehen</a>
+              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Sicherungen</a>
             </div>
           </div>
         </div>
@@ -221,7 +226,7 @@
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
             </div>
             <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Sichtschutz sehen</a>
+              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Sichtschutz</a>
             </div>
           </div>
         </div>
@@ -261,7 +266,7 @@
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
             </div>
             <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Fenstermontage sehen</a>
+              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Fenstermontage</a>
             </div>
           </div>
         </div>
@@ -301,7 +306,7 @@
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
             </div>
             <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Chemische Befestigung sehen</a>
+              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Chemische Befestigung</a>
             </div>
           </div>
         </div>
@@ -341,7 +346,7 @@
               <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
             </div>
             <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Aktionen sehen</a>
+              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Aktionen</a>
             </div>
           </div>
         </div>
@@ -349,4 +354,28 @@
       </ul>
     </div>
   </nav>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var searchInput = document.querySelector('[data-fh-search-input]');
+      var clearButton = document.querySelector('[data-fh-search-clear]');
+
+      if (!searchInput || !clearButton) {
+        return;
+      }
+
+      var toggleClearButton = function () {
+        clearButton.style.display = searchInput.value ? 'flex' : 'none';
+      };
+
+      clearButton.addEventListener('click', function () {
+        searchInput.value = '';
+        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+        searchInput.focus();
+        toggleClearButton();
+      });
+
+      searchInput.addEventListener('input', toggleClearButton);
+      toggleClearButton();
+    });
+  </script>
 </div>


### PR DESCRIPTION
## Summary
- add a dedicated clear button to the header search input and tighten its alignment
- remove the "sehen" suffix from header navigation labels as requested

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d64e7020708331b184dfd0777eefb9