### PR TITLE
Ensure account and wishlist popups overlay navigation

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -37,7 +37,7 @@
           <path d="M6 3h9a2 2 0 0 1 2 2v16l-6.5-3.5L4 21V5a2 2 0 0 1 2-2z"></path>
         </svg>
       </button>
-      <div id="fh-wishlist-menu" data-fh-wishlist-menu aria-hidden="true" style="position:absolute;top:calc(100% + 16px);right:0;display:none;background-color:#ffffff;border:1px solid #e2e2e2;border-radius:16px;padding:20px;width:420px;max-width:calc(100vw - 32px);box-shadow:0 18px 36px rgba(15,23,42,0.12);z-index:50;">
+      <div id="fh-wishlist-menu" data-fh-wishlist-menu aria-hidden="true" style="position:absolute;top:calc(100% + 16px);right:0;display:none;background-color:#ffffff;border:1px solid #e2e2e2;border-radius:16px;padding:20px;width:420px;max-width:calc(100vw - 32px);box-shadow:0 18px 36px rgba(15,23,42,0.12);z-index:3000;">
         <div style="position:absolute;top:-10px;right:12px;width:20px;height:20px;background-color:#ffffff;border-top:1px solid #e2e2e2;border-left:1px solid #e2e2e2;transform:rotate(45deg);pointer-events:none;"></div>
         <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:12px;">
           <div style="font-size:16px;font-weight:700;color:#1a1a1a;">Merkliste</div>
@@ -55,7 +55,7 @@
           <path d="M4.2 21.4c.5-3.6 3.8-6.4 7.8-6.4s7.3 2.8 7.8 6.4"></path>
         </svg>
       </button>
-      <div id="fh-account-menu" data-fh-account-menu aria-hidden="true" style="position:absolute;top:calc(100% + 16px);right:0;display:none;background-color:#ffffff;border:1px solid #e2e2e2;border-radius:16px;padding:20px;width:260px;box-shadow:0 18px 36px rgba(15,23,42,0.12);z-index:50;">
+      <div id="fh-account-menu" data-fh-account-menu aria-hidden="true" style="position:absolute;top:calc(100% + 16px);right:0;display:none;background-color:#ffffff;border:1px solid #e2e2e2;border-radius:16px;padding:20px;width:260px;box-shadow:0 18px 36px rgba(15,23,42,0.12);z-index:3000;">
         <div style="position:absolute;top:-10px;right:12px;width:20px;height:20px;background-color:#ffffff;border-top:1px solid #e2e2e2;border-left:1px solid #e2e2e2;transform:rotate(45deg);pointer-events:none;"></div>
         <div v-if="!$store.getters.isLoggedIn">
           <div style="font-size:16px;font-weight:700;margin-bottom:12px;color:#1a1a1a;">Ihr Konto</div>


### PR DESCRIPTION
## Summary
- raise the z-index of the account and wishlist popups so they appear above the navigation mega menus

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d6ec7dc91083319a98041c682e3cfc