### PR TITLE
Expand FH header to full viewport width

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -1,23 +1,26 @@
-<div class="fh-header" data-fh-header-root style="max-width:1600px;width:100%;margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;position:relative;z-index:1000;">
-  <div style="display:flex;align-items:center;justify-content:center;gap:48px;padding:10px 32px;background:linear-gradient(90deg,#1f2937,#0f172a);color:#ffffff;font-size:13px;letter-spacing:0.3px;text-transform:uppercase;">
-    <a href="https://www.trustedshops.de/bewertung/info_XDCA531410FCCAB88C0D491294FA17294.html" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:8px;color:inherit;text-decoration:none;">
-      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
-      4,88 Sterne auf Trusted Shops
-    </a>
-    <span style="display:flex;align-items:center;gap:8px;">
-      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
-      Schneller Versand
-    </span>
-    <span style="display:flex;align-items:center;gap:8px;">
-      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
-      Hilfreicher Kundenservice &lt;24h
-    </span>
-    <span style="display:flex;align-items:center;gap:8px;">
-      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
-      Große Auswahl
-    </span>
+<div class="fh-header" data-fh-header-root style="width:100%;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;position:relative;z-index:1000;background-color:#ffffff;">
+  <div style="width:100%;background:linear-gradient(90deg,#1f2937,#0f172a);color:#ffffff;">
+    <div style="max-width:1600px;margin:0 auto;display:flex;align-items:center;justify-content:center;gap:48px;padding:10px 32px;font-size:13px;letter-spacing:0.3px;text-transform:uppercase;">
+      <a href="https://www.trustedshops.de/bewertung/info_XDCA531410FCCAB88C0D491294FA17294.html" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:8px;color:inherit;text-decoration:none;">
+        <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
+        4,88 Sterne auf Trusted Shops
+      </a>
+      <span style="display:flex;align-items:center;gap:8px;">
+        <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
+        Schneller Versand
+      </span>
+      <span style="display:flex;align-items:center;gap:8px;">
+        <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
+        Hilfreicher Kundenservice &lt;24h
+      </span>
+      <span style="display:flex;align-items:center;gap:8px;">
+        <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
+        Große Auswahl
+      </span>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:auto 1fr auto auto auto;align-items:center;padding:26px 32px 22px;border-bottom:1px solid #e2e2e2;background-color:#ffffff;column-gap:20px;">
+  <div style="width:100%;border-bottom:1px solid #e2e2e2;background-color:#ffffff;">
+    <div style="max-width:1600px;margin:0 auto;display:grid;grid-template-columns:auto 1fr auto auto auto;align-items:center;padding:26px 32px 22px;column-gap:20px;">
     <a href="/" style="display:flex;align-items:center;">
       <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Logo_neu/FH_Icon_big_Profile_Image_transparent_385x200px.png" alt="FENSTER-HAMMER" style="height:64px;width:auto;">
     </a>
@@ -81,6 +84,7 @@
         <span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
       </a>
       <basket-preview v-if="$store.state.lazyComponent.components['basket-preview']" :show-net-prices="$store.state.basket.showNetPrices" :visible-fields="['basketValueGross','shippingCostsGross','totalSumNet','totalSumGross']"></basket-preview>
+    </div>
     </div>
   </div>
   <nav style="background-color:#ffffff;">


### PR DESCRIPTION
## Summary
- allow the header background sections to span the full viewport width
- keep the header content centered inside a 1600px-wide container for consistency

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d68d4531bc833185327ec9073bc24b