### PR TITLE
Center FH header and footer content

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -48,6 +48,24 @@
 }
 /* End Section: FH Header Navigation Hover Behaviour */
 
+/* Section: FH Header & Footer Container Alignment */
+#page-header-parent {
+  padding: 0 !important;
+}
+
+#page-header-parent .fh-header {
+  width: 100%;
+  max-width: 1600px;
+  margin: 0 auto;
+}
+
+#page-footer .fh-footer {
+  width: 100%;
+  max-width: 1600px;
+  margin: 0 auto;
+}
+/* End Section: FH Header & Footer Container Alignment */
+
 /* Section: Trustbadge ausblenden */
 .basket-open .widget_container_overlay,
 .basket-open #trustami-mobile-view,

--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -1,4 +1,4 @@
-<div style="max-width:1600px;margin:0 auto;border-top:8px solid #000;background:linear-gradient(to bottom,#ffffff,#f1f1f1);padding:40px 20px;font-size:0.9rem;">
+<div class="fh-footer" style="max-width:1600px;margin:0 auto;border-top:8px solid #000;background:linear-gradient(to bottom,#ffffff,#f1f1f1);padding:40px 20px;font-size:0.9rem;">
   <div class="row">
     <div class="col-md-4 col-lg-3">
       <h5 class="d-flex align-items-center font-weight-bold mb-3"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/info_14574710.svg" alt="Infos" style="height:20px" class="mr-2">Infos</h5>


### PR DESCRIPTION
## Summary
- remove the default padding from `#page-header-parent` to let the custom header span edge to edge while staying centered
- constrain both the FH header and footer wrappers to a shared 1600px max-width via CSS and add a footer hook class for targeting

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6964e97288331a9251c1883ca0960