### PR TITLE
Restrict free shipping bar in cart preview to German selection

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -1937,11 +1937,24 @@ fhOnReady(function () {
     'country-id-select'
   ];
 
+  function findCountrySelects(fragment, root = document) {
+    return Array.from(root.querySelectorAll(`select[id*="${fragment}"]`));
+  }
+
   function isGermanySelected() {
-    return COUNTRY_SELECT_ID_FRAGMENTS.some((fragment) => {
-      const select = document.querySelector(`select[id*="${fragment}"]`);
-      return select && select.value === '1';
-    });
+    return COUNTRY_SELECT_ID_FRAGMENTS.some((fragment) =>
+      findCountrySelects(fragment).some((select) => select.value === '1')
+    );
+  }
+
+  function isGermanySelectedInCartPreview() {
+    const bar = document.getElementById('free-shipping-bar');
+    if (!bar) return true;
+    const previewRoot = bar.closest('.basket-preview');
+    if (!previewRoot) return true;
+    const selects = findCountrySelects('shipping-country-select', previewRoot);
+    if (!selects.length) return true;
+    return selects.some((select) => select.value === '1');
   }
 
   function isCheckoutPage() {
@@ -2019,9 +2032,11 @@ fhOnReady(function () {
     if (!bar) return;
     const path = window.location.pathname;
     const total = parseEuro(document.querySelector('dd[data-testing="item-sum"]'));
+    const inCartPreview = Boolean(bar.closest('.basket-preview'));
     const hide =
       (pickup && pickup.checked) ||
       (isCheckoutPage() && !isGermanySelected()) ||
+      (inCartPreview && !isGermanySelectedInCartPreview()) ||
       (path.includes('/bestellbestaetigung') && total < THRESHOLD);
     bar.style.display = hide ? 'none' : '';
   }

--- a/Javascript/SH - Javascript am Ende der Seite.js
+++ b/Javascript/SH - Javascript am Ende der Seite.js
@@ -191,11 +191,24 @@ document.addEventListener("DOMContentLoaded", function () {
       'country-id-select'
     ];
 
+    function findCountrySelects(fragment, root = document) {
+      return Array.from(root.querySelectorAll(`select[id*="${fragment}"]`));
+    }
+
     function isGermanySelected() {
-      return COUNTRY_SELECT_ID_FRAGMENTS.some((fragment) => {
-        const select = document.querySelector(`select[id*="${fragment}"]`);
-        return select && select.value === '1';
-      });
+      return COUNTRY_SELECT_ID_FRAGMENTS.some((fragment) =>
+        findCountrySelects(fragment).some((select) => select.value === '1')
+      );
+    }
+
+    function isGermanySelectedInCartPreview() {
+      const bar = document.getElementById('free-shipping-bar');
+      if (!bar) return true;
+      const previewRoot = bar.closest('.basket-preview');
+      if (!previewRoot) return true;
+      const selects = findCountrySelects('shipping-country-select', previewRoot);
+      if (!selects.length) return true;
+      return selects.some((select) => select.value === '1');
     }
 
   function isCheckoutPage() {
@@ -283,9 +296,11 @@ document.addEventListener("DOMContentLoaded", function () {
       if (!bar) return;
       const path = window.location.pathname;
       const total = parseEuro(document.querySelector('dd[data-testing="item-sum"]'));
+      const inCartPreview = Boolean(bar.closest('.basket-preview'));
       const hide =
         (pickup && pickup.checked) ||
         (isCheckoutPage() && !isGermanySelected()) ||
+        (inCartPreview && !isGermanySelectedInCartPreview()) ||
         (path.includes('/bestellbestaetigung') && total < THRESHOLD);
       bar.style.display = hide ? 'none' : '';
     }


### PR DESCRIPTION
## Summary
- expand the Germany detection helper to look at every shipping, invoice, and country select even when IDs carry numeric suffixes
- hide the free shipping progress bar inside the basket preview unless a shipping-country option with value `1` (Germany) is selected, without changing checkout behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da8e85a740833195e37f14498ec07e