### PR TITLE
Revamp FH footer layout for responsive styling

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -110,6 +110,8 @@
 .fh-footer {
   position: relative;
   isolation: isolate;
+  color: #0f172a;
+  font-family: "Open Sans", Arial, sans-serif;
 }
 
 .fh-footer::before {
@@ -120,8 +122,8 @@
   width: 100vw;
   height: 100%;
   transform: translateX(-50%);
-  background: linear-gradient(to bottom, #ffffff, #f1f1f1);
-  border-top: 8px solid #000000;
+  background: linear-gradient(180deg, #ffffff 0%, #f6f7fb 40%, #eef2ff 100%);
+  border-top: 6px solid #2563eb;
   box-sizing: border-box;
   z-index: -1;
   pointer-events: none;
@@ -130,8 +132,287 @@
 .fh-footer__inner {
   max-width: 1600px;
   margin: 0 auto;
-  padding: 40px 20px;
+  padding: 56px 24px 36px;
+  font-size: 0.95rem;
+}
+
+.fh-footer__content {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 40px;
+}
+
+.fh-footer__column {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 0;
+}
+
+.fh-footer__heading {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #1e293b;
+}
+
+.fh-footer__heading::after {
+  content: "";
+  flex: 1 1 auto;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(37, 99, 235, 0.25) 0%, rgba(14, 165, 233, 0) 70%);
+}
+
+.fh-footer__heading-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.fh-footer__heading-icon img {
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+}
+
+.fh-footer__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.fh-footer__list a {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: inherit;
+  text-decoration: none;
+  padding: 4px 0;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.fh-footer__list a::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: #2563eb;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.fh-footer__list a:hover,
+.fh-footer__list a:focus {
+  color: #2563eb;
+  transform: translateX(2px);
+}
+
+.fh-footer__list a:hover::before,
+.fh-footer__list a:focus::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.fh-footer__community {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.fh-footer__sub-heading {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: #475569;
+}
+
+.fh-footer__social {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
+  gap: 12px;
+  max-width: 220px;
+}
+
+.fh-footer__social-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: #ffffff;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fh-footer__social-link:hover,
+.fh-footer__social-link:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.18);
+}
+
+.fh-footer__social-link img {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+}
+
+.fh-footer__badge-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  gap: 12px;
+  align-items: center;
+}
+
+.fh-footer__badge-grid img {
+  width: 100%;
+  max-width: 110px;
+  height: auto;
+  filter: drop-shadow(0 6px 12px rgba(15, 23, 42, 0.08));
+  border-radius: 12px;
+  background: #ffffff;
+  padding: 6px 10px;
+}
+
+.fh-footer__bottom {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 32px;
+  margin-top: 48px;
+  padding-top: 36px;
+  border-top: 1px solid rgba(148, 163, 184, 0.4);
+  color: #475569;
+}
+
+.fh-footer__brands {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  flex-wrap: wrap;
+}
+
+.fh-footer__brands img {
+  max-height: 72px;
+  width: auto;
+  filter: drop-shadow(0 12px 22px rgba(15, 23, 42, 0.12));
+  border-radius: 18px;
+  background: #ffffff;
+  padding: 10px 18px;
+}
+
+.fh-footer__legal {
+  display: grid;
+  gap: 8px;
   font-size: 0.9rem;
+}
+
+.fh-footer__legal p {
+  margin: 0;
+}
+
+.fh-footer__legal a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.fh-footer__legal a:hover,
+.fh-footer__legal a:focus {
+  color: #2563eb;
+}
+
+@media (max-width: 1199.98px) {
+  .fh-footer__content {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 32px;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .fh-footer__inner {
+    padding: 48px 20px 32px;
+  }
+
+  .fh-footer__content {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 28px;
+  }
+
+  .fh-footer__bottom {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .fh-footer__brands {
+    justify-content: center;
+  }
+
+  .fh-footer__legal {
+    justify-items: center;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .fh-footer__inner {
+    padding: 44px 16px 28px;
+  }
+
+  .fh-footer__content {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 20px;
+  }
+
+  .fh-footer__heading {
+    font-size: 1rem;
+  }
+
+  .fh-footer__heading::after {
+    display: none;
+  }
+
+  .fh-footer__badge-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .fh-footer__social {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .fh-footer__badge-grid img {
+    max-width: none;
+  }
+}
+
+@media (max-width: 420px) {
+  .fh-footer__content {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+  }
+
+  .fh-footer__social-link {
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+  }
+
+  .fh-footer__social-link img {
+    width: 22px;
+    height: 22px;
+  }
 }
 /* End Section: FH Footer Base Layout */
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -242,11 +242,12 @@
   color: #475569;
 }
 
+
 .fh-footer__social {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 12px;
-  max-width: 220px;
+  max-width: 100%;
 }
 
 .fh-footer__social-link {
@@ -257,14 +258,12 @@
   height: 44px;
   border-radius: 14px;
   background: #ffffff;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease;
 }
 
 .fh-footer__social-link:hover,
 .fh-footer__social-link:focus {
   transform: translateY(-2px);
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.18);
 }
 
 .fh-footer__social-link img {
@@ -280,11 +279,14 @@
   align-items: center;
 }
 
+.fh-footer__badge-grid--payments {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
 .fh-footer__badge-grid img {
   width: 100%;
   max-width: 110px;
   height: auto;
-  filter: drop-shadow(0 6px 12px rgba(15, 23, 42, 0.08));
   border-radius: 12px;
   background: #ffffff;
   padding: 6px 10px;
@@ -307,23 +309,29 @@
   flex-wrap: wrap;
 }
 
-.fh-footer__brands img {
+.fh-footer__brand-logo {
   max-height: 72px;
   width: auto;
-  filter: drop-shadow(0 12px 22px rgba(15, 23, 42, 0.12));
-  border-radius: 18px;
-  background: #ffffff;
-  padding: 10px 18px;
+  padding: 0;
+  background: transparent;
+  filter: none;
 }
 
 .fh-footer__legal {
   display: grid;
   gap: 8px;
-  font-size: 0.9rem;
+  font-size: 1rem;
+  line-height: 1.6;
 }
 
 .fh-footer__legal p {
   margin: 0;
+}
+
+.fh-footer__legal p:first-child {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1e293b;
 }
 
 .fh-footer__legal a {
@@ -389,8 +397,12 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .fh-footer__badge-grid--payments {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
   .fh-footer__social {
-    grid-template-columns: repeat(2, 1fr);
+    flex-wrap: nowrap;
   }
 
   .fh-footer__badge-grid img {

--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -33,17 +33,17 @@
         </ul>
         <div class="fh-footer__community">
           <h6 class="fh-footer__sub-heading">Werde Teil der Community</h6>
-          <div class="fh-footer__social">
-            <a class="fh-footer__social-link" href="#" aria-label="Instagram">
+          <div class="fh-footer__social" role="list">
+            <a class="fh-footer__social-link" href="#" aria-label="Instagram" role="listitem">
               <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Instagram.png" alt="Instagram">
             </a>
-            <a class="fh-footer__social-link" href="#" aria-label="TikTok">
+            <a class="fh-footer__social-link" href="#" aria-label="TikTok" role="listitem">
               <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/TikTok.png" alt="TikTok">
             </a>
-            <a class="fh-footer__social-link" href="#" aria-label="YouTube">
+            <a class="fh-footer__social-link" href="#" aria-label="YouTube" role="listitem">
               <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/YouTube.png" alt="YouTube">
             </a>
-            <a class="fh-footer__social-link" href="#" aria-label="Pinterest">
+            <a class="fh-footer__social-link" href="#" aria-label="Pinterest" role="listitem">
               <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Pinterest.png" alt="Pinterest">
             </a>
           </div>
@@ -66,7 +66,7 @@
       </section>
       <section class="fh-footer__column">
         <h5 class="fh-footer__heading">Bezahl bei uns</h5>
-        <div class="fh-footer__badge-grid" aria-label="Akzeptierte Zahlungsmethoden">
+        <div class="fh-footer__badge-grid fh-footer__badge-grid--payments" aria-label="Akzeptierte Zahlungsmethoden">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Apple_Pay.png" alt="Apple Pay">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/PayPal.png" alt="PayPal">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Klarna.png" alt="Klarna">
@@ -86,8 +86,8 @@
     </div>
     <div class="fh-footer__bottom">
       <div class="fh-footer__brands">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="Schraubenhammer">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer">
+        <img class="fh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="Schraubenhammer">
+        <img class="fh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer">
       </div>
       <div class="fh-footer__legal">
         <p>

--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -1,74 +1,104 @@
 <div class="fh-footer">
   <div class="fh-footer__inner">
-    <div class="row">
-      <div class="col-md-4 col-lg-3">
-        <h5 class="d-flex align-items-center font-weight-bold mb-3"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/info_14574710.svg" alt="Infos" style="height:20px" class="mr-2">Infos</h5>
-        <ul class="list-unstyled">
-          <li><a class="text-reset text-decoration-none" href="/versandkosten">Versand</a></li>
-          <li><a class="text-reset text-decoration-none" href="/zahlungsarten">Zahlungsmöglichkeiten</a></li>
-          <li><a class="text-reset text-decoration-none" href="/contact">Kontakt</a></li>
-          <li><a class="text-reset text-decoration-none" href="#">Verpackung und Umwelt</a></li>
-          <li><a class="text-reset text-decoration-none" href="/Retourenabwicklung">Rücksendungen</a></li>
-          <li><a class="text-reset text-decoration-none" href="/ueber-uns">Über uns</a></li>
-          <li><a class="text-reset text-decoration-none" href="#">HAMMER Bonus</a></li>
+    <div class="fh-footer__content">
+      <section class="fh-footer__column">
+        <h5 class="fh-footer__heading">
+          <span class="fh-footer__heading-icon">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/info_14574710.svg" alt="Infos">
+          </span>
+          Infos
+        </h5>
+        <ul class="fh-footer__list">
+          <li><a href="/versandkosten">Versand</a></li>
+          <li><a href="/zahlungsarten">Zahlungsmöglichkeiten</a></li>
+          <li><a href="/contact">Kontakt</a></li>
+          <li><a href="#">Verpackung und Umwelt</a></li>
+          <li><a href="/Retourenabwicklung">Rücksendungen</a></li>
+          <li><a href="/ueber-uns">Über uns</a></li>
+          <li><a href="#">HAMMER Bonus</a></li>
         </ul>
-      </div>
-      <div class="col-md-4 col-lg-3">
-        <h5 class="d-flex align-items-center font-weight-bold mb-3"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/workgroup_12886873.svg" alt="Community" style="height:20px" class="mr-2">Community</h5>
-        <ul class="list-unstyled">
-          <li><a class="text-reset text-decoration-none" href="#">Neuste Beiträge</a></li>
-          <li><a class="text-reset text-decoration-none" href="#">HAMMER Erklärvideos</a></li>
-          <li><a class="text-reset text-decoration-none" href="#">Community Beiträge</a></li>
-          <li><a class="text-reset text-decoration-none" href="#">Botschafter Programm</a></li>
+      </section>
+      <section class="fh-footer__column">
+        <h5 class="fh-footer__heading">
+          <span class="fh-footer__heading-icon">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/workgroup_12886873.svg" alt="Community">
+          </span>
+          Community
+        </h5>
+        <ul class="fh-footer__list">
+          <li><a href="#">Neuste Beiträge</a></li>
+          <li><a href="#">HAMMER Erklärvideos</a></li>
+          <li><a href="#">Community Beiträge</a></li>
+          <li><a href="#">Botschafter Programm</a></li>
         </ul>
-        <h6>Werde Teil der Community:</h6>
-        <div class="d-flex align-items-center">
-          <a href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Instagram.png" alt="Instagram" style="height:32px" class="mr-2"></a>
-          <a href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/TikTok.png" alt="TikTok" style="height:32px" class="mr-2"></a>
-          <a href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/YouTube.png" alt="YouTube" style="height:32px" class="mr-2"></a>
-          <a href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Pinterest.png" alt="Pinterest" style="height:32px"></a>
+        <div class="fh-footer__community">
+          <h6 class="fh-footer__sub-heading">Werde Teil der Community</h6>
+          <div class="fh-footer__social">
+            <a class="fh-footer__social-link" href="#" aria-label="Instagram">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Instagram.png" alt="Instagram">
+            </a>
+            <a class="fh-footer__social-link" href="#" aria-label="TikTok">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/TikTok.png" alt="TikTok">
+            </a>
+            <a class="fh-footer__social-link" href="#" aria-label="YouTube">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/YouTube.png" alt="YouTube">
+            </a>
+            <a class="fh-footer__social-link" href="#" aria-label="Pinterest">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Pinterest.png" alt="Pinterest">
+            </a>
+          </div>
         </div>
-      </div>
-      <div class="col-md-4 col-lg-3">
-        <h5 class="d-flex align-items-center font-weight-bold mb-3"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/balance_2970715.svg" alt="Rechtliches" style="height:20px" class="mr-2">Rechtliches</h5>
-        <ul class="list-unstyled">
-          <li><a class="text-reset text-decoration-none" href="/Impressum">Impressum</a></li>
-          <li><a class="text-reset text-decoration-none" href="/agb">Allgemeine Geschäftsbedingungen</a></li>
-          <li><a class="text-reset text-decoration-none" href="/Datenschutz">Datenschutz</a></li>
-          <li><a class="text-reset text-decoration-none" href="#">Barrierefreiheit</a></li>
-          <li><a class="text-reset text-decoration-none" href="#">Widerrufsbelehrung</a></li>
+      </section>
+      <section class="fh-footer__column">
+        <h5 class="fh-footer__heading">
+          <span class="fh-footer__heading-icon">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/balance_2970715.svg" alt="Rechtliches">
+          </span>
+          Rechtliches
+        </h5>
+        <ul class="fh-footer__list">
+          <li><a href="/Impressum">Impressum</a></li>
+          <li><a href="/agb">Allgemeine Geschäftsbedingungen</a></li>
+          <li><a href="/Datenschutz">Datenschutz</a></li>
+          <li><a href="#">Barrierefreiheit</a></li>
+          <li><a href="#">Widerrufsbelehrung</a></li>
         </ul>
-      </div>
-      <div class="col-lg-3">
-        <h5 class="font-weight-bold mb-3">Bezahl bei uns</h5>
-        <div class="d-flex flex-wrap align-items-center">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Apple_Pay.png" alt="Apple Pay" style="height:32px" class="m-1">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/PayPal.png" alt="PayPal" style="height:32px" class="m-1">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Klarna.png" alt="Klarna" style="height:32px" class="m-1">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/American_Express.png" alt="American Express" style="height:32px" class="m-1">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Mastercard.png" alt="Mastercard" style="height:32px" class="m-1">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Visa.png" alt="Visa" style="height:32px" class="m-1">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Billie_Rechnungskauf_fuer_Fimrnen.png" alt="Billie Rechnungskauf für Firmen" style="height:32px" class="m-1">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Vorkasse.png" alt="Vorkasse" style="height:32px" class="m-1">
+      </section>
+      <section class="fh-footer__column">
+        <h5 class="fh-footer__heading">Bezahl bei uns</h5>
+        <div class="fh-footer__badge-grid" aria-label="Akzeptierte Zahlungsmethoden">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Apple_Pay.png" alt="Apple Pay">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/PayPal.png" alt="PayPal">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Klarna.png" alt="Klarna">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/American_Express.png" alt="American Express">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Mastercard.png" alt="Mastercard">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Visa.png" alt="Visa">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Billie_Rechnungskauf_fuer_Fimrnen.png" alt="Billie Rechnungskauf für Firmen">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Vorkasse.png" alt="Vorkasse">
         </div>
-        <h6 class="mt-3">Wir versenden mit</h6>
-        <div class="d-flex flex-wrap align-items-center">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand" style="height:32px" class="m-1">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express" style="height:32px" class="m-1">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer" style="height:32px" class="m-1">
+        <h6 class="fh-footer__sub-heading">Wir versenden mit</h6>
+        <div class="fh-footer__badge-grid" aria-label="Versanddienstleister">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer">
         </div>
-      </div>
+      </section>
     </div>
-    <div class="row mt-4 text-center">
-      <div class="col-12">
-        <div class="d-flex justify-content-center align-items-center mb-3">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="Schraubenhammer" style="height:80px;width:auto;" class="mr-3">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer" style="height:80px;width:auto;">
-        </div>
-        <p class="mb-0 small">Onlineshops der INTRA-TEC GmbH <a class="text-reset text-decoration-none d-inline-flex align-items-center" href="#"><img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/LinkedIn.png" alt="LinkedIn" style="height:16px" class="mr-1"></a><br>
-        Stegerwaldstraße 1b &amp; 1d, 51427 Bergisch Gladbach<br>
-        Öffnungszeiten: Mo-Fr von 8-13 Uhr &amp; 13:30 bis 16 Uhr<br>
-        24/7 Telefonisch erreichbar unter 02204 910 980</p>
+    <div class="fh-footer__bottom">
+      <div class="fh-footer__brands">
+        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="Schraubenhammer">
+        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer">
+      </div>
+      <div class="fh-footer__legal">
+        <p>
+          Onlineshops der INTRA-TEC GmbH
+          <a class="fh-footer__social-link" href="#" aria-label="LinkedIn">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/LinkedIn.png" alt="LinkedIn">
+          </a>
+        </p>
+        <p>Stegerwaldstraße 1b &amp; 1d, 51427 Bergisch Gladbach</p>
+        <p>Öffnungszeiten: Mo-Fr von 8-13 Uhr &amp; 13:30 bis 16 Uhr</p>
+        <p>24/7 Telefonisch erreichbar unter 02204 910 980</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- rebuild the FH footer markup into dedicated sections for info, community, legal and payment areas plus a refined brand/legal strip
- refresh the footer styling with gradients, grids, hover treatments and updated typography for a more polished desktop presentation
- add responsive rules that tighten spacing and provide a two-column mobile layout while improving social, payment and shipping badge displays

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd2709f6188331955b1e4ee036abc0