### PR TITLE
Make FH header responsive with mobile navigation

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -19,9 +19,866 @@
 
 /* End Section: Custom Schriftarten + Preis Text Stylings */
 
-/* Section: FH Header Navigation Hover Behaviour */
-.fh-header .nav {
+/* Section: FH Header Layout and Navigation */
+.fh-header {
+  margin: 0 auto;
+  font-family: "Open Sans", Arial, sans-serif;
+  color: #1a1a1a;
   position: relative;
+  z-index: 1000;
+  background-color: #ffffff;
+}
+
+.fh-header-top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 48px;
+  padding: 10px 32px;
+  background: linear-gradient(90deg, #1f2937, #0f172a);
+  color: #ffffff;
+  font-size: 13px;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+}
+
+.fh-header-top-bar__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: inherit;
+}
+
+.fh-header-top-bar__link {
+  text-decoration: none;
+}
+
+.fh-header-top-bar__dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: #38bdf8;
+}
+
+.fh-header-main {
+  display: grid;
+  grid-template-columns: 0px auto 1fr auto;
+  grid-template-areas: "menu logo search actions";
+  align-items: center;
+  column-gap: 20px;
+  padding: 26px 32px 22px;
+  border-bottom: 1px solid #e2e2e2;
+  background-color: #ffffff;
+  max-width: 1600px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.fh-header-menu-toggle {
+  display: none;
+  align-items: center;
+  gap: 12px;
+  height: 46px;
+  padding: 0 16px;
+  border: 1px solid #d9d9d9;
+  border-radius: 14px;
+  background-color: #ffffff;
+  color: #1a1a1a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  grid-area: menu;
+}
+
+.fh-header-menu-toggle:hover,
+.fh-header-menu-toggle:focus {
+  border-color: #31a5f0;
+  color: #0f172a;
+  box-shadow: 0 4px 12px rgba(49, 165, 240, 0.2);
+  outline: none;
+}
+
+.fh-header-menu-toggle__icon {
+  position: relative;
+  display: block;
+  width: 18px;
+  height: 14px;
+}
+
+.fh-header-menu-toggle__icon::before,
+.fh-header-menu-toggle__icon::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  border-radius: 999px;
+  background-color: currentColor;
+  transition: transform 0.2s ease;
+}
+
+.fh-header-menu-toggle__icon::before {
+  top: 0;
+  box-shadow: 0 6px 0 currentColor;
+}
+
+.fh-header-menu-toggle__icon::after {
+  bottom: 0;
+}
+
+.fh-header-menu-toggle[aria-expanded="true"] .fh-header-menu-toggle__icon::before {
+  transform: translateY(6px) rotate(45deg);
+  box-shadow: none;
+}
+
+.fh-header-menu-toggle[aria-expanded="true"] .fh-header-menu-toggle__icon::after {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+.fh-header-menu-toggle__label {
+  text-transform: uppercase;
+  font-size: 14px;
+  letter-spacing: 0.4px;
+}
+
+.fh-header-logo {
+  display: flex;
+  align-items: center;
+  grid-area: logo;
+  justify-self: start;
+}
+
+.fh-header-logo img {
+  height: 64px;
+  width: auto;
+  display: block;
+}
+
+.fh-header-search {
+  position: relative;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  grid-area: search;
+}
+
+.fh-header-search__input {
+  width: 100%;
+  padding: 14px 52px 14px 24px;
+  border: 1px solid #d5d5d5;
+  border-radius: 18px;
+  font-size: 15px;
+  line-height: 1.4;
+  color: #1f2937;
+  background-color: #f8fafc;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.fh-header-search__input:focus {
+  outline: none;
+  border-color: #31a5f0;
+  box-shadow: 0 0 0 3px rgba(49, 165, 240, 0.25);
+  background-color: #ffffff;
+}
+
+.fh-header-search__clear {
+  position: absolute;
+  right: 18px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: #94a3b8;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.fh-header-search__clear:hover,
+.fh-header-search__clear:focus {
+  color: #1f2937;
+  outline: none;
+}
+
+.fh-header-search__clear svg {
+  width: 16px;
+  height: 16px;
+  display: block;
+}
+
+.fh-header-actions {
+  display: flex;
+  align-items: center;
+  justify-self: end;
+  gap: 16px;
+  grid-area: actions;
+}
+
+.fh-header-action {
+  position: relative;
+}
+
+.fh-header-icon-button {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  border: 1px solid #d9d9d9;
+  border-radius: 14px;
+  background-color: #ffffff;
+  color: #1a1a1a;
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fh-header-icon-button:hover,
+.fh-header-icon-button:focus {
+  border-color: #31a5f0;
+  color: #0f172a;
+  box-shadow: 0 4px 12px rgba(49, 165, 240, 0.2);
+  outline: none;
+}
+
+.fh-header-icon-button svg {
+  width: 22px;
+  height: 22px;
+  display: block;
+}
+
+.fh-header-icon-button__badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background-color: #31a5f0;
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  line-height: 1;
+}
+
+[data-fh-wishlist-menu],
+[data-fh-account-menu] {
+  position: absolute;
+  top: calc(100% + 16px);
+  right: 0;
+  display: none;
+  background-color: #ffffff;
+  border: 1px solid #e2e2e2;
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  z-index: 3000;
+  max-width: calc(100vw - 32px);
+}
+
+[data-fh-wishlist-menu] {
+  width: 420px;
+}
+
+[data-fh-account-menu] {
+  width: 260px;
+}
+
+.fh-header-popover__arrow {
+  position: absolute;
+  top: -10px;
+  right: 12px;
+  width: 20px;
+  height: 20px;
+  background-color: #ffffff;
+  border-top: 1px solid #e2e2e2;
+  border-left: 1px solid #e2e2e2;
+  transform: rotate(45deg);
+  pointer-events: none;
+}
+
+.fh-header-popover__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.fh-header-popover__title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.fh-header-popover__status {
+  display: none;
+  font-size: 14px;
+  color: #6b7280;
+  padding: 12px 0;
+}
+
+.fh-header-popover__status--error {
+  color: #dc2626;
+}
+
+.fh-header-popover__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 340px;
+  overflow: auto;
+}
+
+.fh-header-basket__link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 18px;
+  min-width: 132px;
+  height: 46px;
+  border: 1px solid #31a5f0;
+  border-radius: 14px;
+  background-color: #31a5f0;
+  color: #ffffff;
+  text-decoration: none;
+  position: relative;
+  font-weight: 600;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fh-header-basket__link:hover,
+.fh-header-basket__link:focus {
+  background-color: #1f88ce;
+  border-color: #1f88ce;
+  box-shadow: 0 6px 16px rgba(49, 165, 240, 0.25);
+  outline: none;
+}
+
+.fh-header-basket__badge {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background-color: #000000;
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+}
+
+.fh-header-basket__sum {
+  display: inline-flex;
+  align-items: center;
+  font-size: 16px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.fh-header-basket__sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.fh-header-desktop-nav-wrapper {
+  background-color: #ffffff;
+}
+
+.fh-header-desktop-nav-container {
+  max-width: 1600px;
+  width: 100%;
+  margin: 0 auto;
+  position: relative;
+}
+
+.fh-header-desktop-nav {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0 32px;
+  justify-content: space-between;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+}
+
+.fh-header-desktop-nav__item {
+  position: static;
+  flex: 1;
+  text-align: center;
+}
+
+.fh-header-desktop-nav__link {
+  display: block;
+  padding: 18px 12px;
+  color: #1a1a1a;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.fh-header-desktop-nav__link:hover,
+.fh-header-desktop-nav__link:focus {
+  color: #31a5f0;
+  outline: none;
+}
+
+.fh-header-desktop-nav__link--highlight {
+  color: #31a5f0;
+}
+
+.fh-header-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 1600px;
+  padding: 32px 48px;
+  border: 1px solid #e4e4e4;
+  border-top: none;
+  border-radius: 0 0 18px 18px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.08);
+  background-color: #ffffff;
+  z-index: 2000;
+  display: none;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(12px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.fh-header-desktop-nav__item:hover > .fh-header-dropdown,
+.fh-header-desktop-nav__item:focus-within > .fh-header-dropdown {
+  display: block;
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.fh-header-dropdown__grid {
+  display: grid;
+  gap: 32px;
+}
+
+.fh-header-dropdown__grid--cols-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.fh-header-dropdown__grid--cols-5 {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.fh-header-dropdown__column {
+  text-align: left;
+}
+
+.fh-header-dropdown__title {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0 0 12px;
+  text-transform: none;
+  color: #1a1a1a;
+}
+
+.fh-header-dropdown__link {
+  display: block;
+  color: #555555;
+  text-decoration: none;
+  padding: 6px 0;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.fh-header-dropdown__link:hover,
+.fh-header-dropdown__link:focus {
+  color: #31a5f0;
+  transform: translateX(4px);
+  outline: none;
+}
+
+.fh-header-dropdown__text {
+  margin: 0;
+  color: #4b5563;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.fh-header-dropdown__cta {
+  grid-column: 1 / -1;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #eaeaea;
+}
+
+.fh-header-dropdown__cta-link {
+  display: inline-block;
+  color: #1f2937;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.fh-header-dropdown__cta-link:hover,
+.fh-header-dropdown__cta-link:focus {
+  color: #31a5f0;
+  outline: none;
+}
+
+.fh-header-mobile-menu {
+  position: fixed;
+  inset: 0;
+  z-index: 4000;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.fh-header-mobile-menu--open {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.fh-header-mobile-menu__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.fh-header-mobile-menu--open .fh-header-mobile-menu__backdrop {
+  opacity: 1;
+}
+
+.fh-header-mobile-menu__panel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 85%;
+  max-width: 360px;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 8px 0 24px rgba(15, 23, 42, 0.2);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+}
+
+.fh-header-mobile-menu--open .fh-header-mobile-menu__panel {
+  transform: translateX(0);
+}
+
+.fh-header-mobile-menu__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.fh-header-mobile-menu__title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.fh-header-mobile-menu__close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 12px;
+  background: none;
+  color: #1f2937;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.fh-header-mobile-menu__close:hover,
+.fh-header-mobile-menu__close:focus {
+  background-color: #f1f5f9;
+  color: #0f172a;
+  outline: none;
+}
+
+.fh-header-mobile-menu__close-icon {
+  position: relative;
+  display: block;
+  width: 18px;
+  height: 18px;
+}
+
+.fh-header-mobile-menu__close-icon::before,
+.fh-header-mobile-menu__close-icon::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  border-radius: 999px;
+  background-color: currentColor;
+}
+
+.fh-header-mobile-menu__close-icon::before {
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.fh-header-mobile-menu__close-icon::after {
+  transform: translateY(-50%) rotate(-45deg);
+}
+
+.fh-header-mobile-menu__body {
+  flex: 1;
+  overflow: auto;
+  padding: 12px 0 24px;
+}
+
+.fh-header-mobile-menu__nav {
+  display: block;
+}
+
+.fh-header-mobile-menu__list,
+.fh-header-mobile-menu__sublist,
+.fh-header-mobile-menu__tertiary-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.fh-header-mobile-menu__item {
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.fh-header-mobile-menu__item:last-child {
+  border-bottom: none;
+}
+
+.fh-header-mobile-menu__item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 24px;
+}
+
+.fh-header-mobile-menu__label {
+  font-size: 16px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: #1f2937;
+}
+
+.fh-header-mobile-menu__link,
+.fh-header-mobile-menu__label {
+  font-size: 16px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: #1f2937;
+  text-decoration: none;
+  flex: 1;
+}
+
+.fh-header-mobile-menu__link--highlight {
+  color: #31a5f0;
+}
+
+.fh-header-mobile-menu__link--highlight:hover,
+.fh-header-mobile-menu__link--highlight:focus {
+  color: #0f172a;
+}
+
+.fh-header-mobile-menu__link:hover,
+.fh-header-mobile-menu__link:focus {
+  color: #31a5f0;
+  outline: none;
+}
+
+.fh-header-mobile-menu__accordion-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 50%;
+  background: #f1f5f9;
+  color: #1f2937;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.fh-header-mobile-menu__accordion-button:hover,
+.fh-header-mobile-menu__accordion-button:focus {
+  background: #e2e8f0;
+  outline: none;
+}
+
+.fh-header-mobile-menu__accordion-button[aria-expanded="true"] {
+  background: #31a5f0;
+  color: #ffffff;
+}
+
+.fh-header-mobile-menu__accordion-icon {
+  position: relative;
+  width: 12px;
+  height: 12px;
+  display: block;
+}
+
+.fh-header-mobile-menu__accordion-icon::before,
+.fh-header-mobile-menu__accordion-icon::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  border-radius: 999px;
+  background-color: currentColor;
+}
+
+.fh-header-mobile-menu__accordion-icon::before {
+  transform: translateY(-50%);
+}
+
+.fh-header-mobile-menu__accordion-icon::after {
+  transform: translateY(-50%) rotate(90deg);
+  transition: transform 0.2s ease;
+}
+
+.fh-header-mobile-menu__accordion-button[aria-expanded="true"]
+  .fh-header-mobile-menu__accordion-icon::after {
+  transform: translateY(-50%) rotate(0deg);
+}
+
+.fh-header-mobile-menu__panel {
+  display: none;
+  padding: 0 0 16px;
+}
+
+.fh-header-mobile-menu__panel--open {
+  display: block;
+}
+
+.fh-header-mobile-menu__sublist {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 24px 0 24px;
+}
+
+.fh-header-mobile-menu__subitem {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.fh-header-mobile-menu__subitem-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 24px;
+}
+
+.fh-header-mobile-menu__sublabel {
+  font-size: 15px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.fh-header-mobile-menu__sublink,
+.fh-header-mobile-menu__sublabel {
+  font-size: 15px;
+  font-weight: 600;
+  color: #1f2937;
+  text-decoration: none;
+  display: block;
+  padding: 0 24px;
+}
+
+.fh-header-mobile-menu__sublink:hover,
+.fh-header-mobile-menu__sublink:focus {
+  color: #31a5f0;
+  outline: none;
+}
+
+.fh-header-mobile-menu__tertiary-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-left: 18px;
+}
+
+.fh-header-mobile-menu__tertiary-link {
+  font-size: 14px;
+  color: #4b5563;
+  text-decoration: none;
+  display: block;
+}
+
+.fh-header-mobile-menu__tertiary-link:hover,
+.fh-header-mobile-menu__tertiary-link:focus {
+  color: #31a5f0;
+  outline: none;
+}
+
+.fh-header-mobile-menu__cta {
+  padding: 16px 24px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.fh-header-mobile-menu__cta-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: #31a5f0;
+  text-decoration: none;
+}
+
+.fh-header-mobile-menu__cta-link:hover,
+.fh-header-mobile-menu__cta-link:focus {
+  color: #1f2937;
+  outline: none;
+}
+
+body.fh-mobile-menu-open {
+  overflow: hidden;
 }
 
 /* Section: Page Header Background */
@@ -37,60 +894,106 @@
 /* End Section: Page Header Background */
 
 /* Section: FH search input native control overrides */
-.fh-header .search-input {
+.fh-header-search__input {
   -webkit-appearance: textfield;
   appearance: textfield;
 }
 
-.fh-header .search-input::-webkit-search-cancel-button,
-.fh-header .search-input::-webkit-search-decoration,
-.fh-header .search-input::-webkit-search-results-button,
-.fh-header .search-input::-webkit-search-results-decoration {
+.fh-header-search__input::-webkit-search-cancel-button,
+.fh-header-search__input::-webkit-search-decoration,
+.fh-header-search__input::-webkit-search-results-button,
+.fh-header-search__input::-webkit-search-results-decoration {
   -webkit-appearance: none;
   appearance: none;
   display: none;
 }
 
-.fh-header .search-input::-ms-clear,
-.fh-header .search-input::-ms-reveal {
+.fh-header-search__input::-ms-clear,
+.fh-header-search__input::-ms-reveal {
   display: none;
   width: 0;
   height: 0;
 }
 /* End Section: FH search input native control overrides */
 
-/* Section: FH Header Container Sizing */
-.fh-header {
-  width: 1600px;
-  max-width: 1600px;
-  margin-left: auto;
-  margin-right: auto;
-}
-/* End Section: FH Header Container Sizing */
+@media (max-width: 1199px) {
+  .fh-header-main {
+    column-gap: 16px;
+    padding: 22px 24px 20px;
+  }
 
-.fh-header .dropdown-menu {
-  display: none;
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-  transform: translateY(12px);
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  .fh-header-desktop-nav {
+    padding: 0 24px;
+  }
 }
 
-.fh-header .nav-item:hover > .dropdown-menu,
-.fh-header .nav-item:focus-within > .dropdown-menu {
-  display: block;
-  opacity: 1;
-  visibility: visible;
-  pointer-events: auto;
-  transform: translateY(0);
+@media (max-width: 991px) {
+  .fh-header-top-bar {
+    display: none;
+  }
+
+  .fh-header-main {
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas:
+      "menu logo actions"
+      "search search search";
+    row-gap: 16px;
+    padding: 18px 20px 16px;
+  }
+
+  .fh-header-menu-toggle {
+    display: inline-flex;
+    grid-area: menu;
+  }
+
+  .fh-header-logo {
+    grid-area: logo;
+    justify-self: center;
+  }
+
+  .fh-header-actions {
+    grid-area: actions;
+    justify-self: end;
+    gap: 12px;
+  }
+
+  .fh-header-search {
+    grid-area: search;
+  }
+
+  .fh-header-desktop-nav-wrapper {
+    display: none;
+  }
+
+  .fh-header-basket__link {
+    min-width: auto;
+    padding: 0 14px;
+  }
 }
 
-.fh-header .dropdown-menu {
-  width: 100%;
-  max-width: 1600px;
+@media (max-width: 575px) {
+  .fh-header-logo img {
+    height: 48px;
+  }
+
+  .fh-header-actions {
+    gap: 10px;
+  }
+
+  .fh-header-icon-button,
+  .fh-header-basket__link {
+    height: 44px;
+  }
+
+  .fh-header-basket__sum {
+    font-size: 15px;
+  }
+
+  .fh-header-mobile-menu__panel {
+    max-width: 320px;
+  }
 }
-/* End Section: FH Header Navigation Hover Behaviour */
+/* End Section: FH Header Layout and Navigation */
 
 /* Section: Trustbadge ausblenden */
 .basket-open .widget_container_overlay,

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -1,63 +1,68 @@
-<div class="fh-header" data-fh-header-root style="margin:0 auto;font-family:'Open Sans',Arial,sans-serif;color:#1a1a1a;position:relative;z-index:1000;">
-  <div style="display:flex;align-items:center;justify-content:center;gap:48px;padding:10px 32px;background:linear-gradient(90deg,#1f2937,#0f172a);color:#ffffff;font-size:13px;letter-spacing:0.3px;text-transform:uppercase;">
-    <a href="https://www.trustedshops.de/bewertung/info_XDCA531410FCCAB88C0D491294FA17294.html" target="_blank" rel="noopener" style="display:flex;align-items:center;gap:8px;color:inherit;text-decoration:none;">
-      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
+<div class="fh-header" data-fh-header-root>
+  <div class="fh-header-top-bar">
+    <a class="fh-header-top-bar__item fh-header-top-bar__link" href="https://www.trustedshops.de/bewertung/info_XDCA531410FCCAB88C0D491294FA17294.html" target="_blank" rel="noopener">
+      <span class="fh-header-top-bar__dot"></span>
       4,88 Sterne auf Trusted Shops
     </a>
-    <span style="display:flex;align-items:center;gap:8px;">
-      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
+    <span class="fh-header-top-bar__item">
+      <span class="fh-header-top-bar__dot"></span>
       Schneller Versand
     </span>
-    <span style="display:flex;align-items:center;gap:8px;">
-      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
+    <span class="fh-header-top-bar__item">
+      <span class="fh-header-top-bar__dot"></span>
       Hilfreicher Kundenservice &lt;24h
     </span>
-    <span style="display:flex;align-items:center;gap:8px;">
-      <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background-color:#38bdf8;"></span>
+    <span class="fh-header-top-bar__item">
+      <span class="fh-header-top-bar__dot"></span>
       Große Auswahl
     </span>
   </div>
-  <div style="display:grid;grid-template-columns:auto 1fr auto auto auto;align-items:center;padding:26px 32px 22px;border-bottom:1px solid #e2e2e2;background-color:#ffffff;column-gap:20px;">
-    <a href="/" style="display:flex;align-items:center;">
-      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Logo_neu/FH_Icon_big_Profile_Image_transparent_385x200px.png" alt="FENSTER-HAMMER" style="height:64px;width:auto;">
+  <div class="fh-header-main">
+    <button class="fh-header-menu-toggle" type="button" aria-controls="fh-mobile-menu" aria-expanded="false" aria-label="Menü öffnen" data-fh-mobile-menu-toggle>
+      <span class="fh-header-menu-toggle__icon" aria-hidden="true"></span>
+      <span class="fh-header-menu-toggle__label">Menü</span>
+    </button>
+    <a class="fh-header-logo" href="/">
+      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Logo_neu/FH_Icon_big_Profile_Image_transparent_385x200px.png" alt="FENSTER-HAMMER">
     </a>
-    <form action="#" method="get" style="width:100%;display:flex;align-items:center;position:relative;">
-      <input type="search" name="q" class="search-input" placeholder="Suchbegriff eingeben" aria-label="Suche" style="width:100%;padding:14px 52px 14px 24px;border:1px solid #d5d5d5;border-radius:18px;font-size:15px;line-height:1.4;color:#1f2937;background-color:#f8fafc;box-shadow:inset 0 1px 2px rgba(15,23,42,0.08);">
-      <button type="button" data-search-clear aria-label="Eingabe löschen" style="position:absolute;right:18px;top:50%;transform:translateY(-50%);display:none;align-items:center;justify-content:center;width:24px;height:24px;padding:0;border:none;background:none;color:#94a3b8;cursor:pointer;transition:color .2s ease;">
-        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;">
+    <form class="fh-header-search" action="#" method="get">
+      <input type="search" name="q" class="search-input fh-header-search__input" placeholder="Suchbegriff eingeben" aria-label="Suche">
+      <button type="button" class="fh-header-search__clear" data-search-clear aria-label="Eingabe löschen">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <line x1="5" y1="5" x2="15" y2="15"></line>
           <line x1="15" y1="5" x2="5" y2="15"></line>
         </svg>
       </button>
     </form>
-    <div class="fh-wishlist-menu-container" data-fh-wishlist-menu-container style="position:relative;justify-self:end;">
-      <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-wishlist-menu" aria-label="Merkliste" data-fh-wishlist-menu-toggle style="position:relative;display:flex;align-items:center;justify-content:center;width:46px;height:46px;border:1px solid #d9d9d9;border-radius:14px;background-color:#ffffff;color:#1a1a1a;cursor:pointer;padding:0;transition:all .2s ease;">
-        <span style="position:absolute;top:-6px;right:-6px;display:flex;align-items:center;justify-content:center;min-width:20px;height:20px;padding:0 6px;border-radius:999px;background-color:#31a5f0;color:#ffffff;font-size:11px;font-weight:700;letter-spacing:0.3px;line-height:1;" v-cloak v-text="$store.getters.wishListCount || 0"></span>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" style="width:22px;height:22px;display:block;transform:translateX(1px);">
-          <path d="M6 3h9a2 2 0 0 1 2 2v16l-6.5-3.5L4 21V5a2 2 0 0 1 2-2z"></path>
-        </svg>
-      </button>
-      <div id="fh-wishlist-menu" data-fh-wishlist-menu aria-hidden="true" style="position:absolute;top:calc(100% + 16px);right:0;display:none;background-color:#ffffff;border:1px solid #e2e2e2;border-radius:16px;padding:20px;width:420px;max-width:calc(100vw - 32px);box-shadow:0 18px 36px rgba(15,23,42,0.12);z-index:3000;">
-        <div style="position:absolute;top:-10px;right:12px;width:20px;height:20px;background-color:#ffffff;border-top:1px solid #e2e2e2;border-left:1px solid #e2e2e2;transform:rotate(45deg);pointer-events:none;"></div>
-        <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:12px;">
-          <div style="font-size:16px;font-weight:700;color:#1a1a1a;">Merkliste</div>
+    <div class="fh-header-actions">
+      <div class="fh-header-action fh-wishlist-menu-container" data-fh-wishlist-menu-container>
+        <button class="fh-header-icon-button" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-wishlist-menu" aria-label="Merkliste" data-fh-wishlist-menu-toggle>
+          <span class="fh-header-icon-button__badge" v-cloak v-text="$store.getters.wishListCount || 0"></span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M6 3h9a2 2 0 0 1 2 2v16l-6.5-3.5L4 21V5a2 2 0 0 1 2-2z"></path>
+          </svg>
+        </button>
+        <div id="fh-wishlist-menu" data-fh-wishlist-menu aria-hidden="true">
+          <div class="fh-header-popover__arrow"></div>
+          <div class="fh-header-popover__header">
+            <div class="fh-header-popover__title">Merkliste</div>
+          </div>
+          <div data-fh-wishlist-menu-loading class="fh-header-popover__status">Wird geladen …</div>
+          <div data-fh-wishlist-menu-error class="fh-header-popover__status fh-header-popover__status--error">Merkliste konnte nicht geladen werden. Bitte versuchen Sie es erneut.</div>
+          <div data-fh-wishlist-menu-empty class="fh-header-popover__status">Ihre Merkliste ist leer.</div>
+          <ul data-fh-wishlist-menu-list class="fh-header-popover__list"></ul>
         </div>
-        <div data-fh-wishlist-menu-loading style="display:none;font-size:14px;color:#6b7280;padding:12px 0;">Wird geladen …</div>
-        <div data-fh-wishlist-menu-error style="display:none;font-size:14px;color:#dc2626;padding:12px 0;">Merkliste konnte nicht geladen werden. Bitte versuchen Sie es erneut.</div>
-        <div data-fh-wishlist-menu-empty style="display:none;font-size:14px;color:#6b7280;padding:12px 0;">Ihre Merkliste ist leer.</div>
-        <ul data-fh-wishlist-menu-list style="list-style:none;margin:0;padding:0;max-height:340px;overflow:auto;"></ul>
       </div>
-    </div>
-    <div class="fh-account-menu-container" data-fh-account-menu-container style="position:relative;justify-self:end;">
-      <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-account-menu" aria-label="Ihr Konto" data-fh-account-menu-toggle style="display:flex;align-items:center;justify-content:center;width:46px;height:46px;border:1px solid #d9d9d9;border-radius:14px;background-color:#ffffff;color:#1a1a1a;cursor:pointer;padding:0;transition:all .2s ease;">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" style="width:22px;height:22px;">
-          <path d="M12 12c2.8 0 5-2.2 5-5s-2.2-5-5-5-5 2.2-5 5 2.2 5 5 5z"></path>
-          <path d="M4.2 21.4c.5-3.6 3.8-6.4 7.8-6.4s7.3 2.8 7.8 6.4"></path>
-        </svg>
-      </button>
-      <div id="fh-account-menu" data-fh-account-menu aria-hidden="true" style="position:absolute;top:calc(100% + 16px);right:0;display:none;background-color:#ffffff;border:1px solid #e2e2e2;border-radius:16px;padding:20px;width:260px;box-shadow:0 18px 36px rgba(15,23,42,0.12);z-index:3000;">
-        <div style="position:absolute;top:-10px;right:12px;width:20px;height:20px;background-color:#ffffff;border-top:1px solid #e2e2e2;border-left:1px solid #e2e2e2;transform:rotate(45deg);pointer-events:none;"></div>
-        <div v-if="!$store.getters.isLoggedIn">
+      <div class="fh-header-action fh-account-menu-container" data-fh-account-menu-container>
+        <button class="fh-header-icon-button" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-account-menu" aria-label="Ihr Konto" data-fh-account-menu-toggle>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 12c2.8 0 5-2.2 5-5s-2.2-5-5-5-5 2.2-5 5 2.2 5 5 5z"></path>
+            <path d="M4.2 21.4c.5-3.6 3.8-6.4 7.8-6.4s7.3 2.8 7.8 6.4"></path>
+          </svg>
+        </button>
+        <div id="fh-account-menu" data-fh-account-menu aria-hidden="true">
+          <div class="fh-header-popover__arrow"></div>
+          <div v-if="!$store.getters.isLoggedIn">
           <div style="font-size:16px;font-weight:700;margin-bottom:12px;color:#1a1a1a;">Ihr Konto</div>
           <a href="#login" data-toggle="modal" data-target="#login" data-fh-login-trigger style="display:block;text-align:center;padding:12px 16px;background-color:#1f2937;color:#ffffff;text-decoration:none;border-radius:10px;font-weight:600;font-size:15px;">Anmelden</a>
           <div style="display:flex;align-items:center;justify-content:center;gap:6px;margin:14px 0;font-size:13px;color:#6b7280;">
@@ -92,295 +97,295 @@
           <a href="#" v-logout data-fh-account-close style="display:block;text-align:center;padding:11px 16px;background-color:#e7f2fb;color:#1f2937;text-decoration:none;border-radius:10px;font-weight:600;font-size:14px;">Abmelden</a>
         </div>
       </div>
-    </div>
-    <div class="fh-basket-preview" style="position:relative;justify-self:end;display:flex;align-items:center;justify-content:center;">
-      <a v-toggle-basket-preview href="#" class="toggle-basket-preview" aria-label="Warenkorb" style="display:flex;align-items:center;gap:10px;padding:0 18px;min-width:132px;height:46px;border:1px solid #31a5f0;border-radius:14px;background-color:#31a5f0;color:#ffffff;text-decoration:none;position:relative;">
-        <span style="position:absolute;top:-8px;right:-8px;display:flex;align-items:center;justify-content:center;min-width:22px;height:22px;padding:0 6px;border-radius:999px;background-color:#000000;color:#ffffff;font-size:11px;font-weight:700;letter-spacing:0.3px;" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="width:24px;height:24px;">
-          <circle cx="9" cy="20" r="1.5" fill="currentColor"></circle>
-          <circle cx="18" cy="20" r="1.5" fill="currentColor"></circle>
-          <path d="M2.5 3h2l2.4 12.6a1.5 1.5 0 0 0 1.5 1.2H18a1.5 1.5 0 0 0 1.5-1.2L21 7H6"></path>
-        </svg>
-        <span style="display:inline-flex;align-items:center;font-size:16px;font-weight:700;white-space:nowrap;" aria-hidden="true" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
-        <span style="display:inline-flex;align-items:center;font-size:16px;font-weight:700;white-space:nowrap;" aria-hidden="true" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
-        <span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
-        <span style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
-      </a>
-      <basket-preview v-if="$store.state.lazyComponent.components['basket-preview']" :show-net-prices="$store.state.basket.showNetPrices" :visible-fields="['basketValueGross','shippingCostsGross','totalSumNet','totalSumGross']"></basket-preview>
+      <div class="fh-header-action fh-header-basket">
+        <a v-toggle-basket-preview href="#" class="toggle-basket-preview fh-header-basket__link" aria-label="Warenkorb">
+          <span class="fh-header-basket__badge" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.5" fill="currentColor"></circle>
+            <circle cx="18" cy="20" r="1.5" fill="currentColor"></circle>
+            <path d="M2.5 3h2l2.4 12.6a1.5 1.5 0 0 0 1.5 1.2H18a1.5 1.5 0 0 0 1.5-1.2L21 7H6"></path>
+          </svg>
+          <span class="fh-header-basket__sum" aria-hidden="true" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
+          <span class="fh-header-basket__sum" aria-hidden="true" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
+          <span class="fh-header-basket__sr" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
+          <span class="fh-header-basket__sr" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
+        </a>
+        <basket-preview v-if="$store.state.lazyComponent.components['basket-preview']" :show-net-prices="$store.state.basket.showNetPrices" :visible-fields="['basketValueGross','shippingCostsGross','totalSumNet','totalSumGross']"></basket-preview>
+      </div>
     </div>
   </div>
-  <nav style="background-color:#ffffff;">
-    <div style="max-width:1600px;width:100%;margin:0 auto;position:relative;">
-      <ul class="nav" style="display:flex;list-style:none;margin:0;padding:0 32px;justify-content:space-between;font-size:15px;font-weight:600;letter-spacing:0.4px;text-transform:uppercase;">
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="/schloesser" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">SCHLÖSSER</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:32px;">
-            <div>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Einsteckschlösser für Metalltore</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">elektrische Türöffner</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">FH-Schlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Garagentorschlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Haustürschlösser</a>
+  <nav class="fh-header-desktop-nav-wrapper">
+    <div class="fh-header-desktop-nav-container">
+      <ul class="nav fh-header-desktop-nav" data-fh-desktop-nav>
+      <li class="nav-item dropdown fh-header-desktop-nav__item">
+        <a class="nav-link fh-header-desktop-nav__link" href="/schloesser">SCHLÖSSER</a>
+        <div class="dropdown-menu fh-header-dropdown">
+          <div class="fh-header-dropdown__grid fh-header-dropdown__grid--cols-4">
+            <div class="fh-header-dropdown__column">
+              <a class="fh-header-dropdown__link" href="#">Einsteckschlösser für Metalltore</a>
+              <a class="fh-header-dropdown__link" href="#">elektrische Türöffner</a>
+              <a class="fh-header-dropdown__link" href="#">FH-Schlösser</a>
+              <a class="fh-header-dropdown__link" href="#">Garagentorschlösser</a>
+              <a class="fh-header-dropdown__link" href="#">Haustürschlösser</a>
             </div>
-            <div>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Kastenschlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Korridortürschlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Rohrrahmenschlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Rosetten und Schilder</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Schließbleche</a>
+            <div class="fh-header-dropdown__column">
+              <a class="fh-header-dropdown__link" href="#">Kastenschlösser</a>
+              <a class="fh-header-dropdown__link" href="#">Korridortürschlösser</a>
+              <a class="fh-header-dropdown__link" href="#">Rohrrahmenschlösser</a>
+              <a class="fh-header-dropdown__link" href="#">Rosetten und Schilder</a>
+              <a class="fh-header-dropdown__link" href="#">Schließbleche</a>
             </div>
-            <div>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">WC-Tür-Schlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Wohnungstürschlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Zimmertürschlösser</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">Zubehör für Schloss und Tor</a>
+            <div class="fh-header-dropdown__column">
+              <a class="fh-header-dropdown__link" href="#">WC-Tür-Schlösser</a>
+              <a class="fh-header-dropdown__link" href="#">Wohnungstürschlösser</a>
+              <a class="fh-header-dropdown__link" href="#">Zimmertürschlösser</a>
+              <a class="fh-header-dropdown__link" href="#">Zubehör für Schloss und Tor</a>
             </div>
-            <div>
-              <p style="margin:0;color:#4b5563;font-size:14px;line-height:1.6;">Ob Haus-, Wohnungs-, Zimmer- oder Garagentür – hier findest du das passende Schloss für jede Anwendung. Von Einsteck- bis Rohrrahmenschlössern und elektrischen Türöffnern bieten wir geprüfte Qualität und hohe Sicherheit. Ergänzt durch Profilzylinder, Schließbleche und Türdrücker erhältst du alles aus einer Hand für eine sichere Türlösung.</p>
+            <div class="fh-header-dropdown__column">
+              <p class="fh-header-dropdown__text">Ob Haus-, Wohnungs-, Zimmer- oder Garagentür – hier findest du das passende Schloss für jede Anwendung. Von Einsteck- bis Rohrrahmenschlössern und elektrischen Türöffnern bieten wir geprüfte Qualität und hohe Sicherheit. Ergänzt durch Profilzylinder, Schließbleche und Türdrücker erhältst du alles aus einer Hand für eine sichere Türlösung.</p>
             </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="/schloesser" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle SCHLÖSSER sehen</a>
-            </div>
-          </div>
-        </div>
-      </li>
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Beschläge</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Beschläge sehen</a>
+            <div class="fh-header-dropdown__cta">
+              <a class="fh-header-dropdown__cta-link" href="/schloesser">Alle SCHLÖSSER sehen</a>
             </div>
           </div>
         </div>
       </li>
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Sicherungen</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+      <li class="nav-item dropdown fh-header-desktop-nav__item">
+        <a class="nav-link fh-header-desktop-nav__link" href="#">Beschläge</a>
+        <div class="dropdown-menu fh-header-dropdown">
+          <div class="fh-header-dropdown__grid fh-header-dropdown__grid--cols-5">
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Platzhalter Menu 2</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 2</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 3</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 4</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 5</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Sicherungen sehen</a>
-            </div>
-          </div>
-        </div>
-      </li>
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Sichtschutz</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Sichtschutz sehen</a>
+            <div class="fh-header-dropdown__cta">
+              <a class="fh-header-dropdown__cta-link" href="#">Alle Beschläge sehen</a>
             </div>
           </div>
         </div>
       </li>
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Fenstermontage</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+      <li class="nav-item dropdown fh-header-desktop-nav__item">
+        <a class="nav-link fh-header-desktop-nav__link" href="#">Sicherungen</a>
+        <div class="dropdown-menu fh-header-dropdown">
+          <div class="fh-header-dropdown__grid fh-header-dropdown__grid--cols-5">
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Platzhalter Menu 3</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 2</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 3</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 4</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 5</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Fenstermontage sehen</a>
-            </div>
-          </div>
-        </div>
-      </li>
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#1a1a1a;text-decoration:none;">Chemische Befestigung</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 6</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-            </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Chemische Befestigung sehen</a>
+            <div class="fh-header-dropdown__cta">
+              <a class="fh-header-dropdown__cta-link" href="#">Alle Sicherungen sehen</a>
             </div>
           </div>
         </div>
       </li>
-      <li class="nav-item dropdown" style="position:static;flex:1;text-align:center;">
-        <a class="nav-link" href="#" style="display:block;padding:18px 12px;color:#31a5f0;text-decoration:none;">Aktionen</a>
-        <div class="dropdown-menu" style="position:absolute;top:100%;left:0;right:0;margin:0 auto;width:100%;padding:32px 48px;border:1px solid #e4e4e4;border-top:none;border-radius:0 0 18px 18px;box-shadow:0 24px 48px rgba(0,0,0,0.08);margin-top:0;background-color:#ffffff;z-index:2000;">
-          <div style="display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:32px;">
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Platzhalter Menu 7</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+      <li class="nav-item dropdown fh-header-desktop-nav__item">
+        <a class="nav-link fh-header-desktop-nav__link" href="#">Sichtschutz</a>
+        <div class="dropdown-menu fh-header-dropdown">
+          <div class="fh-header-dropdown__grid fh-header-dropdown__grid--cols-5">
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Platzhalter Menu 4</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 2</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 2</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 3</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 3</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 4</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 4</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div>
-              <h6 style="font-size:16px;font-weight:700;margin:0 0 12px;text-transform:none;color:#1a1a1a;">Kategorie 5</h6>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
-              <a href="#" style="display:block;color:#555;text-decoration:none;padding:6px 0;">[Platzhalter]</a>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 5</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
             </div>
-            <div style="grid-column:1 / -1;margin-top:16px;padding-top:16px;border-top:1px solid #eaeaea;">
-              <a href="#" style="display:inline-block;color:#1f2937;font-weight:600;text-decoration:none;">Alle Aktionen sehen</a>
+            <div class="fh-header-dropdown__cta">
+              <a class="fh-header-dropdown__cta-link" href="#">Alle Sichtschutz sehen</a>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li class="nav-item dropdown fh-header-desktop-nav__item">
+        <a class="nav-link fh-header-desktop-nav__link" href="#">Fenstermontage</a>
+        <div class="dropdown-menu fh-header-dropdown">
+          <div class="fh-header-dropdown__grid fh-header-dropdown__grid--cols-5">
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Platzhalter Menu 5</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 2</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 3</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 4</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 5</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__cta">
+              <a class="fh-header-dropdown__cta-link" href="#">Alle Fenstermontage sehen</a>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li class="nav-item dropdown fh-header-desktop-nav__item">
+        <a class="nav-link fh-header-desktop-nav__link" href="#">Chemische Befestigung</a>
+        <div class="dropdown-menu fh-header-dropdown">
+          <div class="fh-header-dropdown__grid fh-header-dropdown__grid--cols-5">
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Platzhalter Menu 6</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 2</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 3</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 4</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 5</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__cta">
+              <a class="fh-header-dropdown__cta-link" href="#">Alle Chemische Befestigung sehen</a>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li class="nav-item dropdown fh-header-desktop-nav__item">
+        <a class="nav-link fh-header-desktop-nav__link fh-header-desktop-nav__link--highlight" href="#">Aktionen</a>
+        <div class="dropdown-menu fh-header-dropdown">
+          <div class="fh-header-dropdown__grid fh-header-dropdown__grid--cols-5">
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Platzhalter Menu 7</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 2</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 3</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 4</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__column">
+              <h6 class="fh-header-dropdown__title">Kategorie 5</h6>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+              <a class="fh-header-dropdown__link" href="#">[Platzhalter]</a>
+            </div>
+            <div class="fh-header-dropdown__cta">
+              <a class="fh-header-dropdown__cta-link" href="#">Alle Aktionen sehen</a>
             </div>
           </div>
         </div>
@@ -388,4 +393,20 @@
       </ul>
     </div>
   </nav>
+  <div class="fh-header-mobile-menu" id="fh-mobile-menu" data-fh-mobile-menu aria-hidden="true">
+    <div class="fh-header-mobile-menu__backdrop" data-fh-mobile-menu-backdrop></div>
+    <div class="fh-header-mobile-menu__panel" role="dialog" aria-modal="true" aria-label="Menü">
+      <div class="fh-header-mobile-menu__header">
+        <span class="fh-header-mobile-menu__title">Menü</span>
+        <button class="fh-header-mobile-menu__close" type="button" aria-label="Menü schließen" data-fh-mobile-menu-close>
+          <span class="fh-header-mobile-menu__close-icon" aria-hidden="true"></span>
+        </button>
+      </div>
+      <div class="fh-header-mobile-menu__body">
+        <nav class="fh-header-mobile-menu__nav" aria-label="Hauptnavigation mobil">
+          <ul class="fh-header-mobile-menu__list" data-fh-mobile-menu-list></ul>
+        </nav>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- rebuild the FH header structure with semantic wrappers and a reusable actions block
- add responsive styling for desktop and mobile, including the new drawer navigation and search overrides
- implement JavaScript to mirror the desktop navigation into a mobile accordion drawer with proper focus and state handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d70627d0148331879ae8e9e100831e