### PR TITLE
Add wishlist flyout menu to header

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -35,20 +35,11 @@
         <div style="position:absolute;top:-10px;right:12px;width:20px;height:20px;background-color:#ffffff;border-top:1px solid #e2e2e2;border-left:1px solid #e2e2e2;transform:rotate(45deg);pointer-events:none;"></div>
         <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:12px;">
           <div style="font-size:16px;font-weight:700;color:#1a1a1a;">Merkzettel</div>
-          <a href="/wish-list" style="font-size:13px;color:#1f7ae0;text-decoration:none;font-weight:600;">Zur Wunschliste</a>
         </div>
         <div data-fh-wishlist-menu-loading style="display:none;font-size:14px;color:#6b7280;padding:12px 0;">Wird geladen …</div>
         <div data-fh-wishlist-menu-error style="display:none;font-size:14px;color:#dc2626;padding:12px 0;">Merkzettel konnte nicht geladen werden. Bitte versuchen Sie es erneut.</div>
         <div data-fh-wishlist-menu-empty style="display:none;font-size:14px;color:#6b7280;padding:12px 0;">Ihr Merkzettel ist leer.</div>
         <ul data-fh-wishlist-menu-list style="list-style:none;margin:0;padding:0;max-height:360px;overflow:auto;"></ul>
-        <div data-fh-wishlist-menu-footer style="margin-top:16px;padding-top:12px;border-top:1px solid #eef2f6;text-align:center;">
-          <a href="/wish-list" style="display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 16px;background-color:#1f2937;color:#ffffff;text-decoration:none;border-radius:10px;font-weight:600;font-size:14px;">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" style="width:18px;height:18px;">
-              <path d="M6 3h9a2 2 0 0 1 2 2v16l-6.5-3.5L4 21V5a2 2 0 0 1 2-2z"></path>
-            </svg>
-            Zur Wunschliste
-          </a>
-        </div>
       </div>
     </div>
     <div class="fh-account-menu-container" data-fh-account-menu-container style="position:relative;justify-self:end;">

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -22,6 +22,10 @@ document.addEventListener('DOMContentLoaded', function () {
       return;
     }
 
+    if (window.fhWishlistMenu && typeof window.fhWishlistMenu.close === 'function') {
+      window.fhWishlistMenu.close();
+    }
+
     menu.style.display = 'block';
     menu.setAttribute('aria-hidden', 'false');
     toggleButton.setAttribute('aria-expanded', 'true');
@@ -74,6 +78,12 @@ document.addEventListener('DOMContentLoaded', function () {
       closeMenu();
     }
   });
+
+  window.fhAccountMenu = window.fhAccountMenu || {};
+  window.fhAccountMenu.close = closeMenu;
+  window.fhAccountMenu.isOpen = function () {
+    return isOpen;
+  };
 });
 // End Section: FH account menu toggle behaviour
 
