### PR TITLE
Show account contact options on separate lines

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -682,6 +682,72 @@
   color: #6b7280;
 }
 
+.fh-header__panel-contact {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+  color: #0f172a;
+}
+
+.fh-header__panel-contact-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.fh-header__panel-contact-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.fh-header__panel-contact-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.15);
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 1.25;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fh-header__panel-contact-chip:hover,
+.fh-header__panel-contact-chip:focus {
+  background: rgba(59, 130, 246, 0.25);
+  color: #0f172a;
+  text-decoration: none;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+  outline: none;
+}
+
+.fh-header__panel-contact-icon {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+}
+
+.fh-header__panel-contact-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.fh-header__panel-contact-text {
+  white-space: nowrap;
+}
+
+.fh-header__panel-contact-separator {
+  font-size: 12px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
 .fh-header__panel-inline {
   display: flex;
   align-items: center;

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -96,6 +96,30 @@
               <div class="fh-header__panel-text">Schön, dass Sie wieder da sind!</div>
             </div>
             <div class="fh-header__panel-divider mb-3"></div>
+            <div class="fh-header__panel-contact">
+              <div class="fh-header__panel-contact-label">Fragen? Sie erreichen uns hier:</div>
+              <div class="fh-header__panel-contact-line">
+                <a href="tel:02204910980" class="fh-header__panel-contact-chip">
+                  <span class="fh-header__panel-contact-icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                      <path d="M4.9 3A1.9 1.9 0 0 1 6.8 1.1l2.3.4a1.9 1.9 0 0 1 1.5 1.6l.3 2.5a1.9 1.9 0 0 1-.6 1.6L8.9 8.5a10.6 10.6 0 0 0 6.6 6.6l1.3-1.4a1.9 1.9 0 0 1 1.6-.6l2.5.3a1.9 1.9 0 0 1 1.6 1.5l.4 2.3a1.9 1.9 0 0 1-1.9 1.9h-.2A16.6 16.6 0 0 1 35.1v-.2Z" fill="currentColor"/>
+                    </svg>
+                  </span>
+                  <span class="fh-header__panel-contact-text">02204 910 980</span>
+                </a>
+                <span class="fh-header__panel-contact-separator">oder</span>
+              </div>
+              <div class="fh-header__panel-contact-line">
+                <a href="mailto:service@fenster-hammer.de" class="fh-header__panel-contact-chip">
+                  <span class="fh-header__panel-contact-icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                      <path d="M3 6.75A2.75 2.75 0 0 1 5.75 4h12.5A2.75 2.75 0 0 1 21 6.75v10.5A2.75 2.75 0 0 1 18.25 20H5.75A2.75 2.75 0 0 1 3 17.25Zm2.75-.25a.75.75 0 0 0-.75.75v.26l7 4.38 7-4.38V7.25a.75.75 0 0 0-.75-.75Z" fill="currentColor"/>
+                    </svg>
+                  </span>
+                  <span class="fh-header__panel-contact-text">service@fenster-hammer.de</span>
+                </a>
+              </div>
+            </div>
             <nav class="fh-header__panel-links mb-4">
               <a href="/my-account" class="fh-header__panel-link">Kontoübersicht</a>
               <a href="/hammer-praemien" class="fh-header__panel-link">Hammer Prämien</a>


### PR DESCRIPTION
## Summary
- revert the account menu contact label to the original phrasing and split the contact actions into individual lines
- insert an "oder" separator after the phone chip so the email address sits on its own third line
- adjust the account menu styles with a new flex line helper and separator styling for the stacked layout

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de49056ed08331888b35fcd6dcc345