### PR TITLE
Adjust account type label placement in FH header

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1116,22 +1116,49 @@
 .fh-header__panel-links {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
 }
 
 .fh-header__panel-link {
-  display: block;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   padding: 4px 0;
-  color: #1a1a1a;
+  color: inherit;
   text-decoration: none;
   font-size: 14px;
   font-weight: 500;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.fh-header__panel-link::before {
+  content: "";
+  display: inline-flex;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: #2563eb;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
 .fh-header__panel-link:hover,
 .fh-header__panel-link:focus {
-  color: #0f172a;
+  color: #2563eb;
   text-decoration: none;
+  transform: translateX(2px);
+}
+
+.fh-header__panel-link:hover::before,
+.fh-header__panel-link:focus::before {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.fh-header__account-type {
+  margin-bottom: 16px;
 }
 
 .fh-header__logout {

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -195,7 +195,7 @@
               v-cloak
             >
               <span v-if="Number($store.state.user.userData.classId) === 1">Konto: Standardkonto</span>
-              <span v-else>Konto: Firmenkunden</span>
+              <span v-else>Konto: Firmenkunde</span>
             </div>
             <a href="#" v-logout data-fh-account-close class="fh-header__logout">Abmelden</a>
           </div>

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -119,11 +119,6 @@
               class="fh-header__customer-segment"
               v-if="$store.state.user && $store.state.user.userData && [1, 12, 16, 21].includes(Number($store.state.user.userData.classId))"
             >
-              <span
-                class="fh-header__customer-badge"
-                v-text="({ 1: 'Standardkonto', 12: 'Firmenkunde', 16: 'Firmenkunde', 21: 'Firmenkunde' })[Number($store.state.user.userData.classId)]"
-                v-cloak
-              ></span>
               <div
                 class="fh-header__customer-contact fh-header__customer-contact--standard"
                 v-if="Number($store.state.user.userData.classId) === 1"
@@ -194,6 +189,14 @@
               <a href="/my-account/orders" class="fh-header__panel-link">Meine Bestellungen</a>
               <a href="/hammer-praemien" class="fh-header__panel-link">Hammer Punkte einlösen</a>
             </nav>
+            <div
+              class="fh-header__panel-text fh-header__account-type"
+              v-if="$store.state.user && $store.state.user.userData && [1, 12, 16, 21].includes(Number($store.state.user.userData.classId))"
+              v-cloak
+            >
+              <span v-if="Number($store.state.user.userData.classId) === 1">Konto: Standardkonto</span>
+              <span v-else>Konto: Firmenkunden</span>
+            </div>
             <a href="#" v-logout data-fh-account-close class="fh-header__logout">Abmelden</a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the account type badge from the account panel header
- show the account type text above the logout button for standard and corporate customers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e273e49f0883319dc666fdc9f51dc3