### PR TITLE
Center saved list icon and add count badge

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -24,8 +24,9 @@
     <form action="#" method="get" style="width:100%;display:flex;align-items:center;">
       <input type="search" name="q" class="search-input" placeholder="Suchbegriff eingeben" aria-label="Suche" style="width:100%;padding:14px 52px 14px 24px;border:1px solid #d5d5d5;border-radius:18px;font-size:15px;line-height:1.4;color:#1f2937;background-color:#f8fafc;box-shadow:inset 0 1px 2px rgba(15,23,42,0.08);">
     </form>
-    <a href="/wish-list" aria-label="Merkzettel" style="display:flex;align-items:center;justify-content:center;width:46px;height:46px;border:1px solid #d9d9d9;border-radius:14px;color:#1a1a1a;text-decoration:none;justify-self:end;transition:all .2s ease;background-color:#ffffff;">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" style="width:22px;height:22px;">
+    <a href="/wish-list" aria-label="Merkzettel" style="position:relative;display:flex;align-items:center;justify-content:center;width:46px;height:46px;border:1px solid #d9d9d9;border-radius:14px;color:#1a1a1a;text-decoration:none;justify-self:end;transition:all .2s ease;background-color:#ffffff;">
+      <span style="position:absolute;top:-6px;right:-6px;display:flex;align-items:center;justify-content:center;min-width:20px;height:20px;padding:0 6px;border-radius:999px;background-color:#31a5f0;color:#ffffff;font-size:11px;font-weight:700;letter-spacing:0.3px;line-height:1;" v-cloak v-text="$store.getters.wishListCount || 0"></span>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" style="width:22px;height:22px;display:block;">
         <path d="M6 3h9a2 2 0 0 1 2 2v16l-6.5-3.5L4 21V5a2 2 0 0 1 2-2z"></path>
       </svg>
     </a>


### PR DESCRIPTION
## Summary
- center the wish list button icon within the header action
- add a wish list count badge that reads the plentymarkets store getter for live updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6571d47088331be3a3479c318635c