### PR TITLE
Adjust FH header account greeting by local time

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -77,8 +77,8 @@
         <div v-else>
           <div style="display:flex;flex-direction:column;gap:6px;margin-bottom:16px;color:#1a1a1a;">
             <div style="font-size:16px;font-weight:700;">
-              <span v-if="$store.state.user && $store.state.user.userData && $store.state.user.userData.lastName && (({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title)" v-cloak>Hallo, <span v-text="((({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title) + ' ' + $store.state.user.userData.lastName)" v-cloak></span></span>
-              <span v-else v-cloak>Hallo</span>
+              <span v-if="$store.state.user && $store.state.user.userData && $store.state.user.userData.lastName && (({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title)" v-cloak><span data-fh-account-greeting>Hallo,</span> <span v-text="((({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title) + ' ' + $store.state.user.userData.lastName)" v-cloak></span></span>
+              <span v-else v-cloak data-fh-account-greeting>Hallo</span>
             </div>
             <div style="font-size:13px;color:#6b7280;">Schön, dass Sie wieder da sind!</div>
           </div>

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -87,6 +87,36 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 // End Section: FH account menu toggle behaviour
 
+// Section: FH account greeting based on local time
+document.addEventListener('DOMContentLoaded', function () {
+  const greetingElements = document.querySelectorAll('[data-fh-account-greeting]');
+
+  if (!greetingElements.length) {
+    return;
+  }
+
+  const hour = new Date().getHours();
+  let greeting = 'Guten Tag';
+
+  if (hour < 10) {
+    greeting = 'Guten Morgen';
+  } else if (hour >= 16) {
+    greeting = 'Guten Abend';
+  }
+
+  greetingElements.forEach(function (element) {
+    if (!element || !element.textContent) {
+      return;
+    }
+
+    const originalText = element.textContent.trim();
+    const suffix = originalText.endsWith(',') ? ',' : '';
+
+    element.textContent = greeting + suffix;
+  });
+});
+// End Section: FH account greeting based on local time
+
 // Section: FH Merkliste button enhancements
 document.addEventListener('DOMContentLoaded', function () {
   const iconMarkup =


### PR DESCRIPTION
## Summary
- mark the FH account greeting spans with a data attribute for scripted updates
- add a lightweight script that replaces the greeting with an appropriate local-time salutation

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d6e871503083319b772e2468803649