### PR TITLE
Add responsive FH header mobile menu

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -61,7 +61,7 @@
 
 /* Section: FH Header Container Sizing */
 .fh-header {
-  width: 1600px;
+  width: 100%;
   max-width: 1600px;
   margin-left: auto;
   margin-right: auto;
@@ -503,3 +503,418 @@ button[data-testing="quantity-btn-decrease"],
   padding-right: 0px;
 }
 /* End Section: Method list item label padding */
+
+/* Section: FH Header responsive behaviour */
+.fh-header-top-bar {
+  transition: transform 0.3s ease;
+}
+
+.fh-header-main {
+  transition: padding 0.3s ease;
+}
+
+.fh-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.fh-mobile-menu-toggle {
+  display: none !important;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.45px;
+}
+
+.fh-mobile-menu-toggle__icon {
+  position: relative;
+}
+
+.fh-mobile-menu-toggle__icon span {
+  height: 2px;
+  border-radius: 999px;
+  background-color: currentColor;
+}
+
+.fh-mobile-menu-toggle__label {
+  font-size: 0.8rem;
+}
+
+.fh-mobile-menu {
+  position: fixed;
+  inset: 0;
+  z-index: 5000;
+  pointer-events: none;
+  display: none;
+}
+
+.fh-mobile-menu__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.fh-mobile-menu__panel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: min(86vw, 360px);
+  background: #ffffff;
+  border-radius: 0 18px 18px 0;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(-100%);
+  transition: transform 0.32s ease;
+  box-shadow: 16px 0 48px rgba(15, 23, 42, 0.18);
+}
+
+.fh-mobile-menu__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px 24px 20px;
+  background: linear-gradient(120deg, #1f2937 0%, #0f172a 60%, #1d4ed8 100%);
+  color: #ffffff;
+}
+
+.fh-mobile-menu__title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fh-mobile-menu__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+}
+
+.fh-mobile-menu__subtitle {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.fh-mobile-menu__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: none;
+  background: rgba(15, 23, 42, 0.25);
+  color: #ffffff;
+  font-size: 1.6rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.fh-mobile-menu__close:hover,
+.fh-mobile-menu__close:focus {
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.fh-mobile-menu__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 0 32px;
+}
+
+.fh-mobile-menu__nav {
+  padding: 0 6px 0 0;
+}
+
+.fh-mobile-menu__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.fh-mobile-menu__item + .fh-mobile-menu__item {
+  border-top: 1px solid #e2e8f0;
+}
+
+.fh-mobile-menu__link {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 28px;
+  background: none;
+  border: none;
+  color: #0f172a;
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+}
+
+.fh-mobile-menu__submenu {
+  display: none;
+  padding: 0 24px 24px;
+  animation: fh-mobile-submenu-in 0.3s ease forwards;
+}
+
+.fh-mobile-menu__submenu-list {
+  list-style: none;
+  margin: 16px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.fh-mobile-menu__submenu-list a {
+  display: block;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: #f8fafc;
+  color: #0f172a;
+  font-weight: 600;
+  text-decoration: none;
+  border: 1px solid #e2e8f0;
+}
+
+.fh-mobile-menu__section {
+  margin-top: 14px;
+  border-radius: 14px;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
+  overflow: hidden;
+}
+
+.fh-mobile-menu__section-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  background: none;
+  border: none;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #0f172a;
+  cursor: pointer;
+}
+
+.fh-mobile-menu__section-panel {
+  display: none;
+  padding: 4px 18px 18px;
+}
+
+.fh-mobile-menu__section-panel ul {
+  list-style: none;
+  margin: 0;
+  padding: 8px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fh-mobile-menu__section-panel a {
+  display: block;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #ffffff;
+  border: 1px solid #dbe0eb;
+  color: #1f2937;
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.fh-mobile-menu__section-cta {
+  margin-top: 20px;
+  padding: 0 6px;
+}
+
+.fh-mobile-menu__section-cta a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.fh-mobile-menu__chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+}
+
+.fh-mobile-menu__chevron::before {
+  content: '';
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(-45deg);
+  transition: transform 0.25s ease;
+}
+
+.fh-mobile-menu__section.is-open,
+[data-fh-mobile-submenu-toggle][aria-expanded='true'] {
+  color: #1d4ed8;
+}
+
+[data-fh-mobile-submenu-toggle][aria-expanded='true'] {
+  background: rgba(37, 99, 235, 0.06);
+}
+
+.fh-mobile-menu__section.is-open .fh-mobile-menu__section-toggle {
+  color: #1d4ed8;
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.fh-mobile-menu__section.is-open .fh-mobile-menu__section-panel {
+  display: block;
+}
+
+.fh-mobile-menu__section.is-open .fh-mobile-menu__chevron::before {
+  transform: rotate(45deg);
+}
+
+[data-fh-mobile-submenu-toggle][aria-expanded='true'] + .fh-mobile-menu__submenu {
+  display: block;
+}
+
+[data-fh-mobile-submenu-toggle][aria-expanded='true'] .fh-mobile-menu__chevron::before {
+  transform: rotate(45deg);
+}
+
+.fh-mobile-menu--open {
+  pointer-events: auto;
+}
+
+.fh-mobile-menu--open .fh-mobile-menu__overlay {
+  opacity: 1;
+}
+
+.fh-mobile-menu--open .fh-mobile-menu__panel {
+  transform: translateX(0);
+}
+
+body.fh-mobile-menu-open {
+  overflow: hidden;
+}
+
+@keyframes fh-mobile-submenu-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1180px) {
+  .fh-header {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 1024px) {
+  .fh-header-top-bar {
+    display: none !important;
+  }
+
+  .fh-header-nav {
+    display: none !important;
+  }
+
+  .fh-mobile-menu {
+    display: block;
+  }
+
+  .fh-mobile-menu-toggle {
+    display: inline-flex !important;
+  }
+
+  .fh-header-main {
+    grid-template-columns: auto 1fr auto !important;
+    grid-template-areas:
+      'menu logo actions'
+      'search search search';
+    row-gap: 18px;
+    column-gap: 16px !important;
+    padding: 20px 20px 18px !important;
+  }
+
+  .fh-mobile-menu-toggle {
+    grid-area: menu;
+  }
+
+  .fh-header-logo {
+    grid-area: logo;
+    justify-self: center;
+  }
+
+  .fh-header-actions {
+    grid-area: actions;
+    justify-self: end;
+    gap: 12px;
+  }
+
+  .fh-header-search {
+    grid-area: search;
+    width: 100% !important;
+  }
+
+  .fh-header-search .search-input {
+    padding: 12px 48px 12px 18px !important;
+    font-size: 0.95rem !important;
+  }
+
+  .fh-header-actions .toggle-basket-preview {
+    min-width: auto !important;
+    padding: 0 16px !important;
+  }
+}
+
+@media (max-width: 768px) {
+  .fh-header-main {
+    padding: 18px 16px 16px !important;
+  }
+
+  .fh-header-actions {
+    gap: 10px;
+  }
+
+  .fh-mobile-menu__panel {
+    width: min(92vw, 340px);
+  }
+
+  .fh-mobile-menu__link {
+    padding: 16px 22px;
+  }
+
+  .fh-mobile-menu-toggle__label {
+    display: none;
+  }
+}
+
+@media (max-width: 520px) {
+  .fh-header-actions .toggle-basket-preview {
+    padding: 0 12px !important;
+    gap: 8px !important;
+  }
+
+  .fh-header-actions .toggle-basket-preview span[aria-hidden='true'] {
+    font-size: 0.9rem !important;
+  }
+}
+/* End Section: FH Header responsive behaviour */

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -1,5 +1,5 @@
 <div class="fh-header" data-fh-header-root style="margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;position:relative;z-index:1000;">
-  <div style="display:flex;align-items:center;justify-content:center;gap:48px;padding:10px 32px;background:linear-gradient(90deg,#1f2937,#0f172a);color:#ffffff;font-size:13px;letter-spacing:0.3px;text-transform:uppercase;">
+  <div class="fh-header-top-bar" style="display:flex;align-items:center;justify-content:center;gap:48px;padding:10px 32px;background:linear-gradient(90deg,#1f2937,#0f172a);color:#ffffff;font-size:13px;letter-spacing:0.3px;text-transform:uppercase;">
     <a href="https://www.trustedshops.de/bewertung/info_XDCA531410FCCAB88C0D491294FA17294.html" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:8px;color:inherit;text-decoration:none;">
       <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
       4,88 Sterne auf Trusted Shops
@@ -17,11 +17,19 @@
       Große Auswahl
     </span>
   </div>
-  <div style="display:grid;grid-template-columns:auto 1fr auto auto auto;align-items:center;padding:26px 32px 22px;border-bottom:1px solid #e2e2e2;background-color:#ffffff;column-gap:20px;">
-    <a href="/" style="display:flex;align-items:center;">
+  <div class="fh-header-main" style="display:grid;grid-template-columns:auto 1fr auto auto auto;align-items:center;padding:26px 32px 22px;border-bottom:1px solid #e2e2e2;background-color:#ffffff;column-gap:20px;">
+    <button type="button" class="fh-mobile-menu-toggle" data-fh-mobile-menu-toggle aria-expanded="false" aria-controls="fh-mobile-menu" aria-label="Menü öffnen" style="display:none;align-items:center;justify-content:center;width:48px;height:48px;border:1px solid #d9d9d9;border-radius:16px;background-color:#ffffff;color:#1a1a1a;cursor:pointer;padding:0;">
+      <span class="fh-mobile-menu-toggle__icon" aria-hidden="true" style="display:flex;flex-direction:column;gap:6px;width:20px;">
+        <span style="display:block;height:2px;background-color:currentColor;border-radius:999px;"></span>
+        <span style="display:block;height:2px;background-color:currentColor;border-radius:999px;"></span>
+        <span style="display:block;height:2px;background-color:currentColor;border-radius:999px;"></span>
+      </span>
+      <span class="fh-mobile-menu-toggle__label" style="margin-left:10px;font-size:13px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;">Menü</span>
+    </button>
+    <a href="/" class="fh-header-logo" style="display:flex;align-items:center;">
       <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Logo_neu/FH_Icon_big_Profile_Image_transparent_385x200px.png" alt="FENSTER-HAMMER" style="height:64px;width:auto;">
     </a>
-    <form action="#" method="get" style="width:100%;display:flex;align-items:center;position:relative;">
+    <form action="#" method="get" class="fh-header-search" style="width:100%;display:flex;align-items:center;position:relative;">
       <input type="search" name="q" class="search-input" placeholder="Suchbegriff eingeben" aria-label="Suche" style="width:100%;padding:14px 52px 14px 24px;border:1px solid #d5d5d5;border-radius:18px;font-size:15px;line-height:1.4;color:#1f2937;background-color:#f8fafc;box-shadow:inset 0 1px 2px rgba(15,23,42,0.08);">
       <button type="button" data-search-clear aria-label="Eingabe löschen" style="position:absolute;right:18px;top:50%;transform:translateY(-50%);display:none;align-items:center;justify-content:center;width:24px;height:24px;padding:0;border:none;background:none;color:#94a3b8;cursor:pointer;transition:color .2s ease;">
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;">
@@ -30,8 +38,9 @@
         </svg>
       </button>
     </form>
-    <div class="fh-wishlist-menu-container" data-fh-wishlist-menu-container style="position:relative;justify-self:end;">
-      <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-wishlist-menu" aria-label="Merkliste" data-fh-wishlist-menu-toggle style="position:relative;display:flex;align-items:center;justify-content:center;width:46px;height:46px;border:1px solid #d9d9d9;border-radius:14px;background-color:#ffffff;color:#1a1a1a;cursor:pointer;padding:0;transition:all .2s ease;">
+    <div class="fh-header-actions" style="display:flex;align-items:center;gap:12px;justify-self:end;">
+      <div class="fh-wishlist-menu-container" data-fh-wishlist-menu-container style="position:relative;">
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-wishlist-menu" aria-label="Merkliste" data-fh-wishlist-menu-toggle style="position:relative;display:flex;align-items:center;justify-content:center;width:46px;height:46px;border:1px solid #d9d9d9;border-radius:14px;background-color:#ffffff;color:#1a1a1a;cursor:pointer;padding:0;transition:all .2s ease;">
         <span style="position:absolute;top:-6px;right:-6px;display:flex;align-items:center;justify-content:center;min-width:20px;height:20px;padding:0 6px;border-radius:999px;background-color:#31a5f0;color:#ffffff;font-size:11px;font-weight:700;letter-spacing:0.3px;line-height:1;" v-cloak v-text="$store.getters.wishListCount || 0"></span>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" style="width:22px;height:22px;display:block;transform:translateX(1px);">
           <path d="M6 3h9a2 2 0 0 1 2 2v16l-6.5-3.5L4 21V5a2 2 0 0 1 2-2z"></path>
@@ -47,9 +56,8 @@
         <div data-fh-wishlist-menu-empty style="display:none;font-size:14px;color:#6b7280;padding:12px 0;">Ihre Merkliste ist leer.</div>
         <ul data-fh-wishlist-menu-list style="list-style:none;margin:0;padding:0;max-height:340px;overflow:auto;"></ul>
       </div>
-    </div>
-    <div class="fh-account-menu-container" data-fh-account-menu-container style="position:relative;justify-self:end;">
-      <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-account-menu" aria-label="Ihr Konto" data-fh-account-menu-toggle style="display:flex;align-items:center;justify-content:center;width:46px;height:46px;border:1px solid #d9d9d9;border-radius:14px;background-color:#ffffff;color:#1a1a1a;cursor:pointer;padding:0;transition:all .2s ease;">
+      <div class="fh-account-menu-container" data-fh-account-menu-container style="position:relative;">
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-account-menu" aria-label="Ihr Konto" data-fh-account-menu-toggle style="display:flex;align-items:center;justify-content:center;width:46px;height:46px;border:1px solid #d9d9d9;border-radius:14px;background-color:#ffffff;color:#1a1a1a;cursor:pointer;padding:0;transition:all .2s ease;">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" style="width:22px;height:22px;">
           <path d="M12 12c2.8 0 5-2.2 5-5s-2.2-5-5-5-5 2.2-5 5 2.2 5 5 5z"></path>
           <path d="M4.2 21.4c.5-3.6 3.8-6.4 7.8-6.4s7.3 2.8 7.8 6.4"></path>
@@ -92,9 +100,8 @@
           <a href="#" v-logout data-fh-account-close style="display:block;text-align:center;padding:11px 16px;background-color:#e7f2fb;color:#1f2937;text-decoration:none;border-radius:10px;font-weight:600;font-size:14px;">Abmelden</a>
         </div>
       </div>
-    </div>
-    <div class="fh-basket-preview" style="position:relative;justify-self:end;display:flex;align-items:center;justify-content:center;">
-      <a v-toggle-basket-preview href="#" class="toggle-basket-preview" aria-label="Warenkorb" style="display:flex;align-items:center;gap:10px;padding:0 18px;min-width:132px;height:46px;border:1px solid #31a5f0;border-radius:14px;background-color:#31a5f0;color:#ffffff;text-decoration:none;position:relative;">
+      <div class="fh-basket-preview" style="position:relative;display:flex;align-items:center;justify-content:center;">
+        <a v-toggle-basket-preview href="#" class="toggle-basket-preview" aria-label="Warenkorb" style="display:flex;align-items:center;gap:10px;padding:0 18px;min-width:132px;height:46px;border:1px solid #31a5f0;border-radius:14px;background-color:#31a5f0;color:#ffffff;text-decoration:none;position:relative;">
         <span style="position:absolute;top:-8px;right:-8px;display:flex;align-items:center;justify-content:center;min-width:22px;height:22px;padding:0 6px;border-radius:999px;background-color:#000000;color:#ffffff;font-size:11px;font-weight:700;letter-spacing:0.3px;" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="width:24px;height:24px;">
           <circle cx="9" cy="20" r="1.5" fill="currentColor"></circle>
@@ -105,13 +112,14 @@
         <span style="display:inline-flex;align-items:center;font-size:16px;font-weight:700;white-space:nowrap;" aria-hidden="true" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
         <span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
         <span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
-      </a>
-      <basket-preview v-if="$store.state.lazyComponent.components['basket-preview']" :show-net-prices="$store.state.basket.showNetPrices" :visible-fields="['basketValueGross','shippingCostsGross','totalSumNet','totalSumGross']"></basket-preview>
+        </a>
+        <basket-preview v-if="$store.state.lazyComponent.components['basket-preview']" :show-net-prices="$store.state.basket.showNetPrices" :visible-fields="['basketValueGross','shippingCostsGross','totalSumNet','totalSumGross']"></basket-preview>
+      </div>
     </div>
   </div>
-  <nav style="background-color:#ffffff;">
+  <nav class="fh-header-nav" style="background-color:#ffffff;">
     <div style="max-width:1600px;width:100%;margin:0 auto;position:relative;">
-      <ul class="nav" style="display:flex;list-style:none;margin:0;padding:0 32px;justify-content:space-between;font-size:15px;font-weight:600;letter-spacing:0.4px;text-transform:uppercase;">
+      <ul class="nav" data-fh-desktop-nav style="display:flex;list-style:none;margin:0;padding:0 32px;justify-content:space-between;font-size:15px;font-weight:600;letter-spacing:0.4px;text-transform:uppercase;">
       <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
         <a class="nav-link" href="/schloesser" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">SCHLÖSSER</a>
         <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
@@ -388,4 +396,505 @@
       </ul>
     </div>
   </nav>
+  <div class="fh-mobile-menu" id="fh-mobile-menu" data-fh-mobile-menu aria-hidden="true">
+    <div class="fh-mobile-menu__overlay" data-fh-mobile-menu-overlay></div>
+    <div class="fh-mobile-menu__panel" role="dialog" aria-modal="true" aria-labelledby="fh-mobile-menu-title">
+      <header class="fh-mobile-menu__header">
+        <div class="fh-mobile-menu__title-group">
+          <div class="fh-mobile-menu__title" id="fh-mobile-menu-title">Menü</div>
+          <div class="fh-mobile-menu__subtitle">Entdecke unser Sortiment</div>
+        </div>
+        <button type="button" class="fh-mobile-menu__close" data-fh-mobile-menu-close aria-label="Menü schließen">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </header>
+      <div class="fh-mobile-menu__body">
+        <nav class="fh-mobile-menu__nav" aria-label="Hauptnavigation mobil">
+          <ul class="fh-mobile-menu__list">
+            <li class="fh-mobile-menu__item">
+              <button class="fh-mobile-menu__link" type="button" data-fh-mobile-submenu-toggle aria-expanded="false">
+                <span>Schlösser</span>
+                <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+              </button>
+              <div class="fh-mobile-menu__submenu" data-fh-mobile-submenu>
+                <ul class="fh-mobile-menu__submenu-list">
+                  <li><a href="/schloesser">Alle SCHLÖSSER sehen</a></li>
+                  <li><a href="#">Einsteckschlösser für Metalltore</a></li>
+                  <li><a href="#">elektrische Türöffner</a></li>
+                  <li><a href="#">FH-Schlösser</a></li>
+                  <li><a href="#">Garagentorschlösser</a></li>
+                  <li><a href="#">Haustürschlösser</a></li>
+                  <li><a href="#">Kastenschlösser</a></li>
+                  <li><a href="#">Korridortürschlösser</a></li>
+                  <li><a href="#">Rohrrahmenschlösser</a></li>
+                  <li><a href="#">Rosetten und Schilder</a></li>
+                  <li><a href="#">Schließbleche</a></li>
+                  <li><a href="#">WC-Tür-Schlösser</a></li>
+                  <li><a href="#">Wohnungstürschlösser</a></li>
+                  <li><a href="#">Zimmertürschlösser</a></li>
+                  <li><a href="#">Zubehör für Schloss und Tor</a></li>
+                </ul>
+              </div>
+            </li>
+            <li class="fh-mobile-menu__item">
+              <button class="fh-mobile-menu__link" type="button" data-fh-mobile-submenu-toggle aria-expanded="false">
+                <span>Beschläge</span>
+                <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+              </button>
+              <div class="fh-mobile-menu__submenu" data-fh-mobile-submenu>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Platzhalter Menu 2</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 2</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 3</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 4</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 5</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section-cta">
+                  <a href="#">Alle Beschläge sehen</a>
+                </div>
+              </div>
+            </li>
+            <li class="fh-mobile-menu__item">
+              <button class="fh-mobile-menu__link" type="button" data-fh-mobile-submenu-toggle aria-expanded="false">
+                <span>Sicherungen</span>
+                <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+              </button>
+              <div class="fh-mobile-menu__submenu" data-fh-mobile-submenu>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Platzhalter Menu 3</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 2</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 3</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 4</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 5</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section-cta">
+                  <a href="#">Alle Sicherungen sehen</a>
+                </div>
+              </div>
+            </li>
+            <li class="fh-mobile-menu__item">
+              <button class="fh-mobile-menu__link" type="button" data-fh-mobile-submenu-toggle aria-expanded="false">
+                <span>Sichtschutz</span>
+                <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+              </button>
+              <div class="fh-mobile-menu__submenu" data-fh-mobile-submenu>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Platzhalter Menu 4</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 2</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 3</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 4</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 5</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section-cta">
+                  <a href="#">Alle Sichtschutz sehen</a>
+                </div>
+              </div>
+            </li>
+            <li class="fh-mobile-menu__item">
+              <button class="fh-mobile-menu__link" type="button" data-fh-mobile-submenu-toggle aria-expanded="false">
+                <span>Fenstermontage</span>
+                <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+              </button>
+              <div class="fh-mobile-menu__submenu" data-fh-mobile-submenu>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Platzhalter Menu 5</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 2</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 3</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 4</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 5</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section-cta">
+                  <a href="#">Alle Fenstermontage sehen</a>
+                </div>
+              </div>
+            </li>
+            <li class="fh-mobile-menu__item">
+              <button class="fh-mobile-menu__link" type="button" data-fh-mobile-submenu-toggle aria-expanded="false">
+                <span>Chemische Befestigung</span>
+                <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+              </button>
+              <div class="fh-mobile-menu__submenu" data-fh-mobile-submenu>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Platzhalter Menu 6</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 2</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 3</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 4</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 5</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section-cta">
+                  <a href="#">Alle Chemische Befestigung sehen</a>
+                </div>
+              </div>
+            </li>
+            <li class="fh-mobile-menu__item">
+              <button class="fh-mobile-menu__link" type="button" data-fh-mobile-submenu-toggle aria-expanded="false">
+                <span>Aktionen</span>
+                <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+              </button>
+              <div class="fh-mobile-menu__submenu" data-fh-mobile-submenu>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Platzhalter Menu 7</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 2</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 3</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 4</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section">
+                  <button class="fh-mobile-menu__section-toggle" type="button" data-fh-mobile-section-toggle aria-expanded="false">
+                    <span>Kategorie 5</span>
+                    <span class="fh-mobile-menu__chevron" aria-hidden="true"></span>
+                  </button>
+                  <div class="fh-mobile-menu__section-panel" data-fh-mobile-section>
+                    <ul>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                      <li><a href="#">[Platzhalter]</a></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="fh-mobile-menu__section-cta">
+                  <a href="#">Alle Aktionen sehen</a>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
 </div>

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -2152,3 +2152,163 @@ document.addEventListener("DOMContentLoaded", function() {
 // End Section: Warenkorbvorschau "Warenkorb" zu "Weiter einkaufen" Funktion
 
 })();
+
+// Section: FH mobile navigation toggle behaviour
+document.addEventListener('DOMContentLoaded', function () {
+  var menuRoot = document.querySelector('[data-fh-mobile-menu]');
+  var toggleButtons = document.querySelectorAll('[data-fh-mobile-menu-toggle]');
+
+  if (!menuRoot || toggleButtons.length === 0) {
+    return;
+  }
+
+  var closeButton = menuRoot.querySelector('[data-fh-mobile-menu-close]');
+  var overlay = menuRoot.querySelector('[data-fh-mobile-menu-overlay]');
+  var submenuToggles = menuRoot.querySelectorAll('[data-fh-mobile-submenu-toggle]');
+  var sectionToggles = menuRoot.querySelectorAll('[data-fh-mobile-section-toggle]');
+  var activeClass = 'fh-mobile-menu--open';
+  var bodyActiveClass = 'fh-mobile-menu-open';
+  var isOpen = false;
+
+  function resetSections(container) {
+    if (!container) {
+      return;
+    }
+
+    var nestedSectionToggles = container.querySelectorAll('[data-fh-mobile-section-toggle]');
+    var nestedSections = container.querySelectorAll('.fh-mobile-menu__section');
+
+    nestedSectionToggles.forEach(function (toggle) {
+      toggle.setAttribute('aria-expanded', 'false');
+    });
+
+    nestedSections.forEach(function (section) {
+      section.classList.remove('is-open');
+    });
+  }
+
+  function openMenu() {
+    if (isOpen) {
+      return;
+    }
+
+    menuRoot.classList.add(activeClass);
+    menuRoot.setAttribute('aria-hidden', 'false');
+    document.body.classList.add(bodyActiveClass);
+    toggleButtons.forEach(function (button) {
+      button.setAttribute('aria-expanded', 'true');
+    });
+
+    if (closeButton) {
+      window.setTimeout(function () {
+        closeButton.focus();
+      }, 60);
+    }
+
+    document.addEventListener('keydown', handleKeydown, true);
+    isOpen = true;
+  }
+
+  function closeMenu() {
+    if (!isOpen) {
+      return;
+    }
+
+    menuRoot.classList.remove(activeClass);
+    menuRoot.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove(bodyActiveClass);
+    toggleButtons.forEach(function (button) {
+      button.setAttribute('aria-expanded', 'false');
+    });
+
+    submenuToggles.forEach(function (button) {
+      resetSections(button.nextElementSibling);
+      button.setAttribute('aria-expanded', 'false');
+    });
+
+    document.removeEventListener('keydown', handleKeydown, true);
+    isOpen = false;
+  }
+
+  function handleKeydown(event) {
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      closeMenu();
+
+      if (toggleButtons.length) {
+        toggleButtons[0].focus();
+      }
+    }
+  }
+
+  toggleButtons.forEach(function (button) {
+    button.addEventListener('click', function (event) {
+      event.preventDefault();
+
+      if (isOpen) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    });
+  });
+
+  if (overlay) {
+    overlay.addEventListener('click', closeMenu);
+  }
+
+  if (closeButton) {
+    closeButton.addEventListener('click', function (event) {
+      event.preventDefault();
+      closeMenu();
+    });
+  }
+
+  menuRoot.addEventListener('click', function (event) {
+    var link = event.target.closest('a');
+
+    if (link && menuRoot.contains(link)) {
+      closeMenu();
+    }
+  });
+
+  submenuToggles.forEach(function (button) {
+    button.addEventListener('click', function (event) {
+      event.preventDefault();
+
+      var isExpanded = button.getAttribute('aria-expanded') === 'true';
+
+      submenuToggles.forEach(function (otherButton) {
+        if (otherButton !== button) {
+          otherButton.setAttribute('aria-expanded', 'false');
+          resetSections(otherButton.nextElementSibling);
+        }
+      });
+
+      var nextState = !isExpanded;
+      button.setAttribute('aria-expanded', String(nextState));
+
+      if (!nextState) {
+        resetSections(button.nextElementSibling);
+      } else {
+        resetSections(button.nextElementSibling);
+      }
+    });
+  });
+
+  sectionToggles.forEach(function (button) {
+    button.addEventListener('click', function (event) {
+      event.preventDefault();
+
+      var section = button.closest('.fh-mobile-menu__section');
+
+      if (!section) {
+        return;
+      }
+
+      var isExpanded = button.getAttribute('aria-expanded') === 'true';
+      button.setAttribute('aria-expanded', String(!isExpanded));
+      section.classList.toggle('is-open', !isExpanded);
+    });
+  });
+});
+// End Section: FH mobile navigation toggle behaviour


### PR DESCRIPTION
## Summary
- add responsive burger button and mobile navigation markup for the FH header including grouped action icons
- extend the custom stylesheet with mobile layouts and slide-in menu styling while hiding the top bar on small screens
- implement JavaScript to toggle the mobile menu and nested category accordions up to three levels deep

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6fed4c0848331873c97295b60879b