### PR TITLE
Add icons to top-level categories and improve mobile menu

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -548,6 +548,77 @@
   color: #1f7fc9;
 }
 
+/* Section: FH header navigation icons */
+:root {
+  --fh-icon-schloesser: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%3E%3Ccircle%20cx%3D%278%27%20cy%3D%2712%27%20r%3D%274%27%20fill%3D%27black%27%2F%3E%3Crect%20x%3D%2711%27%20y%3D%2710.5%27%20width%3D%2711%27%20height%3D%273%27%20rx%3D%271.5%27%20fill%3D%27black%27%2F%3E%3Crect%20x%3D%2717%27%20y%3D%2710.5%27%20width%3D%273%27%20height%3D%275.5%27%20rx%3D%271.2%27%20fill%3D%27black%27%2F%3E%3Crect%20x%3D%2714%27%20y%3D%2710.5%27%20width%3D%272.5%27%20height%3D%274%27%20rx%3D%271%27%20fill%3D%27black%27%2F%3E%3C%2Fsvg%3E');
+  --fh-icon-beschlaege: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%3E%3Crect%20x%3D%274%27%20y%3D%275%27%20width%3D%276%27%20height%3D%2714%27%20rx%3D%271.5%27%20fill%3D%27black%27%2F%3E%3Crect%20x%3D%2714%27%20y%3D%275%27%20width%3D%276%27%20height%3D%2714%27%20rx%3D%271.5%27%20fill%3D%27black%27%2F%3E%3Ccircle%20cx%3D%277%27%20cy%3D%278%27%20r%3D%271.2%27%20fill%3D%27white%27%2F%3E%3Ccircle%20cx%3D%277%27%20cy%3D%2712%27%20r%3D%271.2%27%20fill%3D%27white%27%2F%3E%3Ccircle%20cx%3D%277%27%20cy%3D%2716%27%20r%3D%271.2%27%20fill%3D%27white%27%2F%3E%3C%2Fsvg%3E');
+  --fh-icon-sicherungen: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%3E%3Cpath%20d%3D%27M12%203L4%206v5c0%205.2%203.5%209.7%208%2010.8%204.5-1.1%208-5.6%208-10.8V6l-8-3z%27%20fill%3D%27black%27%2F%3E%3Cpath%20d%3D%27M12%209.5a3.5%203.5%200%200%200-3.5%203.5c0%202.2%202%204.5%203.5%205%201.5-.5%203.5-2.8%203.5-5A3.5%203.5%200%200%200%2012%209.5z%27%20fill%3D%27white%27%2F%3E%3C%2Fsvg%3E');
+  --fh-icon-sichtschutz: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%3E%3Crect%20x%3D%274%27%20y%3D%276%27%20width%3D%273%27%20height%3D%2712%27%20rx%3D%271.2%27%20fill%3D%27black%27%2F%3E%3Crect%20x%3D%279%27%20y%3D%274%27%20width%3D%273%27%20height%3D%2716%27%20rx%3D%271.2%27%20fill%3D%27black%27%2F%3E%3Crect%20x%3D%2714%27%20y%3D%276%27%20width%3D%273%27%20height%3D%2712%27%20rx%3D%271.2%27%20fill%3D%27black%27%2F%3E%3Crect%20x%3D%2719%27%20y%3D%278%27%20width%3D%273%27%20height%3D%2710%27%20rx%3D%271.2%27%20fill%3D%27black%27%2F%3E%3Crect%20x%3D%276%27%20y%3D%2710%27%20width%3D%2714%27%20height%3D%272%27%20rx%3D%271%27%20fill%3D%27white%27%2F%3E%3C%2Fsvg%3E');
+  --fh-icon-fenstermontage: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%3E%3Crect%20x%3D%273%27%20y%3D%273%27%20width%3D%2718%27%20height%3D%2718%27%20rx%3D%272%27%20fill%3D%27black%27%2F%3E%3Crect%20x%3D%2711%27%20y%3D%273%27%20width%3D%272%27%20height%3D%2718%27%20fill%3D%27white%27%2F%3E%3Crect%20x%3D%273%27%20y%3D%2711%27%20width%3D%2718%27%20height%3D%272%27%20fill%3D%27white%27%2F%3E%3C%2Fsvg%3E');
+  --fh-icon-chemische-befestigung: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%3E%3Crect%20x%3D%2710%27%20y%3D%273%27%20width%3D%274%27%20height%3D%272.5%27%20rx%3D%271.2%27%20fill%3D%27black%27%2F%3E%3Cpath%20d%3D%27M10%205.5v4.6l-4.1%206.8c-1%201.7.2%203.9%202.2%203.9h7.8c2%200%203.2-2.2%202.2-3.9L14%2010.1V5.5h-4z%27%20fill%3D%27black%27%2F%3E%3Crect%20x%3D%278%27%20y%3D%2715%27%20width%3D%278%27%20height%3D%272%27%20rx%3D%271%27%20fill%3D%27white%27%2F%3E%3C%2Fsvg%3E');
+  --fh-icon-aktionen: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%20fill%3D%27none%27%3E%3Cpath%20d%3D%27M3%204v7l10%2010%207-7-10-10H3z%27%20fill%3D%27black%27%2F%3E%3Ccircle%20cx%3D%278%27%20cy%3D%278%27%20r%3D%271.8%27%20fill%3D%27white%27%2F%3E%3Crect%20x%3D%2712%27%20y%3D%2712%27%20width%3D%276%27%20height%3D%272%27%20rx%3D%271%27%20transform%3D%27rotate%2845%2012%2012%29%27%20fill%3D%27white%27%2F%3E%3C%2Fsvg%3E');
+}
+
+[data-fh-category-icon] {
+  --fh-category-icon: none;
+  align-items: center;
+  gap: 10px;
+}
+
+a[data-fh-category-icon] {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.fh-header__nav-link[data-fh-category-icon] {
+  justify-content: center;
+}
+
+.fh-header__mobile-submenu-title[data-fh-category-icon] {
+  display: inline-flex;
+}
+
+[data-fh-category-icon]::before {
+  content: '';
+  width: 20px;
+  height: 20px;
+  flex: none;
+  background-color: currentColor;
+  -webkit-mask: var(--fh-category-icon) center/contain no-repeat;
+  mask: var(--fh-category-icon) center/contain no-repeat;
+}
+
+[data-fh-category-icon='schloesser'] {
+  --fh-category-icon: var(--fh-icon-schloesser);
+}
+
+[data-fh-category-icon='beschlaege'] {
+  --fh-category-icon: var(--fh-icon-beschlaege);
+}
+
+[data-fh-category-icon='sicherungen'] {
+  --fh-category-icon: var(--fh-icon-sicherungen);
+}
+
+[data-fh-category-icon='sichtschutz'] {
+  --fh-category-icon: var(--fh-icon-sichtschutz);
+}
+
+[data-fh-category-icon='fenstermontage'] {
+  --fh-category-icon: var(--fh-icon-fenstermontage);
+}
+
+[data-fh-category-icon='chemische-befestigung'] {
+  --fh-category-icon: var(--fh-icon-chemische-befestigung);
+}
+
+[data-fh-category-icon='aktionen'] {
+  --fh-category-icon: var(--fh-icon-aktionen);
+}
+/* End Section: FH header navigation icons */
+
 .fh-header__dropdown {
   position: absolute;
   top: 100%;
@@ -915,7 +986,12 @@
 
   .fh-header__mobile-close {
     display: inline-flex;
+    position: sticky;
+    top: 0;
+    z-index: 5;
     margin-bottom: 24px;
+    background-color: #ffffff;
+    box-shadow: 0 1px 0 rgba(15, 23, 42, 0.08);
   }
 
   .fh-header__mobile-close-icon {
@@ -969,6 +1045,26 @@
   .fh-header__mobile-submenu-panel.is-active,
   .fh-header__mobile-submenu-panel[aria-hidden="false"] {
     display: flex;
+  }
+
+  .fh-header__mobile-submenu-header {
+    top: 0;
+    z-index: 4;
+    padding-bottom: 20px;
+    background-color: #ffffff;
+    box-shadow: 0 1px 0 rgba(15, 23, 42, 0.08);
+  }
+
+  .fh-header__mobile-submenu-list {
+    padding-top: 4px;
+  }
+
+  .fh-header__mobile-submenu-link--all {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    background-color: #ffffff;
+    box-shadow: 0 1px 0 rgba(15, 23, 42, 0.08);
   }
 
   .fh-header__nav-item {

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -136,7 +136,7 @@
         <div class="fh-header__mobile-view fh-header__mobile-view--root is-active" data-fh-mobile-panel="root" aria-hidden="false">
           <ul class="nav fh-header__nav-list">
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link" href="/schloesser" data-fh-mobile-submenu-target="schloesser" aria-controls="fh-mobile-submenu-schloesser" aria-expanded="false">SCHLÖSSER</a>
+        <a class="nav-link fh-header__nav-link" href="/schloesser" data-fh-mobile-submenu-target="schloesser" data-fh-category-icon="schloesser" aria-controls="fh-mobile-submenu-schloesser" aria-expanded="false">SCHLÖSSER</a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--four">
             <div>
@@ -177,7 +177,7 @@
         </div>
       </li>
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="beschlaege" aria-controls="fh-mobile-submenu-beschlaege" aria-expanded="false">Beschläge</a>
+        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="beschlaege" data-fh-category-icon="beschlaege" aria-controls="fh-mobile-submenu-beschlaege" aria-expanded="false">Beschläge</a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
             <div>
@@ -217,7 +217,7 @@
         </div>
       </li>
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="sicherungen" aria-controls="fh-mobile-submenu-sicherungen" aria-expanded="false">Sicherungen</a>
+        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="sicherungen" data-fh-category-icon="sicherungen" aria-controls="fh-mobile-submenu-sicherungen" aria-expanded="false">Sicherungen</a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
             <div>
@@ -257,7 +257,7 @@
         </div>
       </li>
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="sichtschutz" aria-controls="fh-mobile-submenu-sichtschutz" aria-expanded="false">Sichtschutz</a>
+        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="sichtschutz" data-fh-category-icon="sichtschutz" aria-controls="fh-mobile-submenu-sichtschutz" aria-expanded="false">Sichtschutz</a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
             <div>
@@ -297,7 +297,7 @@
         </div>
       </li>
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="fenstermontage" aria-controls="fh-mobile-submenu-fenstermontage" aria-expanded="false">Fenstermontage</a>
+        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="fenstermontage" data-fh-category-icon="fenstermontage" aria-controls="fh-mobile-submenu-fenstermontage" aria-expanded="false">Fenstermontage</a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
             <div>
@@ -337,7 +337,7 @@
         </div>
       </li>
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="chemische-befestigung" aria-controls="fh-mobile-submenu-chemische-befestigung" aria-expanded="false">Chemische Befestigung</a>
+        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="chemische-befestigung" data-fh-category-icon="chemische-befestigung" aria-controls="fh-mobile-submenu-chemische-befestigung" aria-expanded="false">Chemische Befestigung</a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
             <div>
@@ -377,7 +377,7 @@
         </div>
       </li>
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link fh-header__nav-link--highlight" href="#" data-fh-mobile-submenu-target="aktionen" aria-controls="fh-mobile-submenu-aktionen" aria-expanded="false">Aktionen</a>
+        <a class="nav-link fh-header__nav-link fh-header__nav-link--highlight" href="#" data-fh-mobile-submenu-target="aktionen" data-fh-category-icon="aktionen" aria-controls="fh-mobile-submenu-aktionen" aria-expanded="false">Aktionen</a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
             <div>
@@ -426,10 +426,10 @@
               </svg>
               <span>Zurück</span>
             </button>
-            <div class="fh-header__mobile-submenu-title">Schlösser</div>
+            <div class="fh-header__mobile-submenu-title" data-fh-category-icon="schloesser">Schlösser</div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/schloesser" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Schlösser</a></li>
+            <li><a href="/schloesser" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all" data-fh-category-icon="schloesser">Alle Schlösser</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">Einsteckschlösser für Metalltore</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">elektrische Türöffner</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">FH-Schlösser</a></li>
@@ -454,10 +454,10 @@
               </svg>
               <span>Zurück</span>
             </button>
-            <div class="fh-header__mobile-submenu-title">Beschläge</div>
+            <div class="fh-header__mobile-submenu-title" data-fh-category-icon="beschlaege">Beschläge</div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Beschläge</a></li>
+            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all" data-fh-category-icon="beschlaege">Alle Beschläge</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
@@ -473,10 +473,10 @@
               </svg>
               <span>Zurück</span>
             </button>
-            <div class="fh-header__mobile-submenu-title">Sicherungen</div>
+            <div class="fh-header__mobile-submenu-title" data-fh-category-icon="sicherungen">Sicherungen</div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Sicherungen</a></li>
+            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all" data-fh-category-icon="sicherungen">Alle Sicherungen</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
@@ -492,10 +492,10 @@
               </svg>
               <span>Zurück</span>
             </button>
-            <div class="fh-header__mobile-submenu-title">Sichtschutz</div>
+            <div class="fh-header__mobile-submenu-title" data-fh-category-icon="sichtschutz">Sichtschutz</div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Sichtschutz-Artikel</a></li>
+            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all" data-fh-category-icon="sichtschutz">Alle Sichtschutz-Artikel</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
@@ -511,10 +511,10 @@
               </svg>
               <span>Zurück</span>
             </button>
-            <div class="fh-header__mobile-submenu-title">Fenstermontage</div>
+            <div class="fh-header__mobile-submenu-title" data-fh-category-icon="fenstermontage">Fenstermontage</div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Fenstermontage-Artikel</a></li>
+            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all" data-fh-category-icon="fenstermontage">Alle Fenstermontage-Artikel</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
@@ -530,10 +530,10 @@
               </svg>
               <span>Zurück</span>
             </button>
-            <div class="fh-header__mobile-submenu-title">Chemische Befestigung</div>
+            <div class="fh-header__mobile-submenu-title" data-fh-category-icon="chemische-befestigung">Chemische Befestigung</div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Chemische Befestigung</a></li>
+            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all" data-fh-category-icon="chemische-befestigung">Alle Chemische Befestigung</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
@@ -549,10 +549,10 @@
               </svg>
               <span>Zurück</span>
             </button>
-            <div class="fh-header__mobile-submenu-title">Aktionen</div>
+            <div class="fh-header__mobile-submenu-title" data-fh-category-icon="aktionen">Aktionen</div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Aktionen</a></li>
+            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all" data-fh-category-icon="aktionen">Alle Aktionen</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>


### PR DESCRIPTION
## Summary
- add inline SVG-based icons for each top-level category and reuse them across desktop and mobile views
- keep the mobile close/back/title area sticky and pin the "Alle" entry while sub-categories remain scrollable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da7ae6c5088331afa786acd0174481