### PR TITLE
Fix mobile header panel arrow alignment and width

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1033,11 +1033,13 @@ body.fh-mobile-menu-open {
 
 @media (max-width: 767.98px) {
   .fh-header__panel {
+    --fh-header-mobile-panel-shift: 8px;
     left: 50%;
     right: auto;
-    transform: translateX(-50%);
+    transform: translateX(calc(-50% + var(--fh-header-mobile-panel-shift, 0px)));
     width: calc(100vw - 32px);
     max-width: 360px;
+    box-sizing: border-box;
   }
 
   .fh-header__panel--account {
@@ -1048,7 +1050,7 @@ body.fh-mobile-menu-open {
   .fh-header__panel-arrow {
     left: 50%;
     right: auto;
-    transform: translate(-50%, -50%) rotate(45deg);
+    transform: translateX(calc(-50% + var(--fh-header-mobile-panel-shift, 0px))) rotate(45deg);
   }
 }
 /* End Section: FH Header Base Layout */


### PR DESCRIPTION
## Summary
- ensure mobile header panels use border-box sizing in the mobile breakpoint to prevent horizontal overflow
- adjust the mobile panel arrow transform so the pointer aligns cleanly with the menus
- shift the mobile header panels slightly right on mobile to give the menus a bit more breathing room on that side

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dba399bb9c8331bde0a8bdc1b6f068