### PR TITLE
Add third-level Garagentorschlösser submenu with sliding animation

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -631,8 +631,16 @@
   transform: translateY(0);
 }
 
-.fh-header__mobile-submenu {
-  display: none;
+.fh-header__mobile-views {
+  width: 100%;
+}
+
+.fh-header__mobile-view {
+  width: 100%;
+}
+
+.fh-header__mobile-view--root {
+  display: block;
 }
 
 .fh-header__mobile-submenu-panel {
@@ -693,17 +701,44 @@
 
 .fh-header__mobile-submenu-link {
   display: block;
+  width: 100%;
   padding: 16px 0;
+  border: none;
   border-bottom: 1px solid #e5e7eb;
+  background: none;
   color: #1a1a1a;
   font-size: 16px;
+  text-align: left;
   text-decoration: none;
+  cursor: pointer;
 }
 
 .fh-header__mobile-submenu-link:hover,
 .fh-header__mobile-submenu-link:focus {
   color: #0f172a;
   text-decoration: none;
+}
+
+.fh-header__mobile-submenu-link:focus {
+  outline: none;
+  background-color: rgba(49, 165, 240, 0.12);
+}
+
+.fh-header__mobile-submenu-link--has-children {
+  position: relative;
+  padding-right: 32px;
+}
+
+.fh-header__mobile-submenu-link--has-children::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  width: 8px;
+  height: 8px;
+  border-top: 2px solid currentColor;
+  border-right: 2px solid currentColor;
+  transform: translateY(-50%) rotate(45deg);
 }
 
 .fh-header__mobile-submenu-link--all {
@@ -815,6 +850,7 @@
     max-width: none;
     margin: 0;
     padding: 0 24px 48px;
+    overflow: hidden;
   }
 
   .fh-header__mobile-close {
@@ -834,22 +870,27 @@
   }
 
   .fh-header__nav--submenu-open .fh-header__nav-list {
-    display: none;
+    pointer-events: none;
   }
 
-  .fh-header__mobile-submenu {
-    display: none;
+  .fh-header__mobile-views {
+    position: relative;
+    display: flex;
+    width: 100%;
+    transform: translateX(0);
+    transition: transform 0.28s ease;
+    will-change: transform;
   }
 
-  .fh-header__nav--submenu-open .fh-header__mobile-submenu {
-    display: block;
+  .fh-header__mobile-view {
+    flex: 0 0 100%;
+  }
+
+  .fh-header__mobile-view[aria-hidden="true"] {
+    pointer-events: none;
   }
 
   .fh-header__mobile-submenu-panel {
-    display: none;
-  }
-
-  .fh-header__mobile-submenu-panel.is-active {
     display: block;
   }
 

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -132,7 +132,9 @@
           <line x1="6" y1="6" x2="18" y2="18"></line>
         </svg>
       </button>
-      <ul class="nav fh-header__nav-list">
+      <div class="fh-header__mobile-views" data-fh-mobile-views>
+        <div class="fh-header__mobile-view fh-header__mobile-view--root is-active" data-fh-mobile-panel="root" aria-hidden="false">
+          <ul class="nav fh-header__nav-list">
       <li class="nav-item dropdown fh-header__nav-item">
         <a class="nav-link fh-header__nav-link" href="/schloesser" data-fh-mobile-submenu-target="schloesser" aria-controls="fh-mobile-submenu-schloesser" aria-expanded="false">SCHLÖSSER</a>
         <div class="dropdown-menu fh-header__dropdown">
@@ -141,7 +143,11 @@
               <a href="#" class="fh-header__dropdown-link">Einsteckschlösser für Metalltore</a>
               <a href="#" class="fh-header__dropdown-link">elektrische Türöffner</a>
               <a href="#" class="fh-header__dropdown-link">FH-Schlösser</a>
-              <a href="#" class="fh-header__dropdown-link">Garagentorschlösser</a>
+              <a href="/garagentorschloesser" class="fh-header__dropdown-link">Garagentorschlösser</a>
+              <a href="/schloesser/garagentorschloesser/garagentorschloesser-unten-schliessend" class="fh-header__dropdown-link">Garagentorschlösser unten schließend</a>
+              <a href="/schloesser/garagentorschloesser/garagentorschloesser-seitlich-schliessend" class="fh-header__dropdown-link">Garagentorschlösser seitlich schließend</a>
+              <a href="/schloesser/garagentorschloesser/garagentorschloesser-oben-schliessend" class="fh-header__dropdown-link">Garagentorschlösser oben schließend</a>
+              <a href="/schloesser/garagentorschloesser/garagentorschloesser-oben-und-unten-schliessend" class="fh-header__dropdown-link">Garagentorschlösser oben und unten schließend</a>
               <a href="#" class="fh-header__dropdown-link">Haustürschlösser</a>
             </div>
             <div>
@@ -406,9 +412,9 @@
           </div>
         </div>
       </li>
-      </ul>
-      <div class="fh-header__mobile-submenu" data-fh-mobile-submenu-container>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-schloesser" data-fh-mobile-submenu-panel="schloesser" aria-hidden="true">
+          </ul>
+        </div>
+        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-schloesser" data-fh-mobile-panel="schloesser" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -423,7 +429,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">Einsteckschlösser für Metalltore</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">elektrische Türöffner</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">FH-Schlösser</a></li>
-            <li><a href="#" class="fh-header__mobile-submenu-link">Garagentorschlösser</a></li>
+            <li><button type="button" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--has-children" data-fh-mobile-submenu-target="garagentorschloesser" aria-controls="fh-mobile-submenu-garagentorschloesser" aria-expanded="false">Garagentorschlösser</button></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">Haustürschlösser</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">Kastenschlösser</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">Korridortürschlösser</a></li>
@@ -436,7 +442,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">Zubehör für Schloss und Tor</a></li>
           </ul>
         </div>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-beschlaege" data-fh-mobile-submenu-panel="beschlaege" aria-hidden="true">
+        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-beschlaege" data-fh-mobile-panel="beschlaege" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -455,7 +461,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
           </ul>
         </div>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-sicherungen" data-fh-mobile-submenu-panel="sicherungen" aria-hidden="true">
+        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-sicherungen" data-fh-mobile-panel="sicherungen" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -474,7 +480,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
           </ul>
         </div>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-sichtschutz" data-fh-mobile-submenu-panel="sichtschutz" aria-hidden="true">
+        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-sichtschutz" data-fh-mobile-panel="sichtschutz" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -493,7 +499,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
           </ul>
         </div>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-fenstermontage" data-fh-mobile-submenu-panel="fenstermontage" aria-hidden="true">
+        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-fenstermontage" data-fh-mobile-panel="fenstermontage" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -512,7 +518,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
           </ul>
         </div>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-chemische-befestigung" data-fh-mobile-submenu-panel="chemische-befestigung" aria-hidden="true">
+        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-chemische-befestigung" data-fh-mobile-panel="chemische-befestigung" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -531,7 +537,7 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
           </ul>
         </div>
-        <div class="fh-header__mobile-submenu-panel" id="fh-mobile-submenu-aktionen" data-fh-mobile-submenu-panel="aktionen" aria-hidden="true">
+        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-aktionen" data-fh-mobile-panel="aktionen" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
             <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
@@ -548,6 +554,24 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
+          </ul>
+        </div>
+        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-garagentorschloesser" data-fh-mobile-panel="garagentorschloesser" aria-hidden="true">
+          <div class="fh-header__mobile-submenu-header">
+            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zur Kategorie Garagentorschlösser">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                <polyline points="15 18 9 12 15 6"></polyline>
+              </svg>
+              <span>Zurück</span>
+            </button>
+            <div class="fh-header__mobile-submenu-title">Garagentorschlösser</div>
+          </div>
+          <ul class="fh-header__mobile-submenu-list">
+            <li><a href="/garagentorschloesser" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Garagentorschlösser</a></li>
+            <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-unten-schliessend" class="fh-header__mobile-submenu-link">Garagentorschlösser unten schließend</a></li>
+            <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-seitlich-schliessend" class="fh-header__mobile-submenu-link">Garagentorschlösser seitlich schließend</a></li>
+            <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-oben-schliessend" class="fh-header__mobile-submenu-link">Garagentorschlösser oben schließend</a></li>
+            <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-oben-und-unten-schliessend" class="fh-header__mobile-submenu-link">Garagentorschlösser oben und unten schließend</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add the required Garagentorschlösser links to the Schlösser dropdown and mobile menu
- restructure the mobile navigation into sliding panels to support a third level
- refresh mobile styles to accommodate submenu buttons and animated transitions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95fc267048331b55cc3c3ee632761