### PR TITLE
Adjust logged-in greeting to use salutation and surname

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -76,7 +76,15 @@
         </div>
         <div v-else>
           <div style="display:flex;flex-direction:column;gap:6px;margin-bottom:16px;color:#1a1a1a;">
-            <div style="font-size:16px;font-weight:700;">Hallo, <span v-text="$store.getters.username" v-cloak></span></div>
+            <div style="font-size:16px;font-weight:700;">
+              <template v-if="$store.getters.userData && $store.getters.userData.contact && ($store.getters.userData.contact.lastName || $store.getters.userData.contact.formOfAddress || $store.getters.userData.contact.salutation)">
+                Hallo,
+                <span v-cloak>
+                  {{ [($store.getters.userData.contact.formOfAddress || $store.getters.userData.contact.salutation), $store.getters.userData.contact.lastName].filter(Boolean).join(' ') }}
+                </span>
+              </template>
+              <template v-else>Hallo</template>
+            </div>
             <div style="font-size:13px;color:#6b7280;">Schön, dass Sie wieder da sind!</div>
           </div>
           <div style="height:1px;background-color:#ececec;margin:0 0 16px;"></div>


### PR DESCRIPTION
## Summary
- update the account dropdown greeting to prefer the contact salutation and last name
- fall back to a generic "Hallo" when no contact name data is available

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6c388e098833180588fec91e157a3