### PR TITLE
Add consistent border radius styling for form elements

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1563,6 +1563,26 @@ button[data-testing="quantity-btn-decrease"],
 }
 /* End Section: Input Unit Border Radius */
 
+/* Section: Form Control Border Radius */
+.custom-select {
+  border-radius: 6px;
+}
+
+.form-control {
+  border-radius: 6px;
+}
+
+.page-item:first-child .page-link {
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+}
+
+.page-item:last-child .page-link {
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+/* End Section: Form Control Border Radius */
+
 /* Section: Method list item label padding */
 .cmp-method-list .method-list-item label {
   padding-right: 0px;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -300,6 +300,26 @@ button[data-testing="quantity-btn-decrease"],
 }
 /* End Section: Input Unit Border Radius */
 
+/* Section: Form Control Border Radius */
+.custom-select {
+  border-radius: 6px;
+}
+
+.form-control {
+  border-radius: 6px;
+}
+
+.page-item:first-child .page-link {
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+}
+
+.page-item:last-child .page-link {
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+/* End Section: Form Control Border Radius */
+
 /* Section: Method list item label padding */
 .cmp-method-list .method-list-item label {
   padding-right: 0px;


### PR DESCRIPTION
## Summary
- add consistent 6px border radius styling for custom selects, form controls, and pagination links in FH theme
- mirror the same border radius updates in the SH stylesheet for parity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcff5be14c8331afa727f30ffbc524