### PR TITLE
Limit full-width header override to FH stylesheet

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -5,7 +5,7 @@
 /* Section: Layout Container Width Overrides */
 #page-header > div,
 #vue-app > div.footer.container-max.d-print-none {
-  width: 100vw;
+  max-width: 100vw;
 }
 /* End Section: Layout Container Width Overrides */
 


### PR DESCRIPTION
## Summary
- remove the full-width header/footer override from the SH stylesheet so it only applies to the FH shop variant

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d69343005c833190c515574af8ad63