### PR TITLE
Adjust FH header top bar behavior on desktop

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -31,6 +31,7 @@
 }
 
 .fh-header__top-bar {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -41,6 +42,7 @@
   font-size: 13px;
   letter-spacing: 0.3px;
   text-transform: uppercase;
+  z-index: 1;
 }
 
 .fh-header__top-item,
@@ -61,6 +63,24 @@
   height: 6px;
   border-radius: 50%;
   background-color: #38bdf8;
+}
+
+@media (min-width: 992px) {
+  .fh-header__top-bar::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 50%;
+    width: 100vw;
+    height: 100%;
+    transform: translateX(-50%);
+    background: inherit;
+    z-index: -1;
+  }
+
+  .fh-header--scrolled .fh-header__top-bar {
+    display: none;
+  }
 }
 
 .fh-header__main {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1154,6 +1154,10 @@ body.fh-mobile-menu-open {
 /* End Section: FH Header Base Layout */
 
 /* Section: Page Header Background */
+#page-header-parent {
+  padding: 0;
+}
+
 #page-header {
   background-color: #ffffff !important;
 }

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -116,6 +116,48 @@ fhOnReady(function () {
 });
 // End Section: FH account menu toggle behaviour
 
+// Section: FH desktop header scroll behaviour
+fhOnReady(function () {
+  const header = document.querySelector('[data-fh-header-root]');
+
+  if (!header) return;
+
+  const desktopMediaQuery = window.matchMedia('(min-width: 992px)');
+  const scrolledClassName = 'fh-header--scrolled';
+
+  function updateHeaderState() {
+    if (!desktopMediaQuery.matches) {
+      header.classList.remove(scrolledClassName);
+      return;
+    }
+
+    if (window.scrollY > 0) {
+      header.classList.add(scrolledClassName);
+    } else {
+      header.classList.remove(scrolledClassName);
+    }
+  }
+
+  function handleScroll() {
+    updateHeaderState();
+  }
+
+  function handleMediaChange() {
+    updateHeaderState();
+  }
+
+  if (typeof desktopMediaQuery.addEventListener === 'function') {
+    desktopMediaQuery.addEventListener('change', handleMediaChange);
+  } else if (typeof desktopMediaQuery.addListener === 'function') {
+    desktopMediaQuery.addListener(handleMediaChange);
+  }
+
+  window.addEventListener('scroll', handleScroll, { passive: true });
+
+  updateHeaderState();
+});
+// End Section: FH desktop header scroll behaviour
+
 // Section: FH mobile navigation toggle
 fhOnReady(function () {
   const header = document.querySelector('[data-fh-header-root]');


### PR DESCRIPTION
## Summary
- allow the FH header top bar to render across the full viewport width on desktop
- add scroll handling so the FH top bar hides after leaving the top of the page while keeping the rest of the header sticky

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dbe3a34c388331b806daeeda70b62b