### PR TITLE
Add VAT price toggle to account menu

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -733,6 +733,89 @@
   color: #6b7280;
 }
 
+.fh-header__price-toggle {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.fh-header__price-toggle-label {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.fh-price-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+  min-width: 164px;
+  padding: 6px 14px 6px 20px;
+  border: 0;
+  border-radius: 999px;
+  background: #31a5f0;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, padding 0.2s ease;
+}
+
+.fh-price-toggle__text {
+  flex: 1 1 auto;
+  text-align: left;
+}
+
+.fh-price-toggle__thumb {
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.2);
+  transition: transform 0.25s ease, box-shadow 0.2s ease;
+  margin-left: auto;
+  margin-right: 0;
+}
+
+.fh-price-toggle:hover:not(:disabled) .fh-price-toggle__thumb,
+.fh-price-toggle:focus-visible:not(:disabled) .fh-price-toggle__thumb {
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.25);
+}
+
+.fh-price-toggle:focus,
+.fh-price-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(49, 165, 240, 0.35);
+}
+
+.fh-price-toggle:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.fh-price-toggle--net {
+  flex-direction: row-reverse;
+  padding: 6px 20px 6px 14px;
+  background: #e2e8f0;
+  color: #1f2937;
+}
+
+.fh-price-toggle--net .fh-price-toggle__text {
+  text-align: right;
+}
+
+.fh-price-toggle--net .fh-price-toggle__thumb {
+  margin-right: auto;
+  margin-left: 0;
+}
+
 .fh-header__customer-segment {
   display: flex;
   flex-direction: column;

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -68,6 +68,25 @@
         </button>
         <div id="fh-account-menu" data-fh-account-menu aria-hidden="true" class="fh-header__panel fh-header__panel--account">
           <div class="fh-header__panel-arrow"></div>
+          <div
+            class="fh-header__price-toggle"
+            v-if="$store && $store.state && $store.state.basket"
+            v-cloak
+          >
+            <div class="fh-header__price-toggle-label">Preise anzeigen</div>
+            <button
+              type="button"
+              class="fh-price-toggle"
+              :class="{ 'fh-price-toggle--net': $store.state.basket.showNetPrices }"
+              :aria-pressed="$store.state.basket.showNetPrices ? 'true' : 'false'"
+              :disabled="$store.state.basket.isBasketLoading"
+              @click.prevent.stop="$store.commit('setShowNetPrices', !$store.state.basket.showNetPrices); $store.dispatch('refreshBasket')"
+            >
+              <span class="fh-price-toggle__text" v-text="$store.state.basket.showNetPrices ? 'exkl. MwSt.' : 'inkl. MwSt.'"></span>
+              <span class="fh-price-toggle__thumb" aria-hidden="true"></span>
+              <span class="fh-header__sr-only" v-text="$store.state.basket.showNetPrices ? 'Nettopreise werden angezeigt' : 'Bruttopreise werden angezeigt'"></span>
+            </button>
+          </div>
           <div v-if="!$store.getters.isLoggedIn">
             <div class="fh-header__panel-title mb-3">Ihr Konto</div>
             <a href="#login" data-toggle="modal" data-target="#login" data-fh-login-trigger class="fh-header__account-login">Anmelden</a>


### PR DESCRIPTION
## Summary
- add a VAT toggle to the account menu that switches between gross and net pricing for all users
- style the toggle to match the existing header panel design

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de8703ca448331b62544341b6c6cb6