@@ -324,27 +334,6 @@ document.addEventListener('DOMContentLoaded', function () {
     return container.childNodes.length ? container : null;
   }
 
-  function getAvailabilityBadge(item) {
-    if (!item || !item.variation || !item.variation.availability || !item.variation.availability.names) {
-      return null;
-    }
-
-    const availabilityName = item.variation.availability.names.name;
-
-    if (!availabilityName) {
-      return null;
-    }
-
-    const badge = document.createElement('span');
-    badge.className = 'badge availability-' + item.variation.availability.id;
-    badge.textContent = availabilityName;
-    badge.style.fontSize = '11px';
-    badge.style.marginTop = '8px';
-    badge.style.display = 'inline-block';
-
-    return badge;
-  }
-
   function getBasePrice(item) {
     if (!item || !item.prices) {
       return '';
@@ -510,7 +499,6 @@ document.addEventListener('DOMContentLoaded', function () {
       }
 
       const attributeSummary = createAttributeSummary(item);
-      const availabilityBadge = getAvailabilityBadge(item);
 
       const actionRow = document.createElement('div');
       actionRow.style.display = 'flex';
@@ -521,26 +509,14 @@ document.addEventListener('DOMContentLoaded', function () {
       const addToCartButton = document.createElement('button');
       addToCartButton.type = 'button';
       addToCartButton.textContent = 'In den Warenkorb';
-      addToCartButton.style.display = 'inline-flex';
-      addToCartButton.style.alignItems = 'center';
-      addToCartButton.style.justifyContent = 'center';
-      addToCartButton.style.padding = '8px 12px';
-      addToCartButton.style.backgroundColor = '#31a5f0';
-      addToCartButton.style.color = '#ffffff';
-      addToCartButton.style.border = 'none';
-      addToCartButton.style.borderRadius = '10px';
-      addToCartButton.style.fontSize = '13px';
-      addToCartButton.style.fontWeight = '600';
-      addToCartButton.style.cursor = 'pointer';
-      addToCartButton.style.transition = 'background-color .2s ease';
+      addToCartButton.className = 'btn btn-primary btn-appearance mobile-width-button';
 
       const quantityDefaults = getQuantityDefaults(item);
 
       if (!isSaleable(item)) {
         addToCartButton.disabled = true;
         addToCartButton.textContent = 'Nicht verfügbar';
-        addToCartButton.style.backgroundColor = '#cbd5f5';
-        addToCartButton.style.cursor = 'not-allowed';
+        addToCartButton.classList.add('disabled');
       }
 
       addToCartButton.addEventListener('click', function (event) {
@@ -568,8 +544,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
         const originalText = addToCartButton.textContent;
         addToCartButton.disabled = true;
+        addToCartButton.classList.add('disabled');
         addToCartButton.textContent = 'Wird hinzugefügt…';
-        addToCartButton.style.backgroundColor = '#1f7ae0';
 
         const payload = {
           variationId: variationId,
@@ -581,47 +557,27 @@ document.addEventListener('DOMContentLoaded', function () {
             addToCartButton.textContent = 'Im Warenkorb';
             setTimeout(function () {
               addToCartButton.disabled = false;
+              addToCartButton.classList.remove('disabled');
               addToCartButton.textContent = originalText;
-              addToCartButton.style.backgroundColor = '#31a5f0';
             }, 1600);
           })
           .catch(function () {
             addToCartButton.textContent = 'Fehler';
-            addToCartButton.style.backgroundColor = '#dc2626';
             setTimeout(function () {
               addToCartButton.disabled = false;
+              addToCartButton.classList.remove('disabled');
               addToCartButton.textContent = originalText;
-              addToCartButton.style.backgroundColor = '#31a5f0';
             }, 2000);
           });
       });
 
-      const viewLink = document.createElement('a');
-      viewLink.href = url;
-      viewLink.textContent = 'Artikel ansehen';
-      viewLink.style.display = 'inline-flex';
-      viewLink.style.alignItems = 'center';
-      viewLink.style.justifyContent = 'center';
-      viewLink.style.padding = '8px 12px';
-      viewLink.style.borderRadius = '10px';
-      viewLink.style.fontSize = '13px';
-      viewLink.style.fontWeight = '600';
-      viewLink.style.color = '#1f2937';
-      viewLink.style.backgroundColor = '#f1f5f9';
-      viewLink.style.textDecoration = 'none';
-
       actionRow.appendChild(addToCartButton);
-      actionRow.appendChild(viewLink);
 
       details.appendChild(nameLink);
       details.appendChild(priceLine);
 
       if (attributeSummary) {
         details.appendChild(attributeSummary);
-      }
-
-      if (availabilityBadge) {
-        details.appendChild(availabilityBadge);
       }
 
       details.appendChild(actionRow);
@@ -733,6 +689,10 @@ document.addEventListener('DOMContentLoaded', function () {
       return;
     }
 
+    if (window.fhAccountMenu && typeof window.fhAccountMenu.close === 'function') {
+      window.fhAccountMenu.close();
+    }
+
     menu.style.display = 'block';
     menu.setAttribute('aria-hidden', 'false');
     toggleButton.setAttribute('aria-expanded', 'true');
@@ -772,6 +732,12 @@ document.addEventListener('DOMContentLoaded', function () {
   menu.addEventListener('click', function (event) {
     event.stopPropagation();
   });
+
+  window.fhWishlistMenu = window.fhWishlistMenu || {};
+  window.fhWishlistMenu.close = closeMenu;
+  window.fhWishlistMenu.isOpen = function () {
+    return isOpen;
+  };
 });
 // End Section: FH wish list flyout preview
 


### PR DESCRIPTION
## Summary
- add a wishlist button to the FH header that opens a styled flyout with loading, empty and error states
- implement client-side logic to load wishlist entries from the Vuex store, render product cards and trigger add-to-cart requests

## Testing
- not run (not available in repo)

------
https://chatgpt.com/codex/tasks/task_e_68d659157994833186851b86ced4c8d6