### PR TITLE
Add account type label for FH account badge

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -882,14 +882,25 @@
   align-items: center;
   justify-content: center;
   align-self: flex-start;
+  gap: 4px;
   padding: 4px 10px;
   border-radius: 999px;
   background: rgba(59, 130, 246, 0.15);
   color: #0f172a;
-  font-size: 11px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.fh-header__customer-badge-label {
+  font-weight: 600;
+  text-transform: none;
+}
+
+.fh-header__customer-badge-value {
   font-weight: 700;
-  letter-spacing: 0.4px;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .fh-header__customer-contact {

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -119,11 +119,13 @@
               class="fh-header__customer-segment"
               v-if="$store.state.user && $store.state.user.userData && [1, 12, 16, 21].includes(Number($store.state.user.userData.classId))"
             >
-              <span
-                class="fh-header__customer-badge"
-                v-text="({ 1: 'Standardkonto', 12: 'Firmenkunde', 16: 'Firmenkunde', 21: 'Firmenkunde' })[Number($store.state.user.userData.classId)]"
-                v-cloak
-              ></span>
+              <span class="fh-header__customer-badge" v-cloak>
+                <span class="fh-header__customer-badge-label">Konto:</span>
+                <span
+                  class="fh-header__customer-badge-value"
+                  v-text="({ 1: 'Standardkonto', 12: 'Firmenkunden', 16: 'Firmenkunden', 21: 'Firmenkunden' })[Number($store.state.user.userData.classId)]"
+                ></span>
+              </span>
               <div
                 class="fh-header__customer-contact fh-header__customer-contact--standard"
                 v-if="Number($store.state.user.userData.classId) === 1"


### PR DESCRIPTION
## Summary
- show the account label "Konto:" with the appropriate value in the FH account badge
- adjust the badge styling so the new label/value combination renders in a smaller format inside the chip

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e24e91a0808331b44c571349a0cce0