### PR TITLE
Add customer class badges and contacts to header

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -682,6 +682,75 @@
   color: #6b7280;
 }
 
+.fh-header__customer-segment {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+  color: #0f172a;
+}
+
+.fh-header__customer-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-start;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.15);
+  color: #0f172a;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+}
+
+.fh-header__customer-contact {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: #1f2937;
+}
+
+.fh-header__customer-contact--personal {
+  gap: 6px;
+}
+
+.fh-header__customer-contact-label,
+.fh-header__customer-contact-heading {
+  font-size: 12px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.fh-header__customer-contact-name {
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.fh-header__contact-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 6px;
+  background: #0f172a;
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.fh-header__contact-button:hover,
+.fh-header__contact-button:focus {
+  background: #1f2937;
+  color: #ffffff;
+  text-decoration: none;
+  outline: none;
+}
+
 .fh-header__panel-contact {
   display: flex;
   flex-direction: column;

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -714,7 +714,13 @@
 }
 
 .fh-header__customer-contact--personal {
-  gap: 6px;
+  gap: 8px;
+  padding: 16px 18px;
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(219, 234, 254, 0.45) 0%, rgba(191, 219, 254, 0.25) 100%);
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+  align-self: stretch;
 }
 
 .fh-header__customer-contact-label,
@@ -724,23 +730,35 @@
   color: #1f2937;
 }
 
+.fh-header__customer-contact--personal .fh-header__customer-contact-heading {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #0f172a;
+}
+
 .fh-header__customer-contact-name {
   font-weight: 700;
   color: #0f172a;
+}
+
+.fh-header__customer-contact--personal .fh-header__customer-contact-name {
+  font-size: 15px;
 }
 
 .fh-header__contact-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 6px 12px;
-  border-radius: 6px;
+  padding: 8px 16px;
+  border-radius: 999px;
   background: #0f172a;
   color: #ffffff;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 700;
   text-decoration: none;
-  transition: background-color 0.2s ease, color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
 .fh-header__contact-button:hover,
@@ -749,6 +767,7 @@
   color: #ffffff;
   text-decoration: none;
   outline: none;
+  transform: translateY(-1px);
 }
 
 .fh-header__panel-contact {

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -95,6 +95,51 @@
               </div>
               <div class="fh-header__panel-text">Schön, dass Sie wieder da sind!</div>
             </div>
+            <div
+              class="fh-header__customer-segment"
+              v-if="$store.state.user && $store.state.user.userData && [1, 12, 16, 21].includes(Number($store.state.user.userData.classId))"
+            >
+              <span
+                class="fh-header__customer-badge"
+                v-text="({ 1: 'Standardkunde', 12: 'Firmenkunde', 16: 'Firmenkunde', 21: 'Firmenkunde' })[Number($store.state.user.userData.classId)]"
+                v-cloak
+              ></span>
+              <div
+                class="fh-header__customer-contact fh-header__customer-contact--standard"
+                v-if="Number($store.state.user.userData.classId) === 1"
+                v-cloak
+              >
+                <span class="fh-header__customer-contact-label">Ansprechpartner:</span>
+                <span class="fh-header__customer-contact-name">Standard</span>
+              </div>
+              <div
+                class="fh-header__customer-contact fh-header__customer-contact--personal"
+                v-else-if="Number($store.state.user.userData.classId) === 12"
+                v-cloak
+              >
+                <div class="fh-header__customer-contact-heading">Ihr persönlicher Ansprechpartner:</div>
+                <div class="fh-header__customer-contact-name">Ulrich Vorländer</div>
+                <a href="#" class="fh-header__contact-button">Direkt kontaktieren</a>
+              </div>
+              <div
+                class="fh-header__customer-contact fh-header__customer-contact--personal"
+                v-else-if="Number($store.state.user.userData.classId) === 16"
+                v-cloak
+              >
+                <div class="fh-header__customer-contact-heading">Ihr persönlicher Ansprechpartner:</div>
+                <div class="fh-header__customer-contact-name">Andreas Fischermann</div>
+                <a href="#" class="fh-header__contact-button">Direkt kontaktieren</a>
+              </div>
+              <div
+                class="fh-header__customer-contact fh-header__customer-contact--personal"
+                v-else-if="Number($store.state.user.userData.classId) === 21"
+                v-cloak
+              >
+                <div class="fh-header__customer-contact-heading">Ihr persönlicher Ansprechpartner:</div>
+                <div class="fh-header__customer-contact-name">Gabriele Sprenger</div>
+                <a href="#" class="fh-header__contact-button">Direkt kontaktieren</a>
+              </div>
+            </div>
             <div class="fh-header__panel-divider mb-3"></div>
             <div class="fh-header__panel-contact">
               <div class="fh-header__panel-contact-label">Fragen? Sie erreichen uns hier:</div>

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -101,7 +101,7 @@
             >
               <span
                 class="fh-header__customer-badge"
-                v-text="({ 1: 'Standardkunde', 12: 'Firmenkunde', 16: 'Firmenkunde', 21: 'Firmenkunde' })[Number($store.state.user.userData.classId)]"
+                v-text="({ 1: 'Standardkonto', 12: 'Firmenkunde', 16: 'Firmenkunde', 21: 'Firmenkunde' })[Number($store.state.user.userData.classId)]"
                 v-cloak
               ></span>
               <div
@@ -141,7 +141,10 @@
               </div>
             </div>
             <div class="fh-header__panel-divider mb-3"></div>
-            <div class="fh-header__panel-contact">
+            <div
+              class="fh-header__panel-contact"
+              v-if="!($store.state.user && $store.state.user.userData && [12, 16, 21].includes(Number($store.state.user.userData.classId)))"
+            >
               <div class="fh-header__panel-contact-label">Fragen? Sie erreichen uns hier:</div>
               <div class="fh-header__panel-contact-line">
                 <a href="tel:02204910980" class="fh-header__panel-contact-chip">


### PR DESCRIPTION
## Summary
- display customer-class specific badge and contact details in the logged-in header menu
- style the new customer segment and contact button elements for consistency with existing design

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de62f25488833192afc5fd6ca0b3c6