### PR TITLE
Fix header nav spacing and keep category label on one line

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -509,8 +509,8 @@
 
 .fh-header__nav-list {
   display: flex;
-  justify-content: space-between;
-  gap: 12px;
+  justify-content: flex-start;
+  gap: 0;
   list-style: none;
   margin: 0;
   padding: 0 32px;
@@ -531,6 +531,7 @@
   padding: 18px 12px;
   color: #1a1a1a;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .fh-header__nav-link--highlight {
@@ -980,6 +981,7 @@
     padding: 18px 0;
     font-size: 18px;
     border-bottom: 1px solid #e5e7eb;
+    white-space: normal;
   }
 
   .fh-header__nav-item:last-child .fh-header__nav-link {


### PR DESCRIPTION
## Summary
- remove the flex gaps between desktop navigation items so hovering the row keeps a dropdown visible
- keep desktop navigation labels, including "Chemische Befestigung", on a single line while allowing mobile links to wrap

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db90ed516883319a9d36a7e56e7f93