### PR TITLE
Fix Garagentorschlösser navigation link

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -152,7 +152,7 @@
               <a href="#" class="fh-header__dropdown-link">elektrische Türöffner</a>
               <a href="#" class="fh-header__dropdown-link">FH-Schlösser</a>
               <div class="fh-header__dropdown-group">
-                <a href="/garagentorschloesser" class="fh-header__dropdown-link fh-header__dropdown-link--parent">Garagentorschlösser</a>
+                <a href="/schloesser/garagentorschloesser" class="fh-header__dropdown-link fh-header__dropdown-link--parent">Garagentorschlösser</a>
                 <div class="fh-header__dropdown-sublist">
                   <a href="/schloesser/garagentorschloesser/garagentorschloesser-unten-schliessend" class="fh-header__dropdown-sublink">Garagentorschlösser unten schließend</a>
                   <a href="/schloesser/garagentorschloesser/garagentorschloesser-seitlich-schliessend" class="fh-header__dropdown-sublink">Garagentorschlösser seitlich schließend</a>
@@ -658,7 +658,7 @@
             </div>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/garagentorschloesser" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Garagentorschlösser</a></li>
+            <li><a href="/schloesser/garagentorschloesser" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Garagentorschlösser</a></li>
             <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-unten-schliessend" class="fh-header__mobile-submenu-link">Garagentorschlösser unten schließend</a></li>
             <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-seitlich-schliessend" class="fh-header__mobile-submenu-link">Garagentorschlösser seitlich schließend</a></li>
             <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-oben-schliessend" class="fh-header__mobile-submenu-link">Garagentorschlösser oben schließend</a></li>


### PR DESCRIPTION
## Summary
- update the Garagentorschlösser desktop dropdown link to include the /schloesser path prefix
- align the mobile Garagentorschlösser link with the corrected /schloesser prefix

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbcc58544c8331a3a5a4f323c7be83