### PR TITLE
Fix mobile submenu back button focus

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -309,25 +309,15 @@ fhOnReady(function () {
 
     const removedEntry = panelStack.pop();
 
+    const parentEntry = panelStack[panelStack.length - 1];
+
     if (removedEntry && removedEntry.trigger instanceof HTMLElement) removedEntry.trigger.setAttribute('aria-expanded', 'false');
 
     updatePanelState({ skipFocus: true });
 
     if (options && options.skipFocus === true) return;
 
-    if (removedEntry && removedEntry.trigger instanceof HTMLElement) {
-      removedEntry.trigger.focus();
-      return;
-    }
-
-    const parentEntry = panelStack[panelStack.length - 1];
-
     if (parentEntry) {
-      if (parentEntry.trigger instanceof HTMLElement) {
-        parentEntry.trigger.focus();
-        return;
-      }
-
       if (parentEntry.id !== ROOT_PANEL_ID) {
         const parentPanel = getPanelById(parentEntry.id);
 
@@ -339,6 +329,16 @@ fhOnReady(function () {
             return;
           }
         }
+      }
+
+      if (removedEntry && removedEntry.trigger instanceof HTMLElement) {
+        removedEntry.trigger.focus();
+        return;
+      }
+
+      if (parentEntry.trigger instanceof HTMLElement) {
+        parentEntry.trigger.focus();
+        return;
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure the parent submenu's back button regains focus when stepping back from deeper mobile panels to preserve its styling state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da5202b6a48331846593bfa246a774