### PR TITLE
Hide Trusted Shops badge during search overlay

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1076,6 +1076,10 @@ body.fh-mobile-menu-open div[id^="trustbadge-container-"],
 body.fh-mobile-menu-open #web-chat-loader-root {
   display: none !important;
 }
+
+body.fh-search-overlay-open div[id^="trustbadge-container-"] {
+  display: none !important;
+}
 /* End Section: Trustbadge ausblenden */
 
 /* Section: Allgemeines Button-Styling für .btn-primary */

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -2227,6 +2227,54 @@ fhOnReady(function () {
 // End Section: Animierte Suchplatzhalter Vorschläge
 
 
+// Section: Trusted Shops Badge toggle during search overlay
+fhOnReady(function () {
+  var BODY_CLASS = 'fh-search-overlay-open';
+  var OVERLAY_SELECTORS = ['[data-dfd-screen="mobile-initial"]', '[data-dfd-screen="embedded"]'];
+
+  function isElementVisible(element) {
+    if (!(element instanceof HTMLElement)) return false;
+
+    var style = window.getComputedStyle(element);
+
+    if (!style) return false;
+
+    if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') return false;
+
+    return true;
+  }
+
+  function updateOverlayState() {
+    var overlayIsActive = OVERLAY_SELECTORS.some(function (selector) {
+      var element = document.querySelector(selector);
+
+      if (!element) return false;
+
+      return isElementVisible(element);
+    });
+
+    document.body.classList.toggle(BODY_CLASS, overlayIsActive);
+  }
+
+  var observerTarget = document.body || document.documentElement;
+
+  if (!observerTarget) return;
+
+  var observer = new MutationObserver(function () {
+    updateOverlayState();
+  });
+
+  observer.observe(observerTarget, { childList: true, subtree: true, attributes: true, attributeFilter: ['style', 'class', 'data-dfd-screen'] });
+
+  updateOverlayState();
+
+  window.addEventListener('beforeunload', function () {
+    observer.disconnect();
+  });
+});
+// End Section: Trusted Shops Badge toggle during search overlay
+
+
 
 // Section: Warenkorbvorschau "Warenkorb" zu "Weiter einkaufen" Funktion
 

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -515,6 +515,68 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // End Section: Animierte Suchplatzhalter Vorschläge
 
+  // Section: Trusted Shops Badge toggle during search overlay
+  (function () {
+    var BODY_CLASS = 'sh-search-overlay-open';
+    var OVERLAY_SELECTORS = ['[data-dfd-screen="mobile-initial"]', '[data-dfd-screen="embedded"]'];
+
+    function isElementVisible(element) {
+      if (!(element instanceof HTMLElement)) return false;
+
+      var style = window.getComputedStyle(element);
+
+      if (!style) return false;
+
+      if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') return false;
+
+      return true;
+    }
+
+    function updateOverlayState() {
+      var overlayIsActive = OVERLAY_SELECTORS.some(function (selector) {
+        var element = document.querySelector(selector);
+
+        if (!element) return false;
+
+        return isElementVisible(element);
+      });
+
+      if (!document.body) return;
+
+      document.body.classList.toggle(BODY_CLASS, overlayIsActive);
+    }
+
+    function setupObserver() {
+      var observerTarget = document.body || document.documentElement;
+
+      if (!observerTarget) return;
+
+      var observer = new MutationObserver(function () {
+        updateOverlayState();
+      });
+
+      observer.observe(observerTarget, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['style', 'class', 'data-dfd-screen'],
+      });
+
+      updateOverlayState();
+
+      window.addEventListener('beforeunload', function () {
+        observer.disconnect();
+      });
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', setupObserver);
+    } else {
+      setupObserver();
+    }
+  })();
+  // End Section: Trusted Shops Badge toggle during search overlay
+
   // Section: Warenkorbvorschau "Warenkorb" zu "Weiter einkaufen" Funktion
 
   function patchBasketButton() {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -37,6 +37,10 @@
   #web-chat-loader-root {
   display: none !important;
 }
+
+body.sh-search-overlay-open div[id^="trustbadge-container-"] {
+  display: none !important;
+}
 /* End Section: Trustbadge ausblenden */
 
 /* Section: Allgemeines Button-Styling für .btn-primary */


### PR DESCRIPTION
## Summary
- hide the Trusted Shops badge for FH and SH when the search overlay is present
- monitor search overlay elements to toggle body classes that suppress the badge

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da80dbdc088331a05597d02ec483bc