### PR TITLE
Smooth desktop header top bar transition

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -43,6 +43,45 @@
   text-transform: uppercase;
 }
 
+@media (min-width: 992px) {
+  .fh-header__top-bar {
+    position: relative;
+    overflow: hidden;
+    max-height: var(--fh-header-top-bar-height, 120px);
+    transition:
+      max-height 0.35s ease,
+      padding-top 0.35s ease,
+      padding-bottom 0.35s ease,
+      opacity 0.25s ease;
+  }
+
+  .fh-header__top-bar::before {
+    content: "";
+    position: absolute;
+    z-index: -1;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100vw;
+    height: 100%;
+    background: linear-gradient(90deg, #1f2937, #0f172a);
+  }
+
+  .fh-header--top-bar-hidden .fh-header__top-bar {
+    opacity: 0;
+    max-height: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    pointer-events: none;
+  }
+}
+
+@media (min-width: 992px) and (prefers-reduced-motion: reduce) {
+  .fh-header__top-bar {
+    transition: none;
+  }
+}
+
 .fh-header__top-item,
 .fh-header__top-link {
   display: inline-flex;

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -834,6 +834,83 @@ fhOnReady(function () {
 });
 // End Section: FH mobile search row scroll hide/show
 
+// Section: FH desktop top bar visibility on scroll
+fhOnReady(function () {
+  const header = document.querySelector('[data-fh-header-root]');
+
+  if (!header) return;
+
+  const topBar = header.querySelector('.fh-header__top-bar');
+
+  if (!topBar) return;
+
+  const desktopMedia = window.matchMedia('(min-width: 992px)');
+  const raf =
+    typeof window.requestAnimationFrame === 'function'
+      ? window.requestAnimationFrame.bind(window)
+      : function (callback) {
+          return window.setTimeout(callback, 16);
+        };
+  let ticking = false;
+  const hideThreshold = 8;
+  let cachedExpandedHeight = null;
+
+  function syncTopBarHeight() {
+    if (!desktopMedia.matches) {
+      cachedExpandedHeight = null;
+      topBar.style.removeProperty('--fh-header-top-bar-height');
+      return;
+    }
+
+    if (header.classList.contains('fh-header--top-bar-hidden')) return;
+
+    const measuredHeight = topBar.scrollHeight;
+
+    if (!measuredHeight || measuredHeight === cachedExpandedHeight) return;
+
+    cachedExpandedHeight = measuredHeight;
+    topBar.style.setProperty('--fh-header-top-bar-height', measuredHeight + 'px');
+  }
+
+  function applyTopBarState() {
+    ticking = false;
+
+    if (!desktopMedia.matches) {
+      header.classList.remove('fh-header--top-bar-hidden');
+      syncTopBarHeight();
+      return;
+    }
+
+    const scrollPosition = window.pageYOffset || document.documentElement.scrollTop || 0;
+    const shouldHide = scrollPosition > hideThreshold;
+
+    header.classList.toggle('fh-header--top-bar-hidden', shouldHide);
+
+    if (!shouldHide) {
+      syncTopBarHeight();
+    }
+  }
+
+  function requestTopBarUpdate() {
+    if (ticking) return;
+
+    ticking = true;
+    raf(applyTopBarState);
+  }
+
+  window.addEventListener('scroll', requestTopBarUpdate, { passive: true });
+  window.addEventListener('resize', requestTopBarUpdate);
+
+  if (typeof desktopMedia.addEventListener === 'function') {
+    desktopMedia.addEventListener('change', requestTopBarUpdate);
+  } else if (typeof desktopMedia.addListener === 'function') {
+    desktopMedia.addListener(requestTopBarUpdate);
+  }
+
+  requestTopBarUpdate();
+});
+// End Section: FH desktop top bar visibility on scroll
+
 // Section: FH Merkliste button enhancements
 fhOnReady(function () {
   const iconMarkup =


### PR DESCRIPTION
## Summary
- animate the desktop header top bar collapse instead of abruptly removing it
- drive the desktop top bar visibility with scroll-aware logic that caches its expanded height for smoother transitions

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbe3a34c388331b806daeeda70b62b