### PR TITLE
Add working clear control for header search

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -36,6 +36,29 @@
 }
 /* End Section: Page Header Background */
 
+/* Section: FH search input native control overrides */
+.fh-header .search-input {
+  -webkit-appearance: textfield;
+  appearance: textfield;
+}
+
+.fh-header .search-input::-webkit-search-cancel-button,
+.fh-header .search-input::-webkit-search-decoration,
+.fh-header .search-input::-webkit-search-results-button,
+.fh-header .search-input::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+  display: none;
+}
+
+.fh-header .search-input::-ms-clear,
+.fh-header .search-input::-ms-reveal {
+  display: none;
+  width: 0;
+  height: 0;
+}
+/* End Section: FH search input native control overrides */
+
 /* Section: FH Header Container Sizing */
 .fh-header {
   width: 1600px;

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -21,8 +21,14 @@
     <a href="/" style="display:flex;align-items:center;">
       <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Logo_neu/FH_Icon_big_Profile_Image_transparent_385x200px.png" alt="FENSTER-HAMMER" style="height:64px;width:auto;">
     </a>
-    <form action="#" method="get" style="width:100%;display:flex;align-items:center;">
+    <form action="#" method="get" style="width:100%;display:flex;align-items:center;position:relative;">
       <input type="search" name="q" class="search-input" placeholder="Suchbegriff eingeben" aria-label="Suche" style="width:100%;padding:14px 52px 14px 24px;border:1px solid #d5d5d5;border-radius:18px;font-size:15px;line-height:1.4;color:#1f2937;background-color:#f8fafc;box-shadow:inset 0 1px 2px rgba(15,23,42,0.08);">
+      <button type="button" data-search-clear aria-label="Eingabe löschen" style="position:absolute;right:18px;top:50%;transform:translateY(-50%);display:none;align-items:center;justify-content:center;width:24px;height:24px;padding:0;border:none;background:none;color:#94a3b8;cursor:pointer;transition:color .2s ease;">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;">
+          <line x1="5" y1="5" x2="15" y2="15"></line>
+          <line x1="15" y1="5" x2="5" y2="15"></line>
+        </svg>
+      </button>
     </form>
     <div class="fh-wishlist-menu-container" data-fh-wishlist-menu-container style="position:relative;justify-self:end;">
       <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-wishlist-menu" aria-label="Merkliste" data-fh-wishlist-menu-toggle style="position:relative;display:flex;align-items:center;justify-content:center;width:46px;height:46px;border:1px solid #d9d9d9;border-radius:14px;background-color:#ffffff;color:#1a1a1a;cursor:pointer;padding:0;transition:all .2s ease;">

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -1846,6 +1846,28 @@ document.addEventListener("DOMContentLoaded", function () {
   const searchInput = document.querySelector('input.search-input');
   if (!searchInput) return;
 
+  const clearButton = document.querySelector('[data-search-clear]');
+  const toggleClearButton = () => {
+    if (!clearButton) return;
+    clearButton.style.display = searchInput.value ? 'flex' : 'none';
+  };
+
+  if (clearButton) {
+    clearButton.addEventListener('click', function (event) {
+      event.preventDefault();
+      searchInput.value = '';
+      searchInput.focus();
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      toggleClearButton();
+    });
+
+    searchInput.addEventListener('input', toggleClearButton);
+    searchInput.addEventListener('focus', toggleClearButton);
+    searchInput.addEventListener('blur', toggleClearButton);
+
+    toggleClearButton();
+  }
+
   let inputFocused = false;
 
   // CSS-based device detection

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -340,6 +340,28 @@ document.addEventListener("DOMContentLoaded", function () {
     const searchInput = document.querySelector("input.search-input");
     if (!searchInput) return;
 
+    const clearButton = document.querySelector("[data-search-clear]");
+    const toggleClearButton = () => {
+      if (!clearButton) return;
+      clearButton.style.display = searchInput.value ? "flex" : "none";
+    };
+
+    if (clearButton) {
+      clearButton.addEventListener("click", function (event) {
+        event.preventDefault();
+        searchInput.value = "";
+        searchInput.focus();
+        searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+        toggleClearButton();
+      });
+
+      searchInput.addEventListener("input", toggleClearButton);
+      searchInput.addEventListener("focus", toggleClearButton);
+      searchInput.addEventListener("blur", toggleClearButton);
+
+      toggleClearButton();
+    }
+
     let inputFocused = false;
 
     // CSS-based device detection


### PR DESCRIPTION
## Summary
- add an inline clear button to the header search form and position it within the input
- wire the new control into both FH and SH search scripts so the button clears the field and keeps placeholder animations in sync
- hide the browser-provided native cancel icon on the header search input so the custom clear control is the only visible affordance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6a88965a88331a7e84413ddfff5f6