### PR TITLE
Improve desktop header top bar scroll handling

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -66,6 +66,14 @@
 }
 
 @media (min-width: 992px) {
+  .fh-header__top-bar {
+    position: relative;
+    overflow: hidden;
+    max-height: 120px;
+    transition: max-height 0.28s ease, opacity 0.2s ease, padding 0.28s ease;
+    will-change: max-height, opacity;
+  }
+
   .fh-header__top-bar::before {
     content: "";
     position: absolute;
@@ -78,8 +86,16 @@
     z-index: -1;
   }
 
-  .fh-header--scrolled .fh-header__top-bar {
-    display: none;
+  .fh-header--top-hidden .fh-header__top-bar {
+    max-height: 0;
+    opacity: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    pointer-events: none;
+  }
+
+  .fh-header--scrolled .fh-header__main {
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
   }
 }
 


### PR DESCRIPTION
## Summary
- add smooth transition styles for the desktop header top bar and retain a subtle shadow while scrolling
- enhance the desktop scroll script to hide the top bar only when scrolling down and restore it on scroll up with throttled updates

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68dceef169088331aa62a0ca482481e9