### PR TITLE
Update FH navigation icons for key categories

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -527,11 +527,33 @@
 }
 
 .fh-header__nav-link {
-  display: block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
   padding: 18px 12px;
   color: #1a1a1a;
   text-decoration: none;
   white-space: nowrap;
+}
+
+.fh-header__nav-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+}
+
+.fh-header__nav-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.fh-header__nav-text {
+  display: inline-block;
 }
 
 .fh-header__nav-link--highlight {
@@ -982,6 +1004,18 @@
     font-size: 18px;
     border-bottom: 1px solid #e5e7eb;
     white-space: normal;
+    justify-content: flex-start;
+    gap: 12px;
+  }
+
+  .fh-header__nav-icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  .fh-header__nav-icon svg {
+    width: 22px;
+    height: 22px;
   }
 
   .fh-header__nav-item:last-child .fh-header__nav-link {

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -136,7 +136,15 @@
         <div class="fh-header__mobile-view fh-header__mobile-view--root is-active" data-fh-mobile-panel="root" aria-hidden="false">
           <ul class="nav fh-header__nav-list">
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link" href="/schloesser" data-fh-mobile-submenu-target="schloesser" aria-controls="fh-mobile-submenu-schloesser" aria-expanded="false">SCHLÖSSER</a>
+        <a class="nav-link fh-header__nav-link" href="/schloesser" data-fh-mobile-submenu-target="schloesser" aria-controls="fh-mobile-submenu-schloesser" aria-expanded="false">
+          <span class="fh-header__nav-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+              <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+            </svg>
+          </span>
+          <span class="fh-header__nav-text">SCHLÖSSER</span>
+        </a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--four">
             <div>
@@ -177,7 +185,24 @@
         </div>
       </li>
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="beschlaege" aria-controls="fh-mobile-submenu-beschlaege" aria-expanded="false">Beschläge</a>
+        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="beschlaege" aria-controls="fh-mobile-submenu-beschlaege" aria-expanded="false">
+          <span class="fh-header__nav-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="4" y="4" width="5" height="16" rx="1"></rect>
+              <rect x="15" y="4" width="5" height="16" rx="1"></rect>
+              <line x1="9" y1="8" x2="15" y2="8"></line>
+              <line x1="9" y1="12" x2="15" y2="12"></line>
+              <line x1="9" y1="16" x2="15" y2="16"></line>
+              <circle cx="6.5" cy="8" r="1" fill="currentColor" stroke="none"></circle>
+              <circle cx="6.5" cy="12" r="1" fill="currentColor" stroke="none"></circle>
+              <circle cx="6.5" cy="16" r="1" fill="currentColor" stroke="none"></circle>
+              <circle cx="17.5" cy="8" r="1" fill="currentColor" stroke="none"></circle>
+              <circle cx="17.5" cy="12" r="1" fill="currentColor" stroke="none"></circle>
+              <circle cx="17.5" cy="16" r="1" fill="currentColor" stroke="none"></circle>
+            </svg>
+          </span>
+          <span class="fh-header__nav-text">Beschläge</span>
+        </a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
             <div>
@@ -217,7 +242,15 @@
         </div>
       </li>
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="sicherungen" aria-controls="fh-mobile-submenu-sicherungen" aria-expanded="false">Sicherungen</a>
+        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="sicherungen" aria-controls="fh-mobile-submenu-sicherungen" aria-expanded="false">
+          <span class="fh-header__nav-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+              <path d="m9 12 2.5 2.5L16 10"></path>
+            </svg>
+          </span>
+          <span class="fh-header__nav-text">Sicherungen</span>
+        </a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
             <div>
@@ -257,7 +290,17 @@
         </div>
       </li>
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="sichtschutz" aria-controls="fh-mobile-submenu-sichtschutz" aria-expanded="false">Sichtschutz</a>
+        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="sichtschutz" aria-controls="fh-mobile-submenu-sichtschutz" aria-expanded="false">
+          <span class="fh-header__nav-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"></path>
+              <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"></path>
+              <path d="M14.12 14.12a3 3 0 0 1-4.24-4.24"></path>
+              <line x1="1" y1="1" x2="23" y2="23"></line>
+            </svg>
+          </span>
+          <span class="fh-header__nav-text">Sichtschutz</span>
+        </a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
             <div>
@@ -297,7 +340,18 @@
         </div>
       </li>
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="fenstermontage" aria-controls="fh-mobile-submenu-fenstermontage" aria-expanded="false">Fenstermontage</a>
+        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="fenstermontage" aria-controls="fh-mobile-submenu-fenstermontage" aria-expanded="false">
+          <span class="fh-header__nav-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="4" y="4" width="16" height="16" rx="1.5"></rect>
+              <line x1="12" y1="4" x2="12" y2="20"></line>
+              <line x1="4" y1="12" x2="20" y2="12"></line>
+              <path d="M4 9H2v6h2"></path>
+              <path d="M20 9h2v6h-2"></path>
+            </svg>
+          </span>
+          <span class="fh-header__nav-text">Fenstermontage</span>
+        </a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
             <div>
@@ -337,7 +391,14 @@
         </div>
       </li>
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="chemische-befestigung" aria-controls="fh-mobile-submenu-chemische-befestigung" aria-expanded="false">Chemische Befestigung</a>
+        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="chemische-befestigung" aria-controls="fh-mobile-submenu-chemische-befestigung" aria-expanded="false">
+          <span class="fh-header__nav-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z"></path>
+            </svg>
+          </span>
+          <span class="fh-header__nav-text">Chemische Befestigung</span>
+        </a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
             <div>
@@ -377,7 +438,15 @@
         </div>
       </li>
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link fh-header__nav-link--highlight" href="#" data-fh-mobile-submenu-target="aktionen" aria-controls="fh-mobile-submenu-aktionen" aria-expanded="false">Aktionen</a>
+        <a class="nav-link fh-header__nav-link fh-header__nav-link--highlight" href="#" data-fh-mobile-submenu-target="aktionen" aria-controls="fh-mobile-submenu-aktionen" aria-expanded="false">
+          <span class="fh-header__nav-icon" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"></path>
+              <line x1="7" y1="7" x2="7.01" y2="7"></line>
+            </svg>
+          </span>
+          <span class="fh-header__nav-text">Aktionen</span>
+        </a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
             <div>


### PR DESCRIPTION
## Summary
- replace the Beschläge icon with a hinge-inspired outline and screw markers
- add a shield checkmark motif to the Sicherungen icon for clearer meaning
- draw a framed window with mounting brackets for the Fenstermontage category

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db9c122dc883319ca1b9ba349d5615