### PR TITLE
Hide trustbadge when DFD results grid is present

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -2253,6 +2253,10 @@ fhOnReady(function () {
       return isElementVisible(element);
     });
 
+    if (!overlayIsActive) {
+      overlayIsActive = Boolean(document.querySelector('.dfd-results-grid'));
+    }
+
     document.body.classList.toggle(BODY_CLASS, overlayIsActive);
   }
 

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -541,6 +541,10 @@ document.addEventListener("DOMContentLoaded", function () {
         return isElementVisible(element);
       });
 
+      if (!overlayIsActive) {
+        overlayIsActive = Boolean(document.querySelector('.dfd-results-grid'));
+      }
+
       if (!document.body) return;
 
       document.body.classList.toggle(BODY_CLASS, overlayIsActive);


### PR DESCRIPTION
## Summary
- extend the FH and SH trustbadge overlay detection to treat the DFD results grid as active
- ensure the trustbadge hides on mobile when the search results grid is injected into the DOM

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da877a620c83318b77746f54149aad