### PR TITLE
Refine mobile header panel spacing

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1035,20 +1035,21 @@ body.fh-mobile-menu-open {
   .fh-header__panel {
     left: 50%;
     right: auto;
-    transform: translateX(-50%);
-    width: calc(100vw - 32px);
+    transform: translateX(calc(-50% - 8px));
+    width: calc(100vw - 40px);
     max-width: 360px;
+    box-sizing: border-box;
   }
 
   .fh-header__panel--account {
-    width: calc(100vw - 32px);
-    max-width: 260px;
+    width: calc(100vw - 40px);
+    max-width: 252px;
   }
 
   .fh-header__panel-arrow {
     left: 50%;
     right: auto;
-    transform: translate(-50%, -50%) rotate(45deg);
+    transform: translateX(calc(-50% + 8px)) rotate(45deg);
   }
 }
 /* End Section: FH Header Base Layout */


### PR DESCRIPTION
## Summary
- reduce mobile header panels' viewport width usage to leave a larger right-side gutter
- trim the mobile account panel width cap so it no longer extends the header when opened

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dba399bb9c8331bde0a8bdc1b6f068