### PR TITLE
Adjust mobile header panel spacing

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1035,9 +1035,10 @@ body.fh-mobile-menu-open {
   .fh-header__panel {
     left: 50%;
     right: auto;
-    transform: translateX(-50%);
+    transform: translateX(calc(-50% - 8px));
     width: calc(100vw - 32px);
     max-width: 360px;
+    box-sizing: border-box;
   }
 
   .fh-header__panel--account {
@@ -1048,7 +1049,7 @@ body.fh-mobile-menu-open {
   .fh-header__panel-arrow {
     left: 50%;
     right: auto;
-    transform: translate(-50%, -50%) rotate(45deg);
+    transform: translateX(calc(-50% + 8px)) rotate(45deg);
   }
 }
 /* End Section: FH Header Base Layout */


### PR DESCRIPTION
## Summary
- shift the mobile header panels slightly to create additional right-side breathing room
- counterbalance the panel arrow transform so the pointer stays aligned with the trigger buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba399bb9c8331bde0a8bdc1b6f068