### PR TITLE
Adjust header top bar behavior on desktop

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -31,16 +31,29 @@
 }
 
 .fh-header__top-bar {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 48px;
   padding: 10px 32px;
-  background: linear-gradient(90deg, #1f2937, #0f172a);
   color: #ffffff;
   font-size: 13px;
   letter-spacing: 0.3px;
   text-transform: uppercase;
+}
+
+.fh-header__top-bar::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100vw;
+  height: 100%;
+  background: linear-gradient(90deg, #1f2937, #0f172a);
+  z-index: -1;
 }
 
 .fh-header__top-item,
@@ -61,6 +74,12 @@
   height: 6px;
   border-radius: 50%;
   background-color: #38bdf8;
+}
+
+@media (min-width: 992px) {
+  .fh-header--top-hidden .fh-header__top-bar {
+    display: none;
+  }
 }
 
 .fh-header__main {

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -725,6 +725,55 @@ fhOnReady(function () {
 });
 // End Section: FH mobile navigation toggle
 
+// Section: FH desktop top bar scroll visibility
+fhOnReady(function () {
+  const header = document.querySelector('[data-fh-header-root]');
+
+  if (!header) return;
+
+  const topBar = header.querySelector('.fh-header__top-bar');
+
+  if (!topBar) return;
+
+  const desktopMedia = window.matchMedia('(min-width: 992px)');
+  const hiddenClassName = 'fh-header--top-hidden';
+  let lastAppliedState = null;
+
+  function shouldHideTopBar() {
+    if (!desktopMedia.matches) return false;
+
+    return (window.pageYOffset || document.documentElement.scrollTop || 0) > 0;
+  }
+
+  function applyState(forceUpdate) {
+    const shouldHide = shouldHideTopBar();
+
+    if (!forceUpdate && shouldHide === lastAppliedState) return;
+
+    header.classList.toggle(hiddenClassName, shouldHide);
+    lastAppliedState = shouldHide;
+  }
+
+  function handleScroll() {
+    applyState(false);
+  }
+
+  function handleMediaChange() {
+    applyState(true);
+  }
+
+  window.addEventListener('scroll', handleScroll, { passive: true });
+
+  if (typeof desktopMedia.addEventListener === 'function') {
+    desktopMedia.addEventListener('change', handleMediaChange);
+  } else if (typeof desktopMedia.addListener === 'function') {
+    desktopMedia.addListener(handleMediaChange);
+  }
+
+  applyState(true);
+});
+// End Section: FH desktop top bar scroll visibility
+
 // Section: FH mobile search row scroll hide/show
 fhOnReady(function () {
   const header = document.querySelector('[data-fh-header-root]');


### PR DESCRIPTION
## Summary
- extend the desktop header benefit bar background to cover the full viewport width
- hide the desktop benefit bar once the page scrolls while keeping the main header sticky

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe3a34c388331b806daeeda70b62b