### PR TITLE
Refine VAT toggle layout and default state

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -767,6 +767,7 @@
   border: 0;
   background: transparent;
   box-shadow: none;
+  margin-top: 4px;
 }
 
 .fh-header__price-toggle-row {
@@ -788,8 +789,8 @@
   padding: 0 4px;
   border: none;
   border-radius: 999px;
-  background: rgba(148, 163, 184, 0.3);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.45);
+  background: rgba(148, 163, 184, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.5);
   color: #0f172a;
   font-size: 0;
   font-weight: 700;
@@ -805,7 +806,12 @@
 }
 
 .fh-header__price-toggle-button:hover {
-  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.35);
+}
+
+.fh-header__price-toggle-button.is-active {
+  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.9), 0 6px 12px rgba(37, 99, 235, 0.2);
 }
 
 .fh-header__price-toggle-option {
@@ -834,6 +840,7 @@
 
 .fh-header__price-toggle-button.is-active .fh-header__price-toggle-handle {
   transform: translateX(22px);
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.2);
 }
 
 .fh-header__price-toggle-note {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -757,28 +757,41 @@
   gap: 8px;
 }
 
+
 .fh-header__price-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
   gap: 12px;
-  padding: 14px 16px;
-  border-radius: 16px;
-  background: linear-gradient(180deg, rgba(241, 245, 249, 0.95) 0%, rgba(226, 232, 240, 0.75) 100%);
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.fh-header__price-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+  width: 100%;
 }
 
 .fh-header__price-toggle-button {
   position: relative;
   display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 6px;
+  justify-content: center;
+  width: 48px;
+  min-width: 48px;
+  height: 24px;
+  padding: 0 4px;
   border: none;
   border-radius: 999px;
-  background: rgba(148, 163, 184, 0.18);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.3);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.45);
   color: #0f172a;
-  font-size: 12px;
+  font-size: 0;
   font-weight: 700;
   letter-spacing: 0.3px;
   text-transform: uppercase;
