### PR TITLE
Adjust footer logistics badges spacing and labels

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -311,14 +311,15 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 18px;
+  gap: 16px;
   flex-wrap: wrap;
   overflow: visible;
   padding-bottom: 0;
 }
 
 .fh-footer__badge-grid--payments {
-  gap: 20px;
+  gap: 16px;
+  flex-wrap: nowrap;
 }
 
 .fh-footer__badge-grid img {
@@ -327,13 +328,32 @@
   max-height: 48px;
   border-radius: 12px;
   background: #ffffff;
-  padding: 8px 14px;
+  padding: 5px;
   box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
 }
 
 .fh-footer__badge-grid--payments img {
   max-height: 60px;
-  padding: 10px 18px;
+  padding: 5px;
+}
+
+.fh-footer__badge-grid--shipping {
+  gap: 24px;
+}
+
+.fh-footer__shipping-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+}
+
+.fh-footer__shipping-label {
+  font-size: 0.75rem;
+  line-height: 1.3;
+  color: #475569;
+  font-weight: 500;
 }
 
 .fh-footer__bottom {
@@ -492,8 +512,8 @@
   }
 
   .fh-footer__badge-grid {
-    justify-content: flex-start;
-    gap: 16px;
+    justify-content: center;
+    gap: 14px;
   }
 
   .fh-footer__badge-grid img {
@@ -502,7 +522,7 @@
 
   .fh-footer__badge-grid--payments img {
     max-height: 52px;
-    padding: 8px 16px;
+    padding: 5px;
   }
 
   .fh-footer__badge-grid--payments {
@@ -513,6 +533,14 @@
     justify-items: center;
     overflow: visible;
     padding-bottom: 0;
+  }
+
+  .fh-footer__badge-grid--shipping {
+    gap: 20px;
+  }
+
+  .fh-footer__shipping-label {
+    font-size: 0.7rem;
   }
 }
 

--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -117,10 +117,19 @@
         </div>
         <div class="fh-footer__logistics-section">
           <h6 class="fh-footer__sub-heading">Wir versenden mit</h6>
-          <div class="fh-footer__badge-grid" aria-label="Versanddienstleister">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer">
+          <div class="fh-footer__badge-grid fh-footer__badge-grid--shipping" aria-label="Versanddienstleister">
+            <div class="fh-footer__shipping-item">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand">
+              <span class="fh-footer__shipping-label">Standardversand</span>
+            </div>
+            <div class="fh-footer__shipping-item">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express">
+              <span class="fh-footer__shipping-label">Expressversand</span>
+            </div>
+            <div class="fh-footer__shipping-item">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer">
+              <span class="fh-footer__shipping-label">Selbstabholung</span>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- reduce payment and shipping badge padding to 5px and enforce a single-row layout for payment methods on larger screens
- add dedicated styling hooks for shipping badges with centered descriptive labels below each icon
- ensure mobile layout shows payment badges in two rows while keeping shipping labels legible

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1694f513c8331b5f1552af4d35e8e