### PR TITLE
Document key plenty references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,14 @@ Ich möchte den Header und Footer für die Hammer-Shops (FH und SH) auf Basis vo
 | **SEO/Markup**      | Schema.org JSON-LD      | BreadcrumbList, Product Schema                               | Strukturierte Daten für Suchmaschinen                      |
 | **Trust/Widgets**   | Trusted Shops u. a.     | Drittanbieter-JS                                             | Reviews, Trustbadges, Rechtliches                          |
 
+## Primäre Referenzen & Ressourcen
+
+* **REST-API-Dokumentation:** https://developers.plentymarkets.com/en-gb/plentymarkets-rest-api/index.html – Ziehe diese Quelle immer heran, wenn du Datenflüsse, Endpunkte oder Datenstrukturen verstehen oder erweitern musst. Für reine CSS- oder HTML-Änderungen ist ein Blick in die API-Dokumentation in der Regel nicht erforderlich.
+* **IO-Plugin:** https://github.com/plentymarkets/plugin-io – Das IO-Plugin liefert wesentliche Shop-Funktionalitäten (Routing, Controller, Widgets). Prüfe vor komplexeren JS-Anpassungen, ob hier bereits passende Hooks oder Komponenten existieren. Bei kosmetischen Anpassungen kann dieses Nachschlagen entfallen.
+* **plentyShop LTS / Ceres:** https://github.com/plentymarkets/plugin-ceres – Bleibt die maßgebliche Grundlage für Templates, Vue-Komponenten und Styles. Für tiefgreifende Layout- oder Logikänderungen ist der Abgleich Pflicht, während bei isolierten Style-Overrides ein kurzer Plausibilitätscheck genügt.
+
+> **Hinweis:** Nutze diese Ressourcen gezielt. Wenn du z. B. lediglich Farben, Abstände oder Schriftgrößen in einer bestehenden CSS-Datei änderst, reicht es, die lokale Struktur zu kennen. Erst wenn Backend-Daten, Komponenten oder Shop-Flows betroffen sind, sollten IO-Plugin und REST-API eingehend geprüft werden.
+
 ## Stil- und Strukturvorgaben
 
 * Arbeite mit sauber dokumentierten HTML-Strukturen. Inline-CSS ist erlaubt, darf aber keine Skripte einbetten.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Dieses Repository sammelt alle CSS- und JavaScript-Anpassungen, mit denen wir di
   3. Änderungen an diesem Repository müssen mit den jeweiligen Twig- und Vue-Komponenten aus Ceres abgeglichen werden, damit IDs, Klassen und Slots korrekt angesprochen werden.
 * **Priorität:** Wenn Entscheidungen zwischen Inline-Anpassungen hier und nativen Ceres-Funktionen zu treffen sind, gilt: Header- und Footer-Neubauten haben Vorrang, danach greifen zusätzliche Styles oder Skripte.
 
+### Relevante Dokumentation & Ressourcen
+
+* **plentyShop LTS / Ceres:** https://github.com/plentymarkets/plugin-ceres – Maßgeblich für Layouts, Slots und Komponenten. Bei strukturellen Änderungen (neue Blöcke, erweiterte Vue-Logik etc.) ist ein Abgleich Pflicht; bei rein optischen Anpassungen genügt in der Regel das lokale Wissen über die bestehende Struktur.
+* **IO-Plugin:** https://github.com/plentymarkets/plugin-io – Ergänzt das Frontend um Controller, Routing und Widgets. Ziehe die Doku bzw. den Code heran, wenn du neue Funktionen, Datenbindungen oder API-Aufrufe planst. Für reine CSS- oder HTML-Korrekturen muss das IO-Plugin meist nicht konsultiert werden.
+* **Plentymarkets REST-API:** https://developers.plentymarkets.com/en-gb/plentymarkets-rest-api/index.html – Liefert Details zu allen Endpunkten, Datenstrukturen und Berechtigungen. Nutze sie, sobald du mit serverseitigen Daten arbeitest oder neue API-Calls hinzufügst. Bei Aufgaben ohne Backend-Bezug (z. B. Farbänderungen) kann dieser Schritt entfallen.
+
+> **Faustregel:** Greife auf IO-Plugin, REST-API und Ceres-Quellen zu, sobald deine Arbeit über reine Styling-Overrides hinausgeht. Für schnelle Anpassungen an Farben, Abständen oder Schriftgrößen reicht meist ein Blick in die bestehende CSS- oder Template-Struktur dieses Repos.
+
 ## Arbeitsweise für Header- und Footer-Neubau
 
 * Der Header und Footer werden in PlentyLTS vollständig neu aufgebaut. Verwende dieses Repository, um die benötigten HTML-Gerüste (innerhalb der zulässigen Content-Boxen), CSS-Overrides und unterstützenden JavaScript-Hooks vorzubereiten.


### PR DESCRIPTION
## Summary
- document how to consult the plentymarkets REST API, IO plugin, and Ceres resources in AGENTS.md
- extend the README with guidance on when to use the core plentymarkets documentation for custom work

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e23e5a9c648331bb90dea21f7d4591