### PR TITLE
Adjust VAT toggle layout for logged-in users

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -758,12 +758,10 @@
 }
 
 .fh-header__price-toggle {
+  display: flex;
+  align-items: center;
   gap: 12px;
-  padding: 14px 16px;
-  border-radius: 16px;
-  background: linear-gradient(180deg, rgba(241, 245, 249, 0.95) 0%, rgba(226, 232, 240, 0.75) 100%);
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  margin-bottom: 12px;
 }
 
 .fh-header__price-toggle-button {
@@ -771,16 +769,16 @@
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
-  width: 100%;
-  padding: 6px;
+  min-width: 140px;
+  padding: 2px;
   border: none;
   border-radius: 999px;
-  background: rgba(148, 163, 184, 0.18);
+  background: rgba(148, 163, 184, 0.22);
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
   color: #0f172a;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.3px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
   text-transform: uppercase;
   cursor: pointer;
   transition: box-shadow 0.2s ease, background-color 0.2s ease;
@@ -802,34 +800,35 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 8px 10px;
+  padding: 6px 10px;
   border-radius: 999px;
   transition: color 0.2s ease, opacity 0.2s ease;
 }
 
 .fh-header__price-toggle-option[data-fh-price-toggle-option='gross'] {
-  color: #0f172a;
+  color: #475569;
+  opacity: 0.7;
 }
 
 .fh-header__price-toggle-option[data-fh-price-toggle-option='net'] {
-  color: #475569;
-  opacity: 0.7;
-}
-
-.fh-header__price-toggle-button[aria-checked='true'] .fh-header__price-toggle-option[data-fh-price-toggle-option='gross'] {
-  color: #475569;
-  opacity: 0.7;
-}
-
-.fh-header__price-toggle-button[aria-checked='true'] .fh-header__price-toggle-option[data-fh-price-toggle-option='net'] {
   color: #0f172a;
   opacity: 1;
 }
 
+.fh-header__price-toggle-button[aria-checked='true'] .fh-header__price-toggle-option[data-fh-price-toggle-option='gross'] {
+  color: #0f172a;
+  opacity: 1;
+}
+
+.fh-header__price-toggle-button[aria-checked='true'] .fh-header__price-toggle-option[data-fh-price-toggle-option='net'] {
+  color: #475569;
+  opacity: 0.7;
+}
+
 .fh-header__price-toggle-handle {
   position: absolute;
-  top: 6px;
-  bottom: 6px;
+  top: 3px;
+  bottom: 3px;
   left: 6px;
   width: calc(50% - 6px);
   border-radius: 999px;
@@ -838,14 +837,17 @@
   transition: transform 0.25s ease;
 }
 
-.fh-header__price-toggle-button.is-active .fh-header__price-toggle-handle {
+.fh-header__price-toggle-button[aria-checked='true'] .fh-header__price-toggle-handle {
   transform: translateX(100%);
 }
 
-.fh-header__price-toggle-note {
-  font-size: 12px;
-  color: #475569;
-  line-height: 1.4;
+.fh-header__price-toggle-button[aria-checked='false'] .fh-header__price-toggle-handle {
+  transform: translateX(0);
+}
+
+.fh-header__price-toggle-label {
+  font-size: 13px;
+  color: #1a1a1a;
 }
 
 .fh-header__panel-header {

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -68,23 +68,6 @@
         </button>
         <div id="fh-account-menu" data-fh-account-menu aria-hidden="true" class="fh-header__panel fh-header__panel--account">
           <div class="fh-header__panel-arrow"></div>
-          <div class="fh-header__panel-stack fh-header__price-toggle" data-fh-price-toggle-root>
-            <div class="fh-header__panel-subtitle">Preisanzeige</div>
-            <button
-              type="button"
-              class="fh-header__price-toggle-button"
-              data-fh-price-toggle
-              role="switch"
-              aria-checked="false"
-            >
-              <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="gross">inkl. MwSt.</span>
-              <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="net">exkl. MwSt.</span>
-              <span class="fh-header__price-toggle-handle" aria-hidden="true"></span>
-            </button>
-            <div class="fh-header__panel-text fh-header__price-toggle-note" data-fh-price-toggle-note>
-              Aktuell werden Bruttopreise angezeigt.
-            </div>
-          </div>
           <div v-if="!$store.getters.isLoggedIn">
             <div class="fh-header__panel-title mb-3">Ihr Konto</div>
             <a href="#login" data-toggle="modal" data-target="#login" data-fh-login-trigger class="fh-header__account-login">Anmelden</a>
@@ -112,6 +95,20 @@
                 <span v-else v-cloak>Hallo</span>
               </div>
               <div class="fh-header__panel-text">Schön, dass Sie wieder da sind!</div>
+            </div>
+            <div class="fh-header__price-toggle" data-fh-price-toggle-root>
+              <button
+                type="button"
+                class="fh-header__price-toggle-button"
+                data-fh-price-toggle
+                role="switch"
+                aria-checked="true"
+              >
+                <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="gross">inkl. MwSt.</span>
+                <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="net">exkl. MwSt.</span>
+                <span class="fh-header__price-toggle-handle" aria-hidden="true"></span>
+              </button>
+              <span class="fh-header__price-toggle-label" data-fh-price-toggle-label>Preise mit MwSt</span>
             </div>
             <div
               class="fh-header__customer-segment"

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -201,7 +201,7 @@ fhOnReady(function () {
   if (priceToggleRoot && priceToggleButton) {
     const grossOption = priceToggleRoot.querySelector("[data-fh-price-toggle-option='gross']");
     const netOption = priceToggleRoot.querySelector("[data-fh-price-toggle-option='net']");
-    const noteElement = priceToggleRoot.querySelector('[data-fh-price-toggle-note]');
+    const labelElement = priceToggleRoot.querySelector('[data-fh-price-toggle-label]');
     const STORAGE_KEY = 'fh:price-display:show-net-prices';
     let currentShowNet = false;
     let hasIntegratedStore = false;
@@ -468,21 +468,16 @@ fhOnReady(function () {
 
     function updateToggleUi(showNet) {
       const isNet = !!showNet;
+      const isGross = !isNet;
 
-      priceToggleButton.setAttribute('aria-checked', isNet ? 'true' : 'false');
-
-      if (isNet) priceToggleButton.classList.add('is-active'); else {
-        priceToggleButton.classList.remove('is-active');
-      }
+      priceToggleButton.setAttribute('aria-checked', isGross ? 'true' : 'false');
 
       if (grossOption) grossOption.setAttribute('aria-hidden', isNet ? 'true' : 'false');
 
       if (netOption) netOption.setAttribute('aria-hidden', isNet ? 'false' : 'true');
 
-      if (noteElement) {
-        noteElement.textContent = isNet
-          ? 'Aktuell werden Nettopreise angezeigt.'
-          : 'Aktuell werden Bruttopreise angezeigt.';
+      if (labelElement) {
+        labelElement.textContent = isNet ? 'Preise ohne MwSt' : 'Preise mit MwSt';
       }
     }
 


### PR DESCRIPTION
## Summary
- move the VAT toggle into the logged-in greeting panel and display the current mode inline
- shrink and restyle the VAT switch to be more compact and left-aligned
- update the VAT toggle script to default to gross prices and drive the new label text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1930247d88331a8ee3b7cd6f8e749