### PR TITLE
Make mobile submenu top sections sticky with descriptions

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -700,16 +700,29 @@
   flex-direction: column;
 }
 
-.fh-header__mobile-submenu-header {
+.fh-header__mobile-submenu-top {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 0;
+  padding: 8px 0 20px;
+  background-color: #ffffff;
+  box-shadow: 0 14px 18px -18px rgba(15, 23, 42, 0.35);
+}
+
+.fh-header__mobile-submenu-header {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 0;
-  padding: 0 0 24px;
-  background-color: #ffffff;
+}
+
+.fh-header__mobile-submenu-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .fh-header__mobile-submenu-title {
@@ -758,9 +771,44 @@
   flex: 1 1 auto;
   list-style: none;
   margin: 0;
-  padding: 0 0 24px;
+  padding: 8px 0 24px;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+}
+
+.fh-header__mobile-submenu-all-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 14px 18px;
+  border-radius: 14px;
+  background-color: #f1f5f9;
+  color: #0f172a;
+  font-size: 15px;
+  font-weight: 700;
+  text-align: center;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fh-header__mobile-submenu-all-link:hover,
+.fh-header__mobile-submenu-all-link:focus {
+  background-color: #e2e8f0;
+  color: #0f172a;
+  text-decoration: none;
+}
+
+.fh-header__mobile-submenu-all-link:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(49, 165, 240, 0.35);
+}
+
+.fh-header__mobile-submenu-description {
+  margin: 0;
+  color: #475569;
+  font-size: 14px;
+  line-height: 1.55;
 }
 
 .fh-header__mobile-submenu-link {

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -249,7 +249,7 @@
               <path d="m9 12 2.5 2.5L16 10"></path>
             </svg>
           </span>
-          <span class="fh-header__nav-text">Sicherungen</span>
+          <span class="fh-header__nav-text">Fenstersicherungen</span>
         </a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
@@ -284,7 +284,7 @@
               <a href="#" class="fh-header__dropdown-link">[Platzhalter]</a>
             </div>
             <div class="fh-header__dropdown-footer">
-              <a href="#" class="fh-header__dropdown-footer-link">Alle Sicherungen sehen</a>
+              <a href="#" class="fh-header__dropdown-footer-link">Alle Fenstersicherungen sehen</a>
             </div>
           </div>
         </div>
@@ -488,17 +488,22 @@
           </ul>
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-schloesser" data-fh-mobile-panel="schloesser" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Schlösser</div>
+          <div class="fh-header__mobile-submenu-top">
+            <div class="fh-header__mobile-submenu-header">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Schlösser</div>
+            </div>
+            <div class="fh-header__mobile-submenu-content">
+              <a href="/schloesser" class="fh-header__mobile-submenu-all-link">Alle Schlösser</a>
+              <p class="fh-header__mobile-submenu-description">Ob Haus-, Wohnungs-, Zimmer- oder Garagentür – hier findest du das passende Schloss für jede Anwendung. Von Einsteck- bis Rohrrahmenschlössern und elektrischen Türöffnern bieten wir geprüfte Qualität und hohe Sicherheit. Ergänzt durch Profilzylinder, Schließbleche und Türdrücker erhältst du alles aus einer Hand für eine sichere Türlösung.</p>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/schloesser" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Schlösser</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">Einsteckschlösser für Metalltore</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">elektrische Türöffner</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">FH-Schlösser</a></li>
@@ -535,17 +540,22 @@
           </ul>
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-sicherungen" data-fh-mobile-panel="sicherungen" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Sicherungen</div>
+          <div class="fh-header__mobile-submenu-top">
+            <div class="fh-header__mobile-submenu-header">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Fenstersicherungen</div>
+            </div>
+            <div class="fh-header__mobile-submenu-content">
+              <a href="#" class="fh-header__mobile-submenu-all-link">Alle Fenstersicherungen</a>
+              <p class="fh-header__mobile-submenu-description">Fenstersicherungen schützen Ihr Zuhause vor Einbrüchen und unbefugtem Zugang. Einfach zu installieren, bieten sie eine effektive Barriere und erhöhen die Sicherheit sowohl für private Haushalte als auch gewerbliche Anwendungen.</p>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Sicherungen</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>


### PR DESCRIPTION
## Summary
- keep the mobile submenu header area sticky and add a dedicated info block for category actions
- surface the Schlösser and Fenstersicherungen descriptions at the top of their mobile panels
- rename the Sicherungen navigation entry to Fenstersicherungen across the header markup

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbafba151c83319cd5877e75a446d7