### PR TITLE
Add clear button to header search input

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -21,8 +21,14 @@
     <a href="/" style="display:flex;align-items:center;">
       <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Logo_neu/FH_Icon_big_Profile_Image_transparent_385x200px.png" alt="FENSTER-HAMMER" style="height:64px;width:auto;">
     </a>
-    <form action="#" method="get" style="width:100%;display:flex;align-items:center;">
+    <form action="#" method="get" style="position:relative;width:100%;display:flex;align-items:center;">
       <input type="search" name="q" class="search-input" placeholder="Suchbegriff eingeben" aria-label="Suche" style="width:100%;padding:14px 52px 14px 24px;border:1px solid #d5d5d5;border-radius:18px;font-size:15px;line-height:1.4;color:#1f2937;background-color:#f8fafc;box-shadow:inset 0 1px 2px rgba(15,23,42,0.08);">
+      <button type="button" data-search-clear aria-label="Suchbegriff löschen" style="display:none;position:absolute;right:18px;top:50%;transform:translateY(-50%);width:26px;height:26px;border:none;border-radius:999px;background-color:transparent;color:#64748b;cursor:pointer;align-items:center;justify-content:center;padding:0;transition:all .2s ease;">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:14px;height:14px;">
+          <line x1="5" y1="5" x2="15" y2="15"></line>
+          <line x1="15" y1="5" x2="5" y2="15"></line>
+        </svg>
+      </button>
     </form>
     <div class="fh-wishlist-menu-container" data-fh-wishlist-menu-container style="position:relative;justify-self:end;">
       <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-wishlist-menu" aria-label="Merkliste" data-fh-wishlist-menu-toggle style="position:relative;display:flex;align-items:center;justify-content:center;width:46px;height:46px;border:1px solid #d9d9d9;border-radius:14px;background-color:#ffffff;color:#1a1a1a;cursor:pointer;padding:0;transition:all .2s ease;">

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -1846,6 +1846,23 @@ document.addEventListener("DOMContentLoaded", function () {
   const searchInput = document.querySelector('input.search-input');
   if (!searchInput) return;
 
+  const clearButton = document.querySelector('[data-search-clear]');
+
+  const toggleClearButton = () => {
+    if (!clearButton) return;
+    clearButton.style.display = searchInput.value ? 'flex' : 'none';
+  };
+
+  if (clearButton) {
+    clearButton.addEventListener('click', function (event) {
+      event.preventDefault();
+      searchInput.value = '';
+      searchInput.dispatchEvent(new Event('input'));
+      searchInput.focus();
+      toggleClearButton();
+    });
+  }
+
   let inputFocused = false;
 
   // CSS-based device detection
@@ -1958,6 +1975,7 @@ document.addEventListener("DOMContentLoaded", function () {
     if (!searchInput.value) {
       searchInput.placeholder = "Wonach suchst du?";
     }
+    toggleClearButton();
     // Keine Animation starten während Fokus!
   });
 
@@ -1966,12 +1984,14 @@ document.addEventListener("DOMContentLoaded", function () {
     if (!searchInput.value) {
       searchInput.placeholder = "Wonach suchst du?";
     }
+    toggleClearButton();
     // Keine Animation starten während Fokus!
   });
 
   searchInput.addEventListener("blur", function () {
     inputFocused = false;
     resetInactivityTimer(); // Erst nach Verlassen ggf. Animation nach 10s
+    toggleClearButton();
   });
 
   window.addEventListener("scroll", function () {
@@ -1984,6 +2004,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // Beim Start direkt Animation starten
   startTyping();
+  toggleClearButton();
 });
 
 // End Section: Animierte Suchplatzhalter Vorschläge

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -340,6 +340,23 @@ document.addEventListener("DOMContentLoaded", function () {
     const searchInput = document.querySelector("input.search-input");
     if (!searchInput) return;
 
+    const clearButton = document.querySelector('[data-search-clear]');
+
+    const toggleClearButton = () => {
+      if (!clearButton) return;
+      clearButton.style.display = searchInput.value ? "flex" : "none";
+    };
+
+    if (clearButton) {
+      clearButton.addEventListener("click", function (event) {
+        event.preventDefault();
+        searchInput.value = "";
+        searchInput.dispatchEvent(new Event("input"));
+        searchInput.focus();
+        toggleClearButton();
+      });
+    }
+
     let inputFocused = false;
 
     // CSS-based device detection
@@ -446,6 +463,7 @@ document.addEventListener("DOMContentLoaded", function () {
       stopTyping();
       clearTimeout(inactivityTimer);
       searchInput.placeholder = "Wonach suchen Sie?";
+      toggleClearButton();
     }
 
     function handleFocus() {
@@ -467,6 +485,7 @@ document.addEventListener("DOMContentLoaded", function () {
       } else {
         searchInput.placeholder = "";
       }
+      toggleClearButton();
       // Keine Animation starten während Fokus!
     });
 
@@ -477,6 +496,7 @@ document.addEventListener("DOMContentLoaded", function () {
         searchInput.placeholder = "Wonach suchen Sie?";
       }
       resetInactivityTimer(); // Erst nach Verlassen ggf. Animation nach 10s
+      toggleClearButton();
     });
 
     window.addEventListener("scroll", function () {
@@ -489,6 +509,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Beim Start direkt Animation starten
     startTyping();
+    toggleClearButton();
   });
 
   // End Section: Animierte Suchplatzhalter Vorschläge


### PR DESCRIPTION
## Summary
- add a dedicated clear button inside the header search form and style it inline
- hook the new button into the existing search placeholder scripts for both FH and SH so it shows, hides, and clears input text

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6a88965a88331a7e84413ddfff5f6