### PR TITLE
Add persistent drop shadow to FH header

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -30,6 +30,7 @@
   max-width: 1600px; /* Do not change this for Desktop viewport*/
   --fh-top-bar-max-height: 72px;
   --fh-top-bar-padding-y: 14px;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
 }
 
 .fh-header__top-bar {


### PR DESCRIPTION
## Summary
- add a subtle bottom drop shadow to the FH header container so it stays visible in both expanded and compact states

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd1f5e8930833188c4bd6d773c73b6