### PR TITLE
Ensure header and footer gradients span full viewport

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -45,7 +45,8 @@
   letter-spacing: 0.3px;
   text-transform: uppercase;
   z-index: 1;
-  overflow: hidden;
+  overflow: visible;
+  isolation: isolate;
   visibility: visible;
   box-sizing: border-box;
   max-height: var(--fh-top-bar-max-height, 56px);
@@ -53,6 +54,20 @@
     visibility 0s linear 0s;
   transition-delay: 0s, 0s, 0s, 0s;
   will-change: max-height, padding, opacity;
+}
+
+.fh-header__top-bar::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 100vw;
+  height: 100%;
+  transform: translateX(-50%);
+  background: inherit;
+  z-index: -1;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
 }
 
 .fh-header__top-item,
@@ -75,20 +90,6 @@
   background-color: #38bdf8;
 }
 
-@media (min-width: 992px) {
-  .fh-header__top-bar::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 50%;
-    width: 100vw;
-    height: 100%;
-    transform: translateX(-50%);
-    background: inherit;
-    z-index: -1;
-  }
-}
-
 .fh-header--topbar-hidden {
   --fh-top-bar-padding-y: 0px;
 }
@@ -100,6 +101,39 @@
   visibility: hidden;
   transition-delay: 0s, 0s, 0s, 0.35s;
 }
