### PR TITLE
Make mobile submenu header sticky with category descriptions

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -705,11 +705,18 @@
   top: 0;
   z-index: 1;
   display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 16px;
+  margin: 0;
+  padding: 0 0 20px;
+  background-color: #ffffff;
+}
+
+.fh-header__mobile-submenu-bar {
+  display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 0;
-  padding: 0 0 24px;
-  background-color: #ffffff;
 }
 
 .fh-header__mobile-submenu-title {
@@ -717,6 +724,44 @@
   font-weight: 700;
   letter-spacing: 0.4px;
   text-transform: uppercase;
+}
+
+.fh-header__mobile-submenu-description {
+  margin: 0;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background-color: #f5f7fb;
+  color: #1a1a1a;
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.fh-header__mobile-submenu-all {
+  display: block;
+  width: 100%;
+  padding: 14px 16px;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  background-color: #f3f4f6;
+  color: #0f172a;
+  font-size: 16px;
+  font-weight: 700;
+  text-align: center;
+  text-decoration: none;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.fh-header__mobile-submenu-all:hover,
+.fh-header__mobile-submenu-all:focus {
+  background-color: #e5e7eb;
+  border-color: #cbd5f5;
+  color: #0b1120;
+  text-decoration: none;
+}
+
+.fh-header__mobile-submenu-all:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(49, 165, 240, 0.35);
 }
 
 .fh-header__mobile-submenu-back {

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -249,7 +249,7 @@
               <path d="m9 12 2.5 2.5L16 10"></path>
             </svg>
           </span>
-          <span class="fh-header__nav-text">Sicherungen</span>
+          <span class="fh-header__nav-text">Fenstersicherungen</span>
         </a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
@@ -284,7 +284,7 @@
               <a href="#" class="fh-header__dropdown-link">[Platzhalter]</a>
             </div>
             <div class="fh-header__dropdown-footer">
-              <a href="#" class="fh-header__dropdown-footer-link">Alle Sicherungen sehen</a>
+              <a href="#" class="fh-header__dropdown-footer-link">Alle Fenstersicherungen sehen</a>
             </div>
           </div>
         </div>
@@ -489,16 +489,19 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-schloesser" data-fh-mobile-panel="schloesser" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Schlösser</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Schlösser</div>
+            </div>
+            <p class="fh-header__mobile-submenu-description">Ob Haus-, Wohnungs-, Zimmer- oder Garagentür &ndash; hier findest du das passende Schloss für jede Anwendung. Von Einsteck- bis Rohrrahmenschlössern und elektrischen Türöffnern bieten wir geprüfte Qualität und hohe Sicherheit. Ergänzt durch Profilzylinder, Schließbleche und Türdrücker erhältst du alles aus einer Hand für eine sichere Türlösung.</p>
+            <a href="/schloesser" class="fh-header__mobile-submenu-all">Alle Schlösser</a>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/schloesser" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Schlösser</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">Einsteckschlösser für Metalltore</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">elektrische Türöffner</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">FH-Schlösser</a></li>
@@ -517,13 +520,15 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-beschlaege" data-fh-mobile-panel="beschlaege" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Beschläge</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Beschläge</div>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
             <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Beschläge</a></li>
@@ -536,16 +541,19 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-sicherungen" data-fh-mobile-panel="sicherungen" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Sicherungen</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Fenstersicherungen</div>
+            </div>
+            <p class="fh-header__mobile-submenu-description">Fenstersicherungen schützen Ihr Zuhause vor Einbrüchen und unbefugtem Zugang. Einfach zu installieren, bieten sie eine effektive Barriere und erhöhen die Sicherheit sowohl für private Haushalte als auch gewerbliche Anwendungen.</p>
+            <a href="#" class="fh-header__mobile-submenu-all">Alle Fenstersicherungen</a>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Sicherungen</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
@@ -555,13 +563,15 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-sichtschutz" data-fh-mobile-panel="sichtschutz" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Sichtschutz</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Sichtschutz</div>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
             <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Sichtschutz-Artikel</a></li>
@@ -574,13 +584,15 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-fenstermontage" data-fh-mobile-panel="fenstermontage" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Fenstermontage</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Fenstermontage</div>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
             <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Fenstermontage-Artikel</a></li>
@@ -593,13 +605,15 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-chemische-befestigung" data-fh-mobile-panel="chemische-befestigung" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Chemische Befestigung</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Chemische Befestigung</div>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
             <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Chemische Befestigung</a></li>
@@ -612,13 +626,15 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-aktionen" data-fh-mobile-panel="aktionen" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Aktionen</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Aktionen</div>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
             <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Aktionen</a></li>
@@ -631,13 +647,15 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-garagentorschloesser" data-fh-mobile-panel="garagentorschloesser" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zur Kategorie Garagentorschlösser">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Garagentorschlösser</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zur Kategorie Garagentorschlösser">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Garagentorschlösser</div>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
             <li><a href="/garagentorschloesser" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Garagentorschlösser</a></li>


### PR DESCRIPTION
## Summary
- make the mobile submenu header section sticky and add a dedicated container for the top controls
- introduce description copy and prominent "Alle" entry for the Schlösser and Fenstersicherungen categories
- rename "Sicherungen" to "Fenstersicherungen" across navigation and update mobile styles to support the new layout

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbafba151c83319cd5877e75a446d7