### PR TITLE
Fix wishlist tooltip and refresh behaviour

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -144,6 +144,14 @@
 }
 /* End Section: Merkliste Button Styling */
 
+/* Section: FH Header Merkliste Icon Alignment */
+.fh-wishlist-menu-container [data-fh-wishlist-menu-toggle] svg {
+  display: block;
+  margin-left: 1px;
+  transform: translateX(0.5px);
+}
+/* End Section: FH Header Merkliste Icon Alignment */
+
 /* Section: Body Top Margin Fix */
 div.widget.widget-grid.widget-two-col.row.mt-5 {
   margin-top: 1rem !important;


### PR DESCRIPTION
## Summary
- correct the wishlist button tooltip text to use “Merkliste hinzufügen” and update related data attributes
- harden the wishlist flyout to react to all wishlist mutations before opening after an add/remove action
- tweak the header wishlist icon alignment for a centered appearance

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d67da56e14833180f262c9a3bd540a