### PR TITLE
Add third-level Garagentorschlösser menu and animation

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -631,12 +631,12 @@
   transform: translateY(0);
 }
 
-.fh-header__mobile-submenu {
+.fh-header__mobile-stage {
   display: none;
 }
 
-.fh-header__mobile-submenu-panel {
-  display: none;
+.fh-header__mobile-stage-panel {
+  position: relative;
 }
 
 .fh-header__mobile-submenu-header {
@@ -815,6 +815,7 @@
     max-width: none;
     margin: 0;
     padding: 0 24px 48px;
+    position: relative;
   }
 
   .fh-header__mobile-close {
@@ -831,26 +832,37 @@
     flex-direction: column;
     gap: 0;
     padding: 0;
+    margin: 0;
   }
 
-  .fh-header__nav--submenu-open .fh-header__nav-list {
-    display: none;
-  }
-
-  .fh-header__mobile-submenu {
-    display: none;
-  }
-
-  .fh-header__nav--submenu-open .fh-header__mobile-submenu {
+  .fh-header__mobile-stage {
     display: block;
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+    height: auto;
+    transition: height 0.25s ease;
   }
 
-  .fh-header__mobile-submenu-panel {
-    display: none;
+  .fh-header__mobile-stage-panel {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateX(100%);
+    transition: transform 0.25s ease, opacity 0.25s ease;
   }
 
-  .fh-header__mobile-submenu-panel.is-active {
-    display: block;
+  .fh-header__mobile-stage-panel.is-active {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateX(0);
+  }
+
+  .fh-header__mobile-stage.is-transitioning {
+    pointer-events: none;
   }
 
   .fh-header__nav-item {

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -132,7 +132,8 @@
           <line x1="6" y1="6" x2="18" y2="18"></line>
         </svg>
       </button>
-      <ul class="nav fh-header__nav-list">
+      <div class="fh-header__mobile-stage" data-fh-mobile-stage data-fh-mobile-submenu-container>
+      <ul class="nav fh-header__nav-list fh-header__mobile-stage-panel is-active" data-fh-mobile-stage-panel="root" aria-hidden="false">
       <li class="nav-item dropdown fh-header__nav-item">
         <a class="nav-link fh-header__nav-link" href="/schloesser" data-fh-mobile-submenu-target="schloesser" aria-controls="fh-mobile-submenu-schloesser" aria-expanded="false">SCHLÖSSER</a>
         <div class="dropdown-menu fh-header__dropdown">
@@ -141,7 +142,11 @@
               <a href="#" class="fh-header__dropdown-link">Einsteckschlösser für Metalltore</a>
               <a href="#" class="fh-header__dropdown-link">elektrische Türöffner</a>
               <a href="#" class="fh-header__dropdown-link">FH-Schlösser</a>
-              <a href="#" class="fh-header__dropdown-link">Garagentorschlösser</a>
+              <a href="/garagentorschloesser" class="fh-header__dropdown-link">Garagentorschlösser</a>
+              <a href="/schloesser/garagentorschloesser/garagentorschloesser-unten-schliessend" class="fh-header__dropdown-link">Garagentorschlösser unten schließend</a>
+              <a href="/schloesser/garagentorschloesser/garagentorschloesser-seitlich-schliessend" class="fh-header__dropdown-link">Garagentorschlösser seitlich schließend</a>
+              <a href="/schloesser/garagentorschloesser/garagentorschloesser-oben-schliessend" class="fh-header__dropdown-link">Garagentorschlösser oben schließend</a>
+              <a href="/schloesser/garagentorschloesser/garagentorschloesser-oben-und-unten-schliessend" class="fh-header__dropdown-link">Garagentorschlösser oben und unten schließend</a>
               <a href="#" class="fh-header__dropdown-link">Haustürschlösser</a>
             </div>
             <div>
@@ -407,8 +412,7 @@
         </div>
       </li>
       </ul>
-      <div class="fh-header__mobile-submenu" data-fh-mobile-submenu-container>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-schloesser" data-fh-mobile-submenu-panel="schloesser" aria-hidden="true">
+        <div class="fh-header__mobile-submenu-panel fh-header__mobile-stage-panel" id="fh-mobile-submenu-schloesser" data-fh-mobile-submenu-panel="schloesser" data-fh-mobile-stage-panel="schloesser" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -423,7 +427,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">Einsteckschlösser für Metalltore</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">elektrische Türöffner</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">FH-Schlösser</a></li>
-            <li><a href="#" class="fh-header__mobile-submenu-link">Garagentorschlösser</a></li>
+            <li><a href="/garagentorschloesser" class="fh-header__mobile-submenu-link" data-fh-mobile-submenu-target="garagentorschloesser" aria-controls="fh-mobile-submenu-garagentorschloesser">Garagentorschlösser</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">Haustürschlösser</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">Kastenschlösser</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">Korridortürschlösser</a></li>
@@ -436,7 +440,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">Zubehör für Schloss und Tor</a></li>
           </ul>
         </div>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-beschlaege" data-fh-mobile-submenu-panel="beschlaege" aria-hidden="true">
+        <div class="fh-header__mobile-submenu-panel fh-header__mobile-stage-panel" id="fh-mobile-submenu-beschlaege" data-fh-mobile-submenu-panel="beschlaege" data-fh-mobile-stage-panel="beschlaege" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -455,7 +459,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
           </ul>
         </div>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-sicherungen" data-fh-mobile-submenu-panel="sicherungen" aria-hidden="true">
+        <div class="fh-header__mobile-submenu-panel fh-header__mobile-stage-panel" id="fh-mobile-submenu-sicherungen" data-fh-mobile-submenu-panel="sicherungen" data-fh-mobile-stage-panel="sicherungen" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -474,7 +478,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
           </ul>
         </div>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-sichtschutz" data-fh-mobile-submenu-panel="sichtschutz" aria-hidden="true">
+        <div class="fh-header__mobile-submenu-panel fh-header__mobile-stage-panel" id="fh-mobile-submenu-sichtschutz" data-fh-mobile-submenu-panel="sichtschutz" data-fh-mobile-stage-panel="sichtschutz" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -493,7 +497,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
           </ul>
         </div>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-fenstermontage" data-fh-mobile-submenu-panel="fenstermontage" aria-hidden="true">
+        <div class="fh-header__mobile-submenu-panel fh-header__mobile-stage-panel" id="fh-mobile-submenu-fenstermontage" data-fh-mobile-submenu-panel="fenstermontage" data-fh-mobile-stage-panel="fenstermontage" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -512,7 +516,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
           </ul>
         </div>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-chemische-befestigung" data-fh-mobile-submenu-panel="chemische-befestigung" aria-hidden="true">
+        <div class="fh-header__mobile-submenu-panel fh-header__mobile-stage-panel" id="fh-mobile-submenu-chemische-befestigung" data-fh-mobile-submenu-panel="chemische-befestigung" data-fh-mobile-stage-panel="chemische-befestigung" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -531,7 +535,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
           </ul>
         </div>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-aktionen" data-fh-mobile-submenu-panel="aktionen" aria-hidden="true">
+        <div class="fh-header__mobile-submenu-panel fh-header__mobile-stage-panel" id="fh-mobile-submenu-aktionen" data-fh-mobile-submenu-panel="aktionen" data-fh-mobile-stage-panel="aktionen" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -548,6 +552,24 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
+          </ul>
+        </div>
+        <div class="fh-header__mobile-submenu-panel fh-header__mobile-stage-panel" id="fh-mobile-submenu-garagentorschloesser" data-fh-mobile-submenu-panel="garagentorschloesser" data-fh-mobile-stage-panel="garagentorschloesser" data-fh-mobile-submenu-parent="schloesser" aria-hidden="true">
+          <div class="fh-header__mobile-submenu-header">
+            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                <polyline points="15 18 9 12 15 6"></polyline>
+              </svg>
+              <span>Zurück</span>
+            </button>
+            <div class="fh-header__mobile-submenu-title">Garagentorschlösser</div>
+          </div>
+          <ul class="fh-header__mobile-submenu-list">
+            <li><a href="/garagentorschloesser" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Garagentorschlösser</a></li>
+            <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-unten-schliessend" class="fh-header__mobile-submenu-link">Garagentorschlösser unten schließend</a></li>
+            <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-seitlich-schliessend" class="fh-header__mobile-submenu-link">Garagentorschlösser seitlich schließend</a></li>
+            <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-oben-schliessend" class="fh-header__mobile-submenu-link">Garagentorschlösser oben schließend</a></li>
+            <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-oben-und-unten-schliessend" class="fh-header__mobile-submenu-link">Garagentorschlösser oben und unten schließend</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add Garagentorschlösser deep links to the Schlösser dropdown and mobile navigation
- refactor the mobile menu into a staged layout with animated forward/back transitions
- introduce a dedicated third-level mobile panel for Garagentorschlösser variants

## Testing
- manual preview of mobile menu

------
https://chatgpt.com/codex/tasks/task_e_68d95fc267048331b55cc3c3ee632761