### PR TITLE
Debounce mobile header visibility toggles

### DIFF
--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -488,12 +488,15 @@ fhOnReady(function () {
   let upDistance = 0;
   let isHidden = false;
   let ticking = false;
+  let lastToggleAt = Date.now();
+  const TOGGLE_DEBOUNCE_MS = 180;
 
   function showRow() {
     if (!isHidden) return;
 
     header.classList.remove('fh-header--search-hidden');
     isHidden = false;
+    lastToggleAt = Date.now();
   }
 
   function hideRow() {
@@ -501,6 +504,7 @@ fhOnReady(function () {
 
     header.classList.add('fh-header--search-hidden');
     isHidden = true;
+    lastToggleAt = Date.now();
   }
 
   function resetTracking(scrollPosition) {
@@ -524,6 +528,13 @@ fhOnReady(function () {
     if (currentScroll <= 0) {
       showRow();
       resetTracking(0);
+      return;
+    }
+
+    const timeSinceLastToggle = Date.now() - lastToggleAt;
+
+    if (timeSinceLastToggle < TOGGLE_DEBOUNCE_MS) {
+      lastScrollY = currentScroll;
       return;
     }
 


### PR DESCRIPTION
## Summary
- debounce the mobile search row toggle so the header does not flicker during rapid scrolling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba9e1872483318588eda95bdff110