@@ -796,56 +809,44 @@
 }
 
 .fh-header__price-toggle-option {
-  position: relative;
-  z-index: 1;
-  flex: 1 1 50%;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 10px;
-  border-radius: 999px;
-  transition: color 0.2s ease, opacity 0.2s ease;
-}
-
-.fh-header__price-toggle-option[data-fh-price-toggle-option='gross'] {
-  color: #0f172a;
-}
-
-.fh-header__price-toggle-option[data-fh-price-toggle-option='net'] {
-  color: #475569;
-  opacity: 0.7;
+  display: none;
 }
 
 .fh-header__price-toggle-button[aria-checked='true'] .fh-header__price-toggle-option[data-fh-price-toggle-option='gross'] {
-  color: #475569;
-  opacity: 0.7;
+  display: none;
 }
 
 .fh-header__price-toggle-button[aria-checked='true'] .fh-header__price-toggle-option[data-fh-price-toggle-option='net'] {
-  color: #0f172a;
-  opacity: 1;
+  display: none;
 }
 
 .fh-header__price-toggle-handle {
   position: absolute;
-  top: 6px;
-  bottom: 6px;
-  left: 6px;
-  width: calc(50% - 6px);
+  top: 3px;
+  bottom: 3px;
+  left: 4px;
+  width: 18px;
   border-radius: 999px;
   background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.18);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.18);
   transition: transform 0.25s ease;
 }
 
 .fh-header__price-toggle-button.is-active .fh-header__price-toggle-handle {
-  transform: translateX(100%);
+  transform: translateX(22px);
 }
 
 .fh-header__price-toggle-note {
-  font-size: 12px;
-  color: #475569;
+  display: inline-flex;
+  align-items: center;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a1a1a;
   line-height: 1.4;
+}
+
+.fh-header__price-toggle-status--hidden {
+  display: none;
 }
 
 .fh-header__panel-header {

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -68,21 +68,27 @@
         </button>
         <div id="fh-account-menu" data-fh-account-menu aria-hidden="true" class="fh-header__panel fh-header__panel--account">
           <div class="fh-header__panel-arrow"></div>
-          <div class="fh-header__panel-stack fh-header__price-toggle" data-fh-price-toggle-root>
-            <div class="fh-header__panel-subtitle">Preisanzeige</div>
-            <button
-              type="button"
-              class="fh-header__price-toggle-button"
-              data-fh-price-toggle
-              role="switch"
-              aria-checked="false"
-            >
-              <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="gross">inkl. MwSt.</span>
-              <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="net">exkl. MwSt.</span>
-              <span class="fh-header__price-toggle-handle" aria-hidden="true"></span>
-            </button>
-            <div class="fh-header__panel-text fh-header__price-toggle-note" data-fh-price-toggle-note>
-              Aktuell werden Bruttopreise angezeigt.
+          <div class="fh-header__price-toggle" data-fh-price-toggle-root>
+            <div class="fh-header__price-toggle-row">
+              <button
+                type="button"
+                class="fh-header__price-toggle-button"
+                data-fh-price-toggle
+                role="switch"
+                aria-checked="true"
+                aria-label="Preise mit Mehrwertsteuer anzeigen"
+              >
+                <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="gross">inkl. MwSt.</span>
+                <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="net">exkl. MwSt.</span>
+                <span class="fh-header__price-toggle-handle" aria-hidden="true"></span>
+              </button>
+              <span
+                class="fh-header__price-toggle-note fh-header__price-toggle-status"
+                data-fh-price-toggle-note
+                :class="{ 'fh-header__price-toggle-status--hidden': !$store.getters.isLoggedIn }"
+              >
+                Preise mit MwSt
+              </span>
             </div>
           </div>
           <div v-if="!$store.getters.isLoggedIn">

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -68,29 +68,6 @@
         </button>
         <div id="fh-account-menu" data-fh-account-menu aria-hidden="true" class="fh-header__panel fh-header__panel--account">
           <div class="fh-header__panel-arrow"></div>
-          <div class="fh-header__price-toggle" data-fh-price-toggle-root>
-            <div class="fh-header__price-toggle-row">
-              <button
-                type="button"
-                class="fh-header__price-toggle-button"
-                data-fh-price-toggle
-                role="switch"
-                aria-checked="true"
-                aria-label="Preise mit Mehrwertsteuer anzeigen"
-              >
-                <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="gross">inkl. MwSt.</span>
-                <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="net">exkl. MwSt.</span>
-                <span class="fh-header__price-toggle-handle" aria-hidden="true"></span>
-              </button>
-              <span
-                class="fh-header__price-toggle-note fh-header__price-toggle-status"
-                data-fh-price-toggle-note
-                :class="{ 'fh-header__price-toggle-status--hidden': !$store.getters.isLoggedIn }"
-              >
-                Preise mit MwSt
-              </span>
-            </div>
-          </div>
           <div v-if="!$store.getters.isLoggedIn">
             <div class="fh-header__panel-title mb-3">Ihr Konto</div>
             <a href="#login" data-toggle="modal" data-target="#login" data-fh-login-trigger class="fh-header__account-login">Anmelden</a>
@@ -118,6 +95,25 @@
                 <span v-else v-cloak>Hallo</span>
               </div>
               <div class="fh-header__panel-text">Schön, dass Sie wieder da sind!</div>
+              <div class="fh-header__price-toggle" data-fh-price-toggle-root v-if="$store.getters.isLoggedIn">
+                <div class="fh-header__price-toggle-row">
+                  <button
+                    type="button"
+                    class="fh-header__price-toggle-button is-active"
+                    data-fh-price-toggle
+                    role="switch"
+                    aria-checked="true"
+                    aria-label="Preise mit Mehrwertsteuer anzeigen"
+                  >
+                    <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="gross">inkl. MwSt.</span>
+                    <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="net">exkl. MwSt.</span>
+                    <span class="fh-header__price-toggle-handle" aria-hidden="true"></span>
+                  </button>
+                  <span class="fh-header__price-toggle-note fh-header__price-toggle-status" data-fh-price-toggle-note>
+                    Preise mit MwSt
+                  </span>
+                </div>
+              </div>
             </div>
             <div
               class="fh-header__customer-segment"

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -195,10 +195,7 @@ fhOnReady(function () {
     }
   }
 
-  const priceToggleRoot = menu.querySelector('[data-fh-price-toggle-root]');
-  const priceToggleButton = priceToggleRoot ? priceToggleRoot.querySelector('[data-fh-price-toggle]') : null;
-
-  if (priceToggleRoot && priceToggleButton) {
+  function installPriceToggle(priceToggleRoot, priceToggleButton) {
     const grossOption = priceToggleRoot.querySelector("[data-fh-price-toggle-option='gross']");
     const netOption = priceToggleRoot.querySelector("[data-fh-price-toggle-option='net']");
     const noteElement = priceToggleRoot.querySelector('[data-fh-price-toggle-note]');
@@ -586,6 +583,51 @@ fhOnReady(function () {
 
     scheduleStoreIntegration(0);
   }
+
+  function attemptInstallPriceToggle(root) {
+    const element = root || menu.querySelector('[data-fh-price-toggle-root]');
+
+    if (!element || element.__fhPriceToggleInitialized) return false;
+
+    const button = element.querySelector('[data-fh-price-toggle]');
+
+    if (!button) return false;
+
+    element.__fhPriceToggleInitialized = true;
+    installPriceToggle(element, button);
+
+    return true;
+  }
+
+  attemptInstallPriceToggle();
+
+  const priceToggleObserver = new MutationObserver(function (mutations) {
+    for (let index = 0; index < mutations.length; index += 1) {
+      const mutation = mutations[index];
+
+      if (mutation.type !== 'childList') continue;
+
+      if (attemptInstallPriceToggle()) return;
+
+      const addedNodes = mutation.addedNodes;
+
+      for (let nodeIndex = 0; nodeIndex < addedNodes.length; nodeIndex += 1) {
+        const node = addedNodes[nodeIndex];
+
+        if (node && node.nodeType === 1 && typeof node.querySelector === 'function') {
+          if (node.matches && node.matches('[data-fh-price-toggle-root]')) {
+            if (attemptInstallPriceToggle(node)) return;
+          }
+
+          const nestedRoot = node.querySelector('[data-fh-price-toggle-root]');
+
+          if (nestedRoot && attemptInstallPriceToggle(nestedRoot)) return;
+        }
+      }
+    }
+  });
+
+  priceToggleObserver.observe(menu, { childList: true, subtree: true });
 
   window.fhAccountMenu = window.fhAccountMenu || {};
   window.fhAccountMenu.close = closeMenu;

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -468,22 +468,22 @@ fhOnReady(function () {
 
     function updateToggleUi(showNet) {
       const isNet = !!showNet;
+      const isGross = !isNet;
 
-      priceToggleButton.setAttribute('aria-checked', isNet ? 'true' : 'false');
+      priceToggleButton.setAttribute('aria-checked', isGross ? 'true' : 'false');
+      priceToggleButton.setAttribute(
+        'aria-label',
+        isNet ? 'Preise ohne Mehrwertsteuer anzeigen' : 'Preise mit Mehrwertsteuer anzeigen'
+      );
 
-      if (isNet) priceToggleButton.classList.add('is-active'); else {
-        priceToggleButton.classList.remove('is-active');
-      }
+      if (isGross) priceToggleButton.classList.add('is-active');
+      else priceToggleButton.classList.remove('is-active');
 
-      if (grossOption) grossOption.setAttribute('aria-hidden', isNet ? 'true' : 'false');
+      if (grossOption) grossOption.setAttribute('aria-hidden', isGross ? 'false' : 'true');
 
-      if (netOption) netOption.setAttribute('aria-hidden', isNet ? 'false' : 'true');
+      if (netOption) netOption.setAttribute('aria-hidden', isGross ? 'true' : 'false');
 
-      if (noteElement) {
-        noteElement.textContent = isNet
-          ? 'Aktuell werden Nettopreise angezeigt.'
-          : 'Aktuell werden Bruttopreise angezeigt.';
-      }
+      if (noteElement) noteElement.textContent = isNet ? 'Preise ohne MwSt' : 'Preise mit MwSt';
     }
 
     function applyStateToStore(store, desiredState) {


### PR DESCRIPTION
## Summary
- shrink the VAT toggle markup in the account menu and add an inline status label that only shows for logged-in users
- restyle the toggle switch for a compact layout with the default state on the right
- update the toggle script so the gross state is treated as the default, refreshing aria metadata and status copy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1930247d88331a8ee3b7cd6f8e749