### PR TITLE
Add dynamic account greeting with salutation and time-based text

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -74,7 +74,12 @@
         </div>
         <div v-else>
           <div style="display:flex;flex-direction:column;gap:6px;margin-bottom:16px;color:#1a1a1a;">
-            <div style="font-size:16px;font-weight:700;">Hallo, <span v-text="$store.getters.username" v-cloak></span></div>
+            <div style="font-size:16px;font-weight:700;" data-fh-account-greeting>
+              <span data-fh-account-greeting-output style="display:none;"></span>
+              <span data-fh-account-greeting-fallback>
+                Hallo, <span data-fh-account-greeting-username v-text="$store.getters.username" v-cloak></span>
+              </span>
+            </div>
             <div style="font-size:13px;color:#6b7280;">Schön, dass Sie wieder da sind!</div>
           </div>
           <div style="height:1px;background-color:#ececec;margin:0 0 16px;"></div>


### PR DESCRIPTION
## Summary
- add dedicated markup hooks in the account dropdown so a personalised greeting can be injected without breaking the fallback
- implement a JavaScript controller that derives a local-time greeting and resolves the customer salutation/last name from the store
- refresh the greeting whenever the account menu opens or customer data changes to keep the message accurate

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6b7c2bcd083319c0e671d838338d7