### PR TITLE
Add account type labels to FH account menu

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1119,13 +1119,23 @@
   gap: 8px;
 }
 
-.fh-header__panel-link {
+.fh-header__panel-link { 
   display: block;
   padding: 4px 0;
   color: #1a1a1a;
   text-decoration: none;
   font-size: 14px;
   font-weight: 500;
+}
+
+.fh-header__panel-account-type {
+  margin-bottom: 16px;
+  padding: 10px 14px;
+  background-color: #f1f5f9;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #1f2937;
 }
 
 .fh-header__panel-link:hover,

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -188,6 +188,18 @@
                 </a>
               </div>
             </div>
+            <div
+              class="fh-header__panel-account-type"
+              v-if="$store.state.user && $store.state.user.userData && Number($store.state.user.userData.classId) === 1"
+            >
+              Konto: Standardkonto
+            </div>
+            <div
+              class="fh-header__panel-account-type"
+              v-else-if="$store.state.user && $store.state.user.userData && [12, 16, 21].includes(Number($store.state.user.userData.classId))"
+            >
+              Konto: Firmenkunden
+            </div>
             <nav class="fh-header__panel-links mb-4">
               <a href="/my-account" class="fh-header__panel-link">Kontoübersicht</a>
               <a href="/my-account/settings" class="fh-header__panel-link">Kontoeinstellungen</a>


### PR DESCRIPTION
## Summary
- add account type labels for standard and business customer classes in the FH account menu
- style the account type badge to match the panel look and feel

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2711d66bc8331870697a85a82ff76