### PR TITLE
Improve VAT toggle display behaviour

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -35,6 +35,20 @@ body,
 
 /* End Section: Custom Schriftarten + Preis Text Stylings */
 
+/* Section: Cart totals toggle styling */
+.cmp-totals dt.fh-cart-total-active,
+.cmp-totals dd.fh-cart-total-active {
+  font-weight: 700;
+  color: var(--fh-color-bright-blue, #31a5f0);
+}
+
+.cmp-totals dt.fh-cart-total-inactive,
+.cmp-totals dd.fh-cart-total-inactive {
+  font-weight: 400;
+  color: inherit;
+}
+/* End Section: Cart totals toggle styling */
+
 /* Section: FH Header Base Layout */
 .fh-header {
   position: relative;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -11,6 +11,20 @@
 
 /* End Section: Custom Schriftarten + Preis Text Stylings */
 
+/* Section: Cart totals toggle styling */
+.cmp-totals dt.fh-cart-total-active,
+.cmp-totals dd.fh-cart-total-active {
+  font-weight: 700;
+  color: #f20000;
+}
+
+.cmp-totals dt.fh-cart-total-inactive,
+.cmp-totals dd.fh-cart-total-inactive {
+  font-weight: 400;
+  color: inherit;
+}
+/* End Section: Cart totals toggle styling */
+
 /* Section: Artikel Preview Card Preis Styling */
 .price {
   color: #f20000 !important;


### PR DESCRIPTION
## Summary
- adjust the VAT toggle script so cart preview rows switch between netto and brutto entries while keeping both totals visible and highlighted
- add theme styling for active/inactive totals in both FH and SH stylesheets
- reapply the stored VAT preference after basket updates so the toggle stays persistent when items are added

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e386c8a274833186c02e0df64f2d6f