### PR TITLE
feat: make FH header responsive with mobile navigation

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -30,6 +30,17 @@
   max-width: 1600px; /* Do not change this for Desktop viewport*/
 }
 
+@media (max-width: 1600px) {
+  .fh-header {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .fh-header__nav-inner {
+    max-width: 100%;
+  }
+}
+
 .fh-header__top-bar {
   display: flex;
   align-items: center;
@@ -63,9 +74,11 @@
   background-color: #38bdf8;
 }
 
+
 .fh-header__main {
   display: grid;
-  grid-template-columns: auto 1fr auto auto auto;
+  grid-template-columns: auto 1fr auto;
+  grid-template-areas: 'logo search actions';
   align-items: center;
   padding: 26px 32px 22px;
   border-bottom: 1px solid #e2e2e2;
@@ -74,6 +87,7 @@
 }
 
 .fh-header__logo {
+  grid-area: logo;
   display: flex;
   align-items: center;
 }
@@ -83,7 +97,40 @@
   height: 64px;
 }
 
+.fh-header__menu-toggle {
+  grid-area: toggle;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  padding: 0;
+  border: 1px solid #d9d9d9;
+  border-radius: 14px;
+  background-color: #ffffff;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fh-header__menu-toggle:focus,
+.fh-header__menu-toggle:hover {
+  background-color: #f8fafc;
+  border-color: #cbd5f5;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);
+}
+
+.fh-header__menu-toggle-bar {
+  display: block;
+  width: 22px;
+  height: 2px;
+  margin: 3px 0;
+  border-radius: 999px;
+  background-color: #1a1a1a;
+  transition: background-color 0.2s ease;
+}
+
 .fh-header__search-form {
+  grid-area: search;
   position: relative;
   display: flex;
   align-items: center;
@@ -118,6 +165,14 @@
   color: #94a3b8;
   cursor: pointer;
   transition: color 0.2s ease;
+}
+
+.fh-header__actions {
+  grid-area: actions;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 20px;
 }
 
 .fh-header__search-clear-icon {
@@ -445,6 +500,14 @@
   background-color: #ffffff;
 }
 
+.fh-header__mobile-controls {
+  display: none;
+}
+
+.fh-header__mobile-overlay {
+  display: none;
+}
+
 .fh-header__nav-inner {
   position: relative;
   max-width: 1600px;
@@ -573,6 +636,235 @@
   visibility: visible;
   pointer-events: auto;
   transform: translateY(0);
+}
+
+html.fh-header--menu-open,
+body.fh-header--menu-open {
+  overflow: hidden;
+}
+
+@media (max-width: 1199.98px) {
+  .fh-header__main {
+    padding: 22px 24px 18px;
+  }
+
+  .fh-header__actions {
+    gap: 16px;
+  }
+}
+
+@media (max-width: 1023px) {
+  .fh-header__top-bar {
+    display: none;
+  }
+
+  .fh-header__main {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      'logo actions'
+      'toggle search';
+    padding: 18px 16px 16px;
+    row-gap: 16px;
+    column-gap: 16px;
+  }
+
+  .fh-header__logo img {
+    height: 56px;
+  }
+
+  .fh-header__actions {
+    justify-content: flex-end;
+    gap: 12px;
+  }
+
+  .fh-header__menu-toggle {
+    display: flex;
+    align-self: start;
+  }
+
+  .fh-header__search-input {
+    padding: 14px 48px 14px 16px;
+    border-radius: 14px;
+  }
+
+  .fh-header__search-clear {
+    right: 16px;
+  }
+
+  .fh-header__icon-button {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+  }
+
+  .fh-header__basket-total {
+    display: none;
+  }
+
+  .fh-header__nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 100vw;
+    max-width: none;
+    height: 100%;
+    transform: translateX(-100%);
+    transition: transform 0.35s ease;
+    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.32);
+    padding: 0;
+    border: none;
+    z-index: 5000;
+  }
+
+  .fh-header__nav--open {
+    transform: translateX(0);
+  }
+
+  .fh-header__mobile-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px 24px 16px;
+    border-bottom: 1px solid #e5e7eb;
+    background-color: #ffffff;
+  }
+
+  .fh-header__mobile-title {
+    font-size: 18px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #0f172a;
+  }
+
+  .fh-header__mobile-close {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: 1px solid #d9d9d9;
+    background-color: #ffffff;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+  }
+
+  .fh-header__mobile-close:focus,
+  .fh-header__mobile-close:hover {
+    background-color: #f8fafc;
+    border-color: #cbd5f5;
+  }
+
+  .fh-header__mobile-close-bar {
+    position: absolute;
+    width: 18px;
+    height: 2px;
+    border-radius: 999px;
+    background-color: #1a1a1a;
+  }
+
+  .fh-header__mobile-close-bar:first-child {
+    transform: rotate(45deg);
+  }
+
+  .fh-header__mobile-close-bar:last-child {
+    transform: rotate(-45deg);
+  }
+
+  .fh-header__nav-inner {
+    height: calc(100% - 72px);
+    overflow-y: auto;
+    padding: 24px 24px 40px;
+    width: min(420px, 100%);
+    margin: 0 auto;
+  }
+
+  .fh-header__nav-list {
+    flex-direction: column;
+    gap: 0;
+    padding: 0;
+    font-size: 16px;
+  }
+
+  .fh-header__nav-item {
+    flex: none;
+    text-align: left;
+  }
+
+  .fh-header__nav-link {
+    padding: 16px 0;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  .fh-header__nav-item:last-child .fh-header__nav-link {
+    border-bottom: none;
+  }
+
+  .fh-header__dropdown {
+    position: static;
+    width: 100%;
+    margin: 0;
+    padding: 12px 0 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    display: none;
+  }
+
+  .fh-header__nav-item.show > .fh-header__dropdown {
+    display: block;
+  }
+
+  .fh-header__dropdown-grid {
+    gap: 18px;
+  }
+
+  .fh-header__dropdown-grid--four,
+  .fh-header__dropdown-grid--five {
+    grid-template-columns: 1fr;
+  }
+
+  .fh-header__dropdown-footer {
+    margin-top: 16px;
+  }
+
+  .fh-header__mobile-overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.35s ease;
+    z-index: 4000;
+  }
+
+  .fh-header__mobile-overlay.is-visible {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+
+@media (min-width: 1024px) {
+  .fh-header__nav {
+    position: static;
+    transform: none !important;
+    box-shadow: none;
+    height: auto;
+  }
+
+  .fh-header__nav-inner {
+    height: auto;
+    overflow: visible;
+    padding: 0;
+  }
+
+  .fh-header__mobile-overlay {
+    display: none !important;
+  }
 }
 /* End Section: FH Header Base Layout */
 

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -21,8 +21,13 @@
     <a href="/" class="fh-header__logo">
       <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Logo_neu/FH_Icon_big_Profile_Image_transparent_385x200px.png" alt="FENSTER-HAMMER">
     </a>
+    <button type="button" class="fh-header__menu-toggle" data-fh-mobile-menu-toggle aria-controls="fh-header-mobile-menu" aria-expanded="false" aria-label="Menü öffnen">
+      <span class="fh-header__menu-toggle-bar"></span>
+      <span class="fh-header__menu-toggle-bar"></span>
+      <span class="fh-header__menu-toggle-bar"></span>
+    </button>
     <form action="#" method="get" class="fh-header__search-form">
-      <input type="search" name="q" class="search-input fh-header__search-input" placeholder="Suchbegriff eingeben" aria-label="Suche">
+      <input type="search" name="q" class="search-input fh-header__search-input" placeholder="Häufig gesucht: &quot;Edelstahl Bits&quot;" aria-label="Suche">
       <button type="button" data-search-clear aria-label="Eingabe löschen" class="fh-header__search-clear">
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__search-clear-icon">
           <line x1="5" y1="5" x2="15" y2="15"></line>
@@ -30,86 +35,95 @@
         </svg>
       </button>
     </form>
-    <div class="fh-wishlist-menu-container position-relative" data-fh-wishlist-menu-container>
-      <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-wishlist-menu" aria-label="Merkliste" data-fh-wishlist-menu-toggle class="fh-header__icon-button">
-        <span class="fh-header__badge" v-cloak v-text="$store.getters.wishListCount || 0"></span>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="fh-header__icon fh-header__icon--wishlist">
-          <path d="M6 3h9a2 2 0 0 1 2 2v16l-6.5-3.5L4 21V5a2 2 0 0 1 2-2z"></path>
-        </svg>
-      </button>
-      <div id="fh-wishlist-menu" data-fh-wishlist-menu aria-hidden="true" class="fh-header__panel">
-        <div class="fh-header__panel-arrow"></div>
-        <div class="fh-header__panel-header">
-          <div class="fh-header__panel-title">Merkliste</div>
+    <div class="fh-header__actions">
+      <div class="fh-wishlist-menu-container position-relative" data-fh-wishlist-menu-container>
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-wishlist-menu" aria-label="Merkliste" data-fh-wishlist-menu-toggle class="fh-header__icon-button">
+          <span class="fh-header__badge" v-cloak v-text="$store.getters.wishListCount || 0"></span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="fh-header__icon fh-header__icon--wishlist">
+            <path d="M6 3h9a2 2 0 0 1 2 2v16l-6.5-3.5L4 21V5a2 2 0 0 1 2-2z"></path>
+          </svg>
+        </button>
+        <div id="fh-wishlist-menu" data-fh-wishlist-menu aria-hidden="true" class="fh-header__panel">
+          <div class="fh-header__panel-arrow"></div>
+          <div class="fh-header__panel-header">
+            <div class="fh-header__panel-title">Merkliste</div>
+          </div>
+          <div data-fh-wishlist-menu-loading class="fh-header__panel-text py-3">Wird geladen …</div>
+          <div data-fh-wishlist-menu-error class="fh-header__panel-text text-danger py-3">Merkliste konnte nicht geladen werden. Bitte versuchen Sie es erneut.</div>
+          <div data-fh-wishlist-menu-empty class="fh-header__panel-text py-3">Ihre Merkliste ist leer.</div>
+          <ul data-fh-wishlist-menu-list class="list-unstyled mb-0 fh-header__wishlist-list"></ul>
         </div>
-        <div data-fh-wishlist-menu-loading class="fh-header__panel-text py-3">Wird geladen …</div>
-        <div data-fh-wishlist-menu-error class="fh-header__panel-text text-danger py-3">Merkliste konnte nicht geladen werden. Bitte versuchen Sie es erneut.</div>
-        <div data-fh-wishlist-menu-empty class="fh-header__panel-text py-3">Ihre Merkliste ist leer.</div>
-        <ul data-fh-wishlist-menu-list class="list-unstyled mb-0 fh-header__wishlist-list"></ul>
       </div>
-    </div>
-    <div class="fh-account-menu-container position-relative" data-fh-account-menu-container>
-      <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-account-menu" aria-label="Ihr Konto" data-fh-account-menu-toggle class="fh-header__icon-button">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="fh-header__icon">
-          <path d="M12 12c2.8 0 5-2.2 5-5s-2.2-5-5-5-5 2.2-5 5 2.2 5 5 5z"></path>
-          <path d="M4.2 21.4c.5-3.6 3.8-6.4 7.8-6.4s7.3 2.8 7.8 6.4"></path>
-        </svg>
-      </button>
-      <div id="fh-account-menu" data-fh-account-menu aria-hidden="true" class="fh-header__panel fh-header__panel--account">
-        <div class="fh-header__panel-arrow"></div>
-        <div v-if="!$store.getters.isLoggedIn">
-          <div class="fh-header__panel-title mb-3">Ihr Konto</div>
-          <a href="#login" data-toggle="modal" data-target="#login" data-fh-login-trigger class="fh-header__account-login">Anmelden</a>
-          <div class="fh-header__panel-inline my-3 fh-header__panel-text">
-            <span>oder</span>
-            <a href="#registration" data-toggle="modal" data-target="#registration" data-fh-registration-trigger class="fh-header__account-register">Registrieren</a>
-          </div>
-          <div class="fh-header__panel-divider my-3"></div>
-          <div class="fh-header__panel-stack mb-3 text-body">
-            <div class="fh-header__panel-subtitle">Vorteile:</div>
-            <ul class="fh-header__panel-list">
-              <li>Schneller kaufen</li>
-              <li>Hammer Punkte sammeln</li>
-              <li>Einfacherer Support</li>
-            </ul>
-          </div>
-        </div>
-        <div v-else>
-          <div class="fh-header__panel-stack mb-3 text-body">
-            <div class="fh-header__panel-title">
-              <span v-if="$store.state.user && $store.state.user.userData && $store.state.user.userData.lastName && (({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title)" v-cloak><span class="fh-account-greeting" data-default-greeting="Hallo,">Hallo,</span> <span v-text="((({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title) + ' ' + $store.state.user.userData.lastName)" v-cloak></span></span>
-              <span v-else v-cloak>Hallo</span>
+      <div class="fh-account-menu-container position-relative" data-fh-account-menu-container>
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-account-menu" aria-label="Ihr Konto" data-fh-account-menu-toggle class="fh-header__icon-button">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="fh-header__icon">
+            <path d="M12 12c2.8 0 5-2.2 5-5s-2.2-5-5-5-5 2.2-5 5 2.2 5 5 5z"></path>
+            <path d="M4.2 21.4c.5-3.6 3.8-6.4 7.8-6.4s7.3 2.8 7.8 6.4"></path>
+          </svg>
+        </button>
+        <div id="fh-account-menu" data-fh-account-menu aria-hidden="true" class="fh-header__panel fh-header__panel--account">
+          <div class="fh-header__panel-arrow"></div>
+          <div v-if="!$store.getters.isLoggedIn">
+            <div class="fh-header__panel-title mb-3">Ihr Konto</div>
+            <a href="#login" data-toggle="modal" data-target="#login" data-fh-login-trigger class="fh-header__account-login">Anmelden</a>
+            <div class="fh-header__panel-inline my-3 fh-header__panel-text">
+              <span>oder</span>
+              <a href="#registration" data-toggle="modal" data-target="#registration" data-fh-registration-trigger class="fh-header__account-register">Registrieren</a>
             </div>
-            <div class="fh-header__panel-text">Schön, dass Sie wieder da sind!</div>
+            <div class="fh-header__panel-divider my-3"></div>
+            <div class="fh-header__panel-stack mb-3 text-body">
+              <div class="fh-header__panel-subtitle">Vorteile:</div>
+              <ul class="fh-header__panel-list">
+                <li>Schneller kaufen</li>
+                <li>Hammer Punkte sammeln</li>
+                <li>Einfacherer Support</li>
+              </ul>
+            </div>
           </div>
-          <div class="fh-header__panel-divider mb-3"></div>
-          <nav class="fh-header__panel-links mb-4">
-            <a href="/my-account" class="fh-header__panel-link">Kontoübersicht</a>
-            <a href="/hammer-praemien" class="fh-header__panel-link">Hammer Prämien</a>
-            <a href="/my-account/addresses" class="fh-header__panel-link">Adressen</a>
-            <a href="/my-account/orders" class="fh-header__panel-link">Bestellungen</a>
-          </nav>
-          <a href="#" v-logout data-fh-account-close class="fh-header__logout">Abmelden</a>
+          <div v-else>
+            <div class="fh-header__panel-stack mb-3 text-body">
+              <div class="fh-header__panel-title">
+                <span v-if="$store.state.user && $store.state.user.userData && $store.state.user.userData.lastName && (({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title)" v-cloak><span class="fh-account-greeting" data-default-greeting="Hallo,">Hallo,</span> <span v-text="((({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title) + ' ' + $store.state.user.userData.lastName)" v-cloak></span></span>
+                <span v-else v-cloak>Hallo</span>
+              </div>
+              <div class="fh-header__panel-text">Schön, dass Sie wieder da sind!</div>
+            </div>
+            <div class="fh-header__panel-divider mb-3"></div>
+            <nav class="fh-header__panel-links mb-4">
+              <a href="/my-account" class="fh-header__panel-link">Kontoübersicht</a>
+              <a href="/hammer-praemien" class="fh-header__panel-link">Hammer Prämien</a>
+              <a href="/my-account/addresses" class="fh-header__panel-link">Adressen</a>
+              <a href="/my-account/orders" class="fh-header__panel-link">Bestellungen</a>
+            </nav>
+            <a href="#" v-logout data-fh-account-close class="fh-header__logout">Abmelden</a>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="fh-basket-preview fh-header__basket">
-      <a v-toggle-basket-preview href="#" class="toggle-basket-preview fh-header__basket-link" aria-label="Warenkorb">
-        <span class="fh-header__basket-count" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="fh-header__basket-icon">
-          <circle cx="9" cy="20" r="1.5" fill="currentColor"></circle>
-          <circle cx="18" cy="20" r="1.5" fill="currentColor"></circle>
-          <path d="M2.5 3h2l2.4 12.6a1.5 1.5 0 0 0 1.5 1.2H18a1.5 1.5 0 0 0 1.5-1.2L21 7H6"></path>
-        </svg>
-        <span class="fh-header__basket-total" aria-hidden="true" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
-        <span class="fh-header__basket-total" aria-hidden="true" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
-        <span class="fh-header__sr-only" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
-        <span class="fh-header__sr-only" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
-      </a>
-      <basket-preview v-if="$store.state.lazyComponent.components['basket-preview']" :show-net-prices="$store.state.basket.showNetPrices" :visible-fields="['basketValueGross','shippingCostsGross','totalSumNet','totalSumGross']"></basket-preview>
+      <div class="fh-basket-preview fh-header__basket">
+        <a v-toggle-basket-preview href="#" class="toggle-basket-preview fh-header__basket-link" aria-label="Warenkorb">
+          <span class="fh-header__basket-count" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="fh-header__basket-icon">
+            <circle cx="9" cy="20" r="1.5" fill="currentColor"></circle>
+            <circle cx="18" cy="20" r="1.5" fill="currentColor"></circle>
+            <path d="M2.5 3h2l2.4 12.6a1.5 1.5 0 0 0 1.5 1.2H18a1.5 1.5 0 0 0 1.5-1.2L21 7H6"></path>
+          </svg>
+          <span class="fh-header__basket-total" aria-hidden="true" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
+          <span class="fh-header__basket-total" aria-hidden="true" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
+          <span class="fh-header__sr-only" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
+          <span class="fh-header__sr-only" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
+        </a>
+        <basket-preview v-if="$store.state.lazyComponent.components['basket-preview']" :show-net-prices="$store.state.basket.showNetPrices" :visible-fields="['basketValueGross','shippingCostsGross','totalSumNet','totalSumGross']"></basket-preview>
+      </div>
     </div>
   </div>
-  <nav class="fh-header__nav">
+  <nav class="fh-header__nav" id="fh-header-mobile-menu" data-fh-mobile-menu aria-hidden="false">
+    <div class="fh-header__mobile-controls">
+      <div class="fh-header__mobile-title">Menü</div>
+      <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
+        <span class="fh-header__mobile-close-bar"></span>
+        <span class="fh-header__mobile-close-bar"></span>
+      </button>
+    </div>
     <div class="fh-header__nav-inner">
       <ul class="nav fh-header__nav-list">
       <li class="nav-item dropdown fh-header__nav-item">
@@ -388,4 +402,5 @@
       </ul>
     </div>
   </nav>
+  <div class="fh-header__mobile-overlay" data-fh-mobile-menu-overlay hidden></div>
 </div>

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -1,5 +1,189 @@
 // Section: Global scripts for all pages
 
+// Section: FH mobile navigation toggle
+document.addEventListener('DOMContentLoaded', function () {
+  const headerRoot = document.querySelector('[data-fh-header-root]');
+
+  if (!headerRoot) {
+    return;
+  }
+
+  const menu = headerRoot.querySelector('[data-fh-mobile-menu]');
+  const overlay = headerRoot.querySelector('[data-fh-mobile-menu-overlay]');
+  const toggleButtons = headerRoot.querySelectorAll('[data-fh-mobile-menu-toggle]');
+  const closeButtons = headerRoot.querySelectorAll('[data-fh-mobile-menu-close]');
+  const htmlElement = document.documentElement;
+  const bodyElement = document.body;
+  const mediaQuery = window.matchMedia('(min-width: 1024px)');
+
+  if (!menu || toggleButtons.length === 0) {
+    return;
+  }
+
+  let isOpen = false;
+
+  function updateAriaHidden() {
+    if (mediaQuery.matches) {
+      menu.setAttribute('aria-hidden', 'false');
+      return;
+    }
+
+    menu.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+  }
+
+  function showOverlay() {
+    if (!overlay) {
+      return;
+    }
+
+    overlay.removeAttribute('hidden');
+
+    requestAnimationFrame(function () {
+      overlay.classList.add('is-visible');
+    });
+  }
+
+  function hideOverlay() {
+    if (!overlay) {
+      return;
+    }
+
+    overlay.classList.remove('is-visible');
+
+    const handleTransitionEnd = function () {
+      overlay.setAttribute('hidden', '');
+    };
+
+    overlay.addEventListener('transitionend', handleTransitionEnd, { once: true });
+
+    window.setTimeout(function () {
+      if (!overlay.classList.contains('is-visible')) {
+        overlay.setAttribute('hidden', '');
+      }
+    }, 400);
+  }
+
+  function lockScroll() {
+    htmlElement.classList.add('fh-header--menu-open');
+    bodyElement.classList.add('fh-header--menu-open');
+  }
+
+  function releaseScroll() {
+    htmlElement.classList.remove('fh-header--menu-open');
+    bodyElement.classList.remove('fh-header--menu-open');
+  }
+
+  function handleKeydown(event) {
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      closeMenu(true);
+    }
+  }
+
+  function openMenu() {
+    if (isOpen || mediaQuery.matches) {
+      return;
+    }
+
+    menu.classList.add('fh-header__nav--open');
+    toggleButtons.forEach(function (button) {
+      button.setAttribute('aria-expanded', 'true');
+    });
+    showOverlay();
+    lockScroll();
+    isOpen = true;
+    updateAriaHidden();
+    document.addEventListener('keydown', handleKeydown);
+  }
+
+  function closeMenu(shouldFocusToggle) {
+    menu.classList.remove('fh-header__nav--open');
+    toggleButtons.forEach(function (button) {
+      button.setAttribute('aria-expanded', 'false');
+    });
+
+    if (!isOpen) {
+      updateAriaHidden();
+
+      if (shouldFocusToggle && toggleButtons[0]) {
+        toggleButtons[0].focus();
+      }
+
+      return;
+    }
+
+    hideOverlay();
+    releaseScroll();
+    isOpen = false;
+    updateAriaHidden();
+    document.removeEventListener('keydown', handleKeydown);
+
+    if (shouldFocusToggle && toggleButtons[0]) {
+      toggleButtons[0].focus();
+    }
+  }
+
+  toggleButtons.forEach(function (button) {
+    button.addEventListener('click', function (event) {
+      event.preventDefault();
+
+      if (isOpen) {
+        closeMenu(false);
+      } else {
+        openMenu();
+      }
+    });
+  });
+
+  closeButtons.forEach(function (button) {
+    button.addEventListener('click', function (event) {
+      event.preventDefault();
+      closeMenu(true);
+    });
+  });
+
+  if (overlay) {
+    overlay.addEventListener('click', function () {
+      closeMenu(false);
+    });
+  }
+
+  menu.addEventListener('click', function (event) {
+    const trigger = event.target.closest('[data-fh-mobile-menu-close]');
+
+    if (trigger) {
+      event.preventDefault();
+      closeMenu(true);
+    }
+  });
+
+  function handleViewportChange(event) {
+    if (event.matches) {
+      closeMenu(false);
+      releaseScroll();
+
+      if (overlay) {
+        overlay.classList.remove('is-visible');
+        overlay.setAttribute('hidden', '');
+      }
+    }
+
+    updateAriaHidden();
+  }
+
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', handleViewportChange);
+  } else if (typeof mediaQuery.addListener === 'function') {
+    mediaQuery.addListener(handleViewportChange);
+  }
+
+  updateAriaHidden();
+
+  if (!mediaQuery.matches) {
+    closeMenu(false);
+  }
+});
+// End Section: FH mobile navigation toggle
+
 // Section: FH account menu toggle behaviour
 document.addEventListener('DOMContentLoaded', function () {
   function resolveGreeting(defaultGreeting) {


### PR DESCRIPTION
## Summary
- restructure the FH header markup to add a mobile menu toggle, full-screen navigation panel, and consolidated action icons without changing the desktop layout
- extend the stylesheet with responsive grid, mobile navigation overlay, and scroll locking helpers so the header adapts cleanly to smaller viewports
- add JavaScript that handles opening/closing the slide-in menu, accessibility attributes, and viewport change clean-up for the responsive header

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7f6b7b6548331aa950e6a85bcf6c2