### PR TITLE
Update header greeting salutation logic

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -76,7 +76,10 @@
         </div>
         <div v-else>
           <div style="display:flex;flex-direction:column;gap:6px;margin-bottom:16px;color:#1a1a1a;">
-            <div style="font-size:16px;font-weight:700;">Hallo, <span v-text="$store.getters.username" v-cloak></span></div>
+            <div style="font-size:16px;font-weight:700;">
+              <span v-if="$store.state.user && $store.state.user.userData && $store.state.user.userData.lastName && (({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title)" v-cloak>Hallo, <span v-text="((({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title) + ' ' + $store.state.user.userData.lastName)" v-cloak></span></span>
+              <span v-else v-cloak>Hallo</span>
+            </div>
             <div style="font-size:13px;color:#6b7280;">Schön, dass Sie wieder da sind!</div>
           </div>
           <div style="height:1px;background-color:#ececec;margin:0 0 16px;"></div>


### PR DESCRIPTION
## Summary
- update the logged-in account greeting in the header to use the customer's salutation and surname
- fall back to a generic greeting when the necessary customer data is not available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c6659f5c8331bfc7f4c4abaf4e83