+
+.fh-header--topbar-hidden .fh-header__top-bar::before {
+  opacity: 0;
+}
+
+/* Section: FH Footer Base Layout */
+.fh-footer {
+  position: relative;
+  isolation: isolate;
+}
+
+.fh-footer::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 100vw;
+  height: 100%;
+  transform: translateX(-50%);
+  background: linear-gradient(to bottom, #ffffff, #f1f1f1);
+  border-top: 8px solid #000000;
+  box-sizing: border-box;
+  z-index: -1;
+  pointer-events: none;
+}
+
+.fh-footer__inner {
+  max-width: 1600px;
+  margin: 0 auto;
+  padding: 40px 20px;
+  font-size: 0.9rem;
+}
+/* End Section: FH Footer Base Layout */
 
 .fh-header__main {
   display: grid;

--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -1,73 +1,75 @@
-<div style="max-width:1600px;margin:0 auto;border-top:8px solid #000;background:linear-gradient(to bottom,#ffffff,#f1f1f1);padding:40px 20px;font-size:0.9rem;">
-  <div class="row">
-    <div class="col-md-4 col-lg-3">
-      <h5 class="d-flex align-items-center font-weight-bold mb-3"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/info_14574710.svg" alt="Infos" style="height:20px" class="mr-2">Infos</h5>
-      <ul class="list-unstyled">
-        <li><a class="text-reset text-decoration-none" href="/versandkosten">Versand</a></li>
-        <li><a class="text-reset text-decoration-none" href="/zahlungsarten">Zahlungsmöglichkeiten</a></li>
-        <li><a class="text-reset text-decoration-none" href="/contact">Kontakt</a></li>
-        <li><a class="text-reset text-decoration-none" href="#">Verpackung und Umwelt</a></li>
-        <li><a class="text-reset text-decoration-none" href="/Retourenabwicklung">Rücksendungen</a></li>
-        <li><a class="text-reset text-decoration-none" href="/ueber-uns">Über uns</a></li>
-        <li><a class="text-reset text-decoration-none" href="#">HAMMER Bonus</a></li>
-      </ul>
-    </div>
-    <div class="col-md-4 col-lg-3">
-      <h5 class="d-flex align-items-center font-weight-bold mb-3"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/workgroup_12886873.svg" alt="Community" style="height:20px" class="mr-2">Community</h5>
-      <ul class="list-unstyled">
-        <li><a class="text-reset text-decoration-none" href="#">Neuste Beiträge</a></li>
-        <li><a class="text-reset text-decoration-none" href="#">HAMMER Erklärvideos</a></li>
-        <li><a class="text-reset text-decoration-none" href="#">Community Beiträge</a></li>
-        <li><a class="text-reset text-decoration-none" href="#">Botschafter Programm</a></li>
-      </ul>
-      <h6>Werde Teil der Community:</h6>
-      <div class="d-flex align-items-center">
-        <a href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Instagram.png" alt="Instagram" style="height:32px" class="mr-2"></a>
-        <a href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/TikTok.png" alt="TikTok" style="height:32px" class="mr-2"></a>
-        <a href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/YouTube.png" alt="YouTube" style="height:32px" class="mr-2"></a>
-        <a href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Pinterest.png" alt="Pinterest" style="height:32px"></a>
+<div class="fh-footer">
+  <div class="fh-footer__inner">
+    <div class="row">
+      <div class="col-md-4 col-lg-3">
+        <h5 class="d-flex align-items-center font-weight-bold mb-3"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/info_14574710.svg" alt="Infos" style="height:20px" class="mr-2">Infos</h5>
+        <ul class="list-unstyled">
+          <li><a class="text-reset text-decoration-none" href="/versandkosten">Versand</a></li>
+          <li><a class="text-reset text-decoration-none" href="/zahlungsarten">Zahlungsmöglichkeiten</a></li>
+          <li><a class="text-reset text-decoration-none" href="/contact">Kontakt</a></li>
+          <li><a class="text-reset text-decoration-none" href="#">Verpackung und Umwelt</a></li>
+          <li><a class="text-reset text-decoration-none" href="/Retourenabwicklung">Rücksendungen</a></li>
+          <li><a class="text-reset text-decoration-none" href="/ueber-uns">Über uns</a></li>
+          <li><a class="text-reset text-decoration-none" href="#">HAMMER Bonus</a></li>
+        </ul>
+      </div>
+      <div class="col-md-4 col-lg-3">
+        <h5 class="d-flex align-items-center font-weight-bold mb-3"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/workgroup_12886873.svg" alt="Community" style="height:20px" class="mr-2">Community</h5>
+        <ul class="list-unstyled">
+          <li><a class="text-reset text-decoration-none" href="#">Neuste Beiträge</a></li>
+          <li><a class="text-reset text-decoration-none" href="#">HAMMER Erklärvideos</a></li>
+          <li><a class="text-reset text-decoration-none" href="#">Community Beiträge</a></li>
+          <li><a class="text-reset text-decoration-none" href="#">Botschafter Programm</a></li>
+        </ul>
+        <h6>Werde Teil der Community:</h6>
+        <div class="d-flex align-items-center">
+          <a href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Instagram.png" alt="Instagram" style="height:32px" class="mr-2"></a>
+          <a href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/TikTok.png" alt="TikTok" style="height:32px" class="mr-2"></a>
+          <a href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/YouTube.png" alt="YouTube" style="height:32px" class="mr-2"></a>
+          <a href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Pinterest.png" alt="Pinterest" style="height:32px"></a>
+        </div>
+      </div>
+      <div class="col-md-4 col-lg-3">
+        <h5 class="d-flex align-items-center font-weight-bold mb-3"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/balance_2970715.svg" alt="Rechtliches" style="height:20px" class="mr-2">Rechtliches</h5>
+        <ul class="list-unstyled">
+          <li><a class="text-reset text-decoration-none" href="/Impressum">Impressum</a></li>
+          <li><a class="text-reset text-decoration-none" href="/agb">Allgemeine Geschäftsbedingungen</a></li>
+          <li><a class="text-reset text-decoration-none" href="/Datenschutz">Datenschutz</a></li>
+          <li><a class="text-reset text-decoration-none" href="#">Barrierefreiheit</a></li>
+          <li><a class="text-reset text-decoration-none" href="#">Widerrufsbelehrung</a></li>
+        </ul>
+      </div>
+      <div class="col-lg-3">
+        <h5 class="font-weight-bold mb-3">Bezahl bei uns</h5>
+        <div class="d-flex flex-wrap align-items-center">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Apple_Pay.png" alt="Apple Pay" style="height:32px" class="m-1">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/PayPal.png" alt="PayPal" style="height:32px" class="m-1">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Klarna.png" alt="Klarna" style="height:32px" class="m-1">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/American_Express.png" alt="American Express" style="height:32px" class="m-1">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Mastercard.png" alt="Mastercard" style="height:32px" class="m-1">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Visa.png" alt="Visa" style="height:32px" class="m-1">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Billie_Rechnungskauf_fuer_Fimrnen.png" alt="Billie Rechnungskauf für Firmen" style="height:32px" class="m-1">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Vorkasse.png" alt="Vorkasse" style="height:32px" class="m-1">
+        </div>
+        <h6 class="mt-3">Wir versenden mit</h6>
+        <div class="d-flex flex-wrap align-items-center">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand" style="height:32px" class="m-1">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express" style="height:32px" class="m-1">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer" style="height:32px" class="m-1">
+        </div>
       </div>
     </div>
-    <div class="col-md-4 col-lg-3">
-      <h5 class="d-flex align-items-center font-weight-bold mb-3"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/balance_2970715.svg" alt="Rechtliches" style="height:20px" class="mr-2">Rechtliches</h5>
-      <ul class="list-unstyled">
-        <li><a class="text-reset text-decoration-none" href="/Impressum">Impressum</a></li>
-        <li><a class="text-reset text-decoration-none" href="/agb">Allgemeine Geschäftsbedingungen</a></li>
-        <li><a class="text-reset text-decoration-none" href="/Datenschutz">Datenschutz</a></li>
-        <li><a class="text-reset text-decoration-none" href="#">Barrierefreiheit</a></li>
-        <li><a class="text-reset text-decoration-none" href="#">Widerrufsbelehrung</a></li>
-      </ul>
-    </div>
-    <div class="col-lg-3">
-      <h5 class="font-weight-bold mb-3">Bezahl bei uns</h5>
-      <div class="d-flex flex-wrap align-items-center">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Apple_Pay.png" alt="Apple Pay" style="height:32px" class="m-1">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/PayPal.png" alt="PayPal" style="height:32px" class="m-1">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Klarna.png" alt="Klarna" style="height:32px" class="m-1">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/American_Express.png" alt="American Express" style="height:32px" class="m-1">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Mastercard.png" alt="Mastercard" style="height:32px" class="m-1">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Visa.png" alt="Visa" style="height:32px" class="m-1">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Billie_Rechnungskauf_fuer_Fimrnen.png" alt="Billie Rechnungskauf für Firmen" style="height:32px" class="m-1">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Vorkasse.png" alt="Vorkasse" style="height:32px" class="m-1">
+    <div class="row mt-4 text-center">
+      <div class="col-12">
+        <div class="d-flex justify-content-center align-items-center mb-3">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="Schraubenhammer" style="height:80px;width:auto;" class="mr-3">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer" style="height:80px;width:auto;">
+        </div>
+        <p class="mb-0 small">Onlineshops der INTRA-TEC GmbH <a class="text-reset text-decoration-none d-inline-flex align-items-center" href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/LinkedIn.png" alt="LinkedIn" style="height:16px" class="mr-1"></a><br>
+        Stegerwaldstraße 1b &amp; 1d, 51427 Bergisch Gladbach<br>
+        Öffnungszeiten: Mo-Fr von 8-13 Uhr &amp; 13:30 bis 16 Uhr<br>
+        24/7 Telefonisch erreichbar unter 02204 910 980</p>
       </div>
-      <h6 class="mt-3">Wir versenden mit</h6>
-      <div class="d-flex flex-wrap align-items-center">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand" style="height:32px" class="m-1">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express" style="height:32px" class="m-1">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer" style="height:32px" class="m-1">
-      </div>
-    </div>
-  </div>
-  <div class="row mt-4 text-center">
-    <div class="col-12">
-      <div class="d-flex justify-content-center align-items-center mb-3">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="Schraubenhammer" style="height:80px;width:auto;" class="mr-3">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer" style="height:80px;width:auto;">
-      </div>
-      <p class="mb-0 small">Onlineshops der INTRA-TEC GmbH <a class="text-reset text-decoration-none d-inline-flex align-items-center" href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/LinkedIn.png" alt="LinkedIn" style="height:16px" class="mr-1"></a><br>
-      Stegerwaldstraße 1b &amp; 1d, 51427 Bergisch Gladbach<br>
-      Öffnungszeiten: Mo-Fr von 8-13 Uhr &amp; 13:30 bis 16 Uhr<br>
-      24/7 Telefonisch erreichbar unter 02204 910 980</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- extend the top bar gradient beyond the constrained header width via an overlay pseudo element while preserving the hide-on-scroll animation
- wrap the footer markup in structural classes and add CSS so its gradient background and border span the full viewport

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd15a111d083319573c4332bf255a2