### PR TITLE
Inject FH benefits bar before page header

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -1,22 +1,4 @@
 <div class="fh-header" data-fh-header-root style="margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;position:relative;z-index:1000;">
-  <div style="display:flex;align-items:center;justify-content:center;gap:48px;padding:10px 32px;background:linear-gradient(90deg,#1f2937,#0f172a);color:#ffffff;font-size:13px;letter-spacing:0.3px;text-transform:uppercase;">
-    <a href="https://www.trustedshops.de/bewertung/info_XDCA531410FCCAB88C0D491294FA17294.html" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:8px;color:inherit;text-decoration:none;">
-      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
-      4,88 Sterne auf Trusted Shops
-    </a>
-    <span style="display:flex;align-items:center;gap:8px;">
-      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
-      Schneller Versand
-    </span>
-    <span style="display:flex;align-items:center;gap:8px;">
-      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
-      Hilfreicher Kundenservice &lt;24h
-    </span>
-    <span style="display:flex;align-items:center;gap:8px;">
-      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
-      Große Auswahl
-    </span>
-  </div>
   <div style="display:grid;grid-template-columns:auto 1fr auto auto auto;align-items:center;padding:26px 32px 22px;border-bottom:1px solid #e2e2e2;background-color:#ffffff;column-gap:20px;">
     <a href="/" style="display:flex;align-items:center;">
       <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Logo_neu/FH_Icon_big_Profile_Image_transparent_385x200px.png" alt="FENSTER-HAMMER" style="height:64px;width:auto;">

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -1,5 +1,96 @@
 // Section: Global scripts for all pages
 
+// Section: FH header benefits bar injection
+(function () {
+  const BAR_ID = 'fh-header-benefits-bar';
+  const TARGET_SELECTOR = '#page-header';
+  const BENEFITS_MARKUP = `
+<div id="${BAR_ID}" data-fh-header-benefits style="margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#ffffff;position:relative;z-index:1000;">
+  <div style="display:flex;align-items:center;justify-content:center;gap:48px;padding:10px 32px;background:linear-gradient(90deg,#1f2937,#0f172a);color:#ffffff;font-size:13px;letter-spacing:0.3px;text-transform:uppercase;">
+    <a href="https://www.trustedshops.de/bewertung/info_XDCA531410FCCAB88C0D491294FA17294.html" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:8px;color:inherit;text-decoration:none;">
+      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
+      4,88 Sterne auf Trusted Shops
+    </a>
+    <span style="display:flex;align-items:center;gap:8px;">
+      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
+      Schneller Versand
+    </span>
+    <span style="display:flex;align-items:center;gap:8px;">
+      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
+      Hilfreicher Kundenservice &lt;24h
+    </span>
+    <span style="display:flex;align-items:center;gap:8px;">
+      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
+      Große Auswahl
+    </span>
+  </div>
+</div>
+`.trim();
+
+  function isCheckoutPage() {
+    const path = window.location.pathname || '';
+
+    return (
+      path.includes('/checkout') ||
+      path.includes('/kaufabwicklung') ||
+      path.includes('/kasse')
+    );
+  }
+
+  function insertBar() {
+    if (document.getElementById(BAR_ID)) {
+      return true;
+    }
+
+    const target = document.querySelector(TARGET_SELECTOR);
+
+    if (!target || !target.parentNode) {
+      return false;
+    }
+
+    const template = document.createElement('template');
+    template.innerHTML = BENEFITS_MARKUP;
+
+    const bar = template.content.firstElementChild;
+
+    if (!bar) {
+      return true;
+    }
+
+    target.parentNode.insertBefore(bar, target);
+
+    return true;
+  }
+
+  function init() {
+    if (isCheckoutPage()) {
+      return;
+    }
+
+    if (insertBar()) {
+      return;
+    }
+
+    const observer = new MutationObserver(function () {
+      if (insertBar()) {
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})();
+// End Section: FH header benefits bar injection
+
 // Section: FH account menu toggle behaviour
 document.addEventListener('DOMContentLoaded', function () {
   function resolveGreeting(defaultGreeting) {


### PR DESCRIPTION
## Summary
- remove the benefit bar markup from the FH header template so only the main header structure remains inside `#page-header`
- inject the benefits bar before `#page-header` with JavaScript, avoiding checkout pages and waiting for the target to exist to prevent layout shifts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6ef6a31148331a4a6e2a8f8c19f76