### PR TITLE
Adjust desktop header top bar behavior

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -46,6 +46,9 @@
 @media (min-width: 992px) {
   .fh-header__top-bar {
     position: relative;
+    overflow: hidden;
+    max-height: 200px;
+    transition: max-height 0.35s ease, padding-top 0.35s ease, padding-bottom 0.35s ease, opacity 0.3s ease;
   }
 
   .fh-header__top-bar::before {
@@ -58,10 +61,19 @@
     width: 100vw;
     height: 100%;
     background: linear-gradient(90deg, #1f2937, #0f172a);
+    transition: opacity 0.3s ease;
   }
 
   .fh-header--top-bar-hidden .fh-header__top-bar {
-    display: none;
+    max-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .fh-header--top-bar-hidden .fh-header__top-bar::before {
+    opacity: 0;
   }
 }
 

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -845,6 +845,7 @@ fhOnReady(function () {
   if (!topBar) return;
 
   const desktopMedia = window.matchMedia('(min-width: 992px)');
+  const HIDE_SCROLL_THRESHOLD = 24;
   const raf =
     typeof window.requestAnimationFrame === 'function'
       ? window.requestAnimationFrame.bind(window)
@@ -862,7 +863,7 @@ fhOnReady(function () {
     }
 
     const scrollPosition = window.pageYOffset || document.documentElement.scrollTop || 0;
-    const shouldHide = scrollPosition > 0;
+    const shouldHide = scrollPosition > HIDE_SCROLL_THRESHOLD;
 
     header.classList.toggle('fh-header--top-bar-hidden', shouldHide);
   }


### PR DESCRIPTION
## Summary
- extend the desktop header top bar background so it spans the full viewport width
- add scroll-based logic to hide the desktop top bar once the page is scrolled

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dbe3a34c388331b806daeeda70b62b