### PR TITLE
Add scroll-triggered hide/show for mobile header search row

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -810,7 +810,7 @@
     row-gap: 16px;
     padding: 18px 16px 20px;
     transition: row-gap 0.25s ease, padding-bottom 0.25s ease;
-    overflow: hidden;
+    overflow: visible;
   }
 
   .fh-header__logo {
@@ -823,7 +823,7 @@
     grid-template-columns: auto 1fr;
     column-gap: 12px;
     width: 100%;
-    overflow: hidden;
+    overflow: visible;
     max-height: 400px;
     transition: max-height 0.25s ease, opacity 0.25s ease, transform 0.25s ease;
   }
@@ -831,6 +831,7 @@
   .fh-header--search-hidden .fh-header__main {
     row-gap: 0;
     padding-bottom: 12px;
+    overflow: hidden;
   }
 
   .fh-header--search-hidden .fh-header__search-area {
@@ -838,6 +839,7 @@
     opacity: 0;
     transform: translateY(-12px);
     pointer-events: none;
+    overflow: hidden;
   }
 
   .fh-header__actions {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -809,6 +809,8 @@
       "search search";
     row-gap: 16px;
     padding: 18px 16px 20px;
+    transition: row-gap 0.25s ease, padding-bottom 0.25s ease;
+    overflow: hidden;
   }
 
   .fh-header__logo {
@@ -821,6 +823,21 @@
     grid-template-columns: auto 1fr;
     column-gap: 12px;
     width: 100%;
+    overflow: hidden;
+    max-height: 400px;
+    transition: max-height 0.25s ease, opacity 0.25s ease, transform 0.25s ease;
+  }
+
+  .fh-header--search-hidden .fh-header__main {
+    row-gap: 0;
+    padding-bottom: 12px;
+  }
+
+  .fh-header--search-hidden .fh-header__search-area {
+    max-height: 0;
+    opacity: 0;
+    transform: translateY(-12px);
+    pointer-events: none;
   }
 
   .fh-header__actions {

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -469,6 +469,104 @@ fhOnReady(function () {
 });
 // End Section: FH mobile navigation toggle
 
+// Section: FH mobile search row scroll hide/show
+fhOnReady(function () {
+  const header = document.querySelector('[data-fh-header-root]');
+
+  if (!header) return;
+
+  if (!header.querySelector('.fh-header__search-area')) return;
+
+  const mobileMedia = window.matchMedia('(max-width: 991.98px)');
+  const SCROLL_THRESHOLD = 40;
+  const raf =
+    typeof window.requestAnimationFrame === 'function'
+      ? window.requestAnimationFrame.bind(window)
+      : function (callback) { return window.setTimeout(callback, 16); };
+  let lastScrollY = window.pageYOffset || 0;
+  let downDistance = 0;
+  let upDistance = 0;
+  let isHidden = false;
+  let ticking = false;
+
+  function showRow() {
+    if (!isHidden) return;
+
+    header.classList.remove('fh-header--search-hidden');
+    isHidden = false;
+  }
+
+  function hideRow() {
+    if (isHidden) return;
+
+    header.classList.add('fh-header--search-hidden');
+    isHidden = true;
+  }
+
+  function resetTracking(scrollPosition) {
+    downDistance = 0;
+    upDistance = 0;
+    lastScrollY = typeof scrollPosition === 'number' ? scrollPosition : window.pageYOffset || 0;
+  }
+
+  function handleScrollFrame() {
+    ticking = false;
+
+    if (!mobileMedia.matches) {
+      showRow();
+      resetTracking(window.pageYOffset || 0);
+      return;
+    }
+
+    const currentScroll = window.pageYOffset || document.documentElement.scrollTop || 0;
+    const delta = currentScroll - lastScrollY;
+
+    if (currentScroll <= 0) {
+      showRow();
+      resetTracking(0);
+      return;
+    }
+
+    if (delta > 0) {
+      downDistance += delta;
+      upDistance = 0;
+
+      if (!isHidden && downDistance >= SCROLL_THRESHOLD) hideRow();
+    } else if (delta < 0) {
+      upDistance += Math.abs(delta);
+      downDistance = 0;
+
+      if (isHidden && upDistance >= SCROLL_THRESHOLD) showRow();
+    }
+
+    lastScrollY = currentScroll;
+  }
+
+  function handleScroll() {
+    if (ticking) return;
+
+    ticking = true;
+    raf(handleScrollFrame);
+  }
+
+  function handleMediaChange(event) {
+    if (event && event.matches === false) {
+      showRow();
+    }
+
+    resetTracking(window.pageYOffset || 0);
+  }
+
+  window.addEventListener('scroll', handleScroll, { passive: true });
+
+  if (typeof mobileMedia.addEventListener === 'function') mobileMedia.addEventListener('change', handleMediaChange); else if (typeof mobileMedia.addListener === 'function') {
+    mobileMedia.addListener(handleMediaChange);
+  }
+
+  handleMediaChange(mobileMedia);
+});
+// End Section: FH mobile search row scroll hide/show
+
 // Section: FH Merkliste button enhancements
 fhOnReady(function () {
   const iconMarkup =


### PR DESCRIPTION
## Summary
- add responsive CSS so the mobile header search row can collapse smoothly
- implement scroll detection to hide the mobile search row on downward scroll and reveal it when scrolling up

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da621e107c8331a4c4241d2c0c3be4