### PR TITLE
Ensure mobile submenu header stays fixed

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -492,14 +492,13 @@
   justify-content: center;
   width: 46px;
   height: 46px;
-  margin-left: auto;
-  margin-right: 0;
-  margin-bottom: 0;
+  margin: 0;
   padding: 0;
   border: none;
   background: none;
   color: #1a1a1a;
   cursor: pointer;
+  align-self: flex-start;
 }
 
 .fh-header__mobile-close-icon {
@@ -960,7 +959,7 @@
 
   .fh-header__mobile-close {
     display: inline-flex;
-    margin-bottom: 24px;
+    margin: 0 0 24px;
   }
 
   .fh-header__mobile-close-icon {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -703,20 +703,36 @@
 .fh-header__mobile-submenu-header {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+  margin-bottom: 0;
+  padding: 16px 0;
+  background: linear-gradient(180deg, #ffffff 85%, rgba(255, 255, 255, 0.92));
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.fh-header__mobile-submenu-bar {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 0;
-  padding: 0 0 24px;
-  background-color: #ffffff;
 }
 
 .fh-header__mobile-submenu-title {
+  flex: 1 1 auto;
   font-size: 20px;
   font-weight: 700;
   letter-spacing: 0.4px;
   text-transform: uppercase;
+}
+
+.fh-header__mobile-submenu-description {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.6;
+  color: #4b5563;
 }
 
 .fh-header__mobile-submenu-back {
@@ -917,7 +933,9 @@
     left: 0;
     width: 100%;
     height: 100vh;
-    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
     background-color: #ffffff;
     transform: translateX(-100%);
     transition: transform 0.3s ease;
@@ -933,7 +951,11 @@
     max-width: none;
     margin: 0;
     padding: 0 24px 48px;
-    overflow: hidden;
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    overflow-x: hidden;
+    overflow-y: visible;
   }
 
   .fh-header__mobile-close {
@@ -959,12 +981,16 @@
   .fh-header__mobile-views {
     position: relative;
     width: 100%;
-    min-height: calc(100vh - 120px);
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
   }
 
   .fh-header__mobile-view {
     display: none;
     width: 100%;
+    height: 100%;
     opacity: 0;
     visibility: hidden;
     pointer-events: none;
@@ -974,6 +1000,7 @@
 
   .fh-header__mobile-view.is-active {
     display: block;
+    height: 100%;
     opacity: 1;
     visibility: visible;
     pointer-events: auto;
@@ -982,16 +1009,22 @@
 
   .fh-header__mobile-view[aria-hidden="false"] {
     display: block;
+    height: 100%;
   }
 
   .fh-header__mobile-submenu-panel {
-    min-height: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
     height: 100%;
   }
 
   .fh-header__mobile-submenu-panel.is-active,
   .fh-header__mobile-submenu-panel[aria-hidden="false"] {
     display: flex;
+  }
+
+  .fh-header__mobile-view--root {
+    overflow-y: auto;
   }
 
   .fh-header__nav-item {

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -242,14 +242,14 @@
         </div>
       </li>
       <li class="nav-item dropdown fh-header__nav-item">
-        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="sicherungen" aria-controls="fh-mobile-submenu-sicherungen" aria-expanded="false">
+        <a class="nav-link fh-header__nav-link" href="#" data-fh-mobile-submenu-target="fenstersicherungen" aria-controls="fh-mobile-submenu-fenstersicherungen" aria-expanded="false">
           <span class="fh-header__nav-icon" aria-hidden="true">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
               <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
               <path d="m9 12 2.5 2.5L16 10"></path>
             </svg>
           </span>
-          <span class="fh-header__nav-text">Sicherungen</span>
+          <span class="fh-header__nav-text">Fenstersicherungen</span>
         </a>
         <div class="dropdown-menu fh-header__dropdown">
           <div class="fh-header__dropdown-grid fh-header__dropdown-grid--five">
@@ -284,7 +284,7 @@
               <a href="#" class="fh-header__dropdown-link">[Platzhalter]</a>
             </div>
             <div class="fh-header__dropdown-footer">
-              <a href="#" class="fh-header__dropdown-footer-link">Alle Sicherungen sehen</a>
+              <a href="#" class="fh-header__dropdown-footer-link">Alle Fenstersicherungen sehen</a>
             </div>
           </div>
         </div>
@@ -489,13 +489,16 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-schloesser" data-fh-mobile-panel="schloesser" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Schlösser</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Schlösser</div>
+            </div>
+            <p class="fh-header__mobile-submenu-description">Ob Haus-, Wohnungs-, Zimmer- oder Garagentür – hier findest du das passende Schloss für jede Anwendung. Von Einsteck- bis Rohrrahmenschlössern und elektrischen Türöffnern bieten wir geprüfte Qualität und hohe Sicherheit. Ergänzt durch Profilzylinder, Schließbleche und Türdrücker erhältst du alles aus einer Hand für eine sichere Türlösung.</p>
           </div>
           <ul class="fh-header__mobile-submenu-list">
             <li><a href="/schloesser" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Schlösser</a></li>
@@ -517,13 +520,15 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-beschlaege" data-fh-mobile-panel="beschlaege" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Beschläge</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Beschläge</div>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
             <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Beschläge</a></li>
@@ -534,18 +539,21 @@
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
           </ul>
         </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-sicherungen" data-fh-mobile-panel="sicherungen" aria-hidden="true">
+        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-fenstersicherungen" data-fh-mobile-panel="fenstersicherungen" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Sicherungen</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Fenstersicherungen</div>
+            </div>
+            <p class="fh-header__mobile-submenu-description">Fenstersicherungen schützen Ihr Zuhause vor Einbrüchen und unbefugtem Zugang. Einfach zu installieren, bieten sie eine effektive Barriere und erhöhen die Sicherheit sowohl für private Haushalte als auch gewerbliche Anwendungen.</p>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Sicherungen</a></li>
+            <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Fenstersicherungen</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
             <li><a href="#" class="fh-header__mobile-submenu-link">[Platzhalter]</a></li>
@@ -555,13 +563,15 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-sichtschutz" data-fh-mobile-panel="sichtschutz" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Sichtschutz</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Sichtschutz</div>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
             <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Sichtschutz-Artikel</a></li>
@@ -574,13 +584,15 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-fenstermontage" data-fh-mobile-panel="fenstermontage" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Fenstermontage</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Fenstermontage</div>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
             <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Fenstermontage-Artikel</a></li>
@@ -593,13 +605,15 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-chemische-befestigung" data-fh-mobile-panel="chemische-befestigung" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Chemische Befestigung</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Chemische Befestigung</div>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
             <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Chemische Befestigung</a></li>
@@ -612,13 +626,15 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-aktionen" data-fh-mobile-panel="aktionen" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Aktionen</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Aktionen</div>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
             <li><a href="#" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Aktionen</a></li>
@@ -631,13 +647,15 @@
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-garagentorschloesser" data-fh-mobile-panel="garagentorschloesser" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">
-            <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zur Kategorie Garagentorschlösser">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-              <span>Zurück</span>
-            </button>
-            <div class="fh-header__mobile-submenu-title">Garagentorschlösser</div>
+            <div class="fh-header__mobile-submenu-bar">
+              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zur Kategorie Garagentorschlösser">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <div class="fh-header__mobile-submenu-title">Garagentorschlösser</div>
+            </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
             <li><a href="/garagentorschloesser" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Garagentorschlösser</a></li>


### PR DESCRIPTION
## Summary
- refactor the mobile navigation containers to use flexbox so the submenu header remains pinned while its list scrolls independently
- allow the root menu view and submenu panels to expand to the full viewport height so overflow stays within the submenu column

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbafba151c83319cd5877e75a446d7