### PR TITLE
Fix mobile menu view and adjust Garagentorschlösser subcategory styling

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -603,22 +603,26 @@
 
 .fh-header__dropdown-sublist {
   margin-top: 4px;
-  padding-left: 14px;
+  padding-left: 20px;
   display: flex;
   flex-direction: column;
+  row-gap: 2px;
 }
 
 .fh-header__dropdown-sublink {
   display: block;
-  padding: 4px 0;
+  padding: 3px 0;
   font-size: 13px;
-  color: #6b7280;
+  font-weight: 400;
+  line-height: 1.4;
+  color: #111827;
   text-decoration: none;
+  transition: color 0.2s ease;
 }
 
 .fh-header__dropdown-sublink:hover,
 .fh-header__dropdown-sublink:focus {
-  color: #1f2937;
+  color: #0f172a;
 }
 
 .fh-header__dropdown-description {
@@ -666,10 +670,6 @@
 
 .fh-header__mobile-view {
   width: 100%;
-}
-
-.fh-header__mobile-view--root {
-  display: block;
 }
 
 .fh-header__mobile-submenu-panel {
@@ -904,19 +904,30 @@
 
   .fh-header__mobile-views {
     position: relative;
-    display: flex;
     width: 100%;
-    transform: translateX(0);
-    transition: transform 0.28s ease;
-    will-change: transform;
+    min-height: calc(100vh - 120px);
   }
 
   .fh-header__mobile-view {
-    flex: 0 0 100%;
+    display: none;
+    width: 100%;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateX(12px);
+    transition: opacity 0.24s ease, transform 0.24s ease;
   }
 
-  .fh-header__mobile-view[aria-hidden="true"] {
-    pointer-events: none;
+  .fh-header__mobile-view.is-active {
+    display: block;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateX(0);
+  }
+
+  .fh-header__mobile-view[aria-hidden="false"] {
+    display: block;
   }
 
   .fh-header__mobile-submenu-panel {

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -216,9 +216,6 @@ fhOnReady(function () {
     const depth = Math.max(panelStack.length - 1, 0);
     const currentEntry = panelStack[depth] || panelStack[0];
     const currentPanel = getPanelById(currentEntry ? currentEntry.id : ROOT_PANEL_ID);
-    const activeIndex = currentPanel ? panelElements.indexOf(currentPanel) : 0;
-    const normalizedIndex = activeIndex > -1 ? activeIndex : 0;
-
     panelElements.forEach(function (panel) {
       const isActive = panel === currentPanel;
 
@@ -226,7 +223,7 @@ fhOnReady(function () {
       panel.setAttribute('aria-hidden', isActive ? 'false' : 'true');
     });
 
-    panelContainer.style.transform = 'translate3d(-' + normalizedIndex * 100 + '%, 0, 0)';
+    panelContainer.style.transform = '';
     menu.classList.toggle('fh-header__nav--submenu-open', depth > 0);
 
     if (skipFocus) return;


### PR DESCRIPTION
## Summary
- ensure only the active view is visible in the FH mobile navigation and smooth out the transition behavior
- restyle the Garagentorschlösser subcategory links with reduced size, weight, and a neutral color to better reflect their hierarchy

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da4623e6048331a81f0d09cba05410