### PR TITLE
Add subtle drop shadow to FH header

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -22,6 +22,7 @@
 /* Section: FH Header Base Layout */
 .fh-header {
   position: relative;
+  isolation: isolate;
   z-index: 1000;
   margin: 0 auto;
   color: #1a1a1a;
@@ -30,6 +31,26 @@
   max-width: 1600px; /* Do not change this for Desktop viewport*/
   --fh-top-bar-max-height: 72px;
   --fh-top-bar-padding-y: 14px;
+}
+
+.fh-header::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: -1px;
+  transform: translateX(-50%);
+  width: 100vw;
+  max-width: 100vw;
+  height: 28px;
+  pointer-events: none;
+  z-index: -1;
+  background: linear-gradient(
+    to bottom,
+    rgba(15, 23, 42, 0.12),
+    rgba(15, 23, 42, 0.05) 45%,
+    rgba(15, 23, 42, 0)
+  );
+  opacity: 1;
 }
 
 .fh-header__top-bar {


### PR DESCRIPTION
## Summary
- add a stacking context to the FH header so decorative layers can sit behind the content
- render a viewport-wide linear gradient pseudo-element to provide a subtle shadow at the bottom edge of the header

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd1f5e8930833188c4bd6d773c73b6