### PR TITLE
Adjust basket preview totals for VAT toggle

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2383,3 +2383,40 @@ button[data-testing="quantity-btn-decrease"],
   padding-right: 0px;
 }
 /* End Section: Method list item label padding */
+
+/* Section: Basket preview totals visibility */
+:root[data-fh-show-net-prices="net"] .cmp-totals dd[data-testing="item-sum"],
+:root[data-fh-show-net-prices="net"] .cmp-totals dd[data-testing="shipping-amount"],
+:root[data-fh-show-net-prices="net"] .cmp-totals dd[data-testing="vat-amount"],
+:root[data-fh-show-net-prices="net"] .cmp-totals dt:has(+ dd[data-testing="item-sum"]),
+:root[data-fh-show-net-prices="net"] .cmp-totals dt:has(+ dd[data-testing="shipping-amount"]),
+:root[data-fh-show-net-prices="net"] .cmp-totals dt:has(+ dd[data-testing="vat-amount"]) {
+  display: none !important;
+}
+
+:root[data-fh-show-net-prices="gross"] .cmp-totals dd[data-testing="item-sum-net"],
+:root[data-fh-show-net-prices="gross"] .cmp-totals dd[data-testing="shipping-amount-net"],
+:root[data-fh-show-net-prices="gross"] .cmp-totals dt:has(+ dd[data-testing="item-sum-net"]),
+:root[data-fh-show-net-prices="gross"] .cmp-totals dt:has(+ dd[data-testing="shipping-amount-net"]) {
+  display: none !important;
+}
+
+:root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount"]),
+:root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dd[data-testing="basket-amount"],
+:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount-net"]),
+:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dd[data-testing="basket-amount-net"] {
+  opacity: 0.6;
+}
+
+:root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount-net"]),
+:root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dd[data-testing="basket-amount-net"],
+:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount"]),
+:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dd[data-testing="basket-amount"] {
+  opacity: 1;
+}
+
+.cmp-totals .totalSum dt,
+.cmp-totals .totalSum dd {
+  transition: opacity 0.2s ease;
+}
+/* End Section: Basket preview totals visibility */

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -214,7 +214,19 @@
           <span class="fh-header__sr-only" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
           <span class="fh-header__sr-only" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
         </a>
-        <basket-preview v-if="$store.state.lazyComponent.components['basket-preview']" :show-net-prices="$store.state.basket.showNetPrices" :visible-fields="['basketValueGross','shippingCostsGross','totalSumNet','totalSumGross']"></basket-preview>
+        <basket-preview
+          v-if="$store.state.lazyComponent.components['basket-preview']"
+          :show-net-prices="$store.state.basket.showNetPrices"
+          :visible-fields="[
+            'basketValueNet',
+            'basketValueGross',
+            'shippingCostsNet',
+            'shippingCostsGross',
+            'vats',
+            'totalSumNet',
+            'totalSumGross'
+          ]"
+        ></basket-preview>
       </div>
     </div>
   </div>

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -635,6 +635,10 @@ fhOnReady(function () {
       if (netOption) netOption.setAttribute('aria-hidden', isGross ? 'true' : 'false');
 
       if (noteElement) noteElement.textContent = isNet ? 'Preise ohne MwSt' : 'Preise mit MwSt';
+
+      if (typeof document !== 'undefined' && document.documentElement) {
+        document.documentElement.setAttribute('data-fh-show-net-prices', isNet ? 'net' : 'gross');
+      }
     }
 
     function applyStateToStore(store, desiredState) {
@@ -655,11 +659,29 @@ fhOnReady(function () {
         },
         function (value) {
           const normalized = !!value;
+          const storedPreference = readStoredPreference();
+          const hasStoredPreference = storedPreference === true || storedPreference === false;
+
+          if (hasStoredPreference && normalized !== storedPreference) {
+            currentShowNet = storedPreference;
+            updateToggleUi(storedPreference);
+            persistPreference(storedPreference);
+
+            if (lastKnownStore) {
+              applyStateToStore(lastKnownStore, storedPreference);
+            } else {
+              priceDisplayManager.scheduleUpdate(store, storedPreference);
+              schedulePageDisplayUpdate(storedPreference);
+            }
+
+            return;
+          }
 
           currentShowNet = normalized;
           updateToggleUi(normalized);
           persistPreference(normalized);
           if (lastKnownStore) priceDisplayManager.scheduleUpdate(lastKnownStore, normalized);
+          else priceDisplayManager.scheduleUpdate(store, normalized);
           schedulePageDisplayUpdate(normalized);
         }
       );

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -325,3 +325,40 @@ button[data-testing="quantity-btn-decrease"],
   padding-right: 0px;
 }
 /* End Section: Method list item label padding */
+
+/* Section: Basket preview totals visibility */
+:root[data-fh-show-net-prices="net"] .cmp-totals dd[data-testing="item-sum"],
+:root[data-fh-show-net-prices="net"] .cmp-totals dd[data-testing="shipping-amount"],
+:root[data-fh-show-net-prices="net"] .cmp-totals dd[data-testing="vat-amount"],
+:root[data-fh-show-net-prices="net"] .cmp-totals dt:has(+ dd[data-testing="item-sum"]),
+:root[data-fh-show-net-prices="net"] .cmp-totals dt:has(+ dd[data-testing="shipping-amount"]),
+:root[data-fh-show-net-prices="net"] .cmp-totals dt:has(+ dd[data-testing="vat-amount"]) {
+  display: none !important;
+}
+
+:root[data-fh-show-net-prices="gross"] .cmp-totals dd[data-testing="item-sum-net"],
+:root[data-fh-show-net-prices="gross"] .cmp-totals dd[data-testing="shipping-amount-net"],
+:root[data-fh-show-net-prices="gross"] .cmp-totals dt:has(+ dd[data-testing="item-sum-net"]),
+:root[data-fh-show-net-prices="gross"] .cmp-totals dt:has(+ dd[data-testing="shipping-amount-net"]) {
+  display: none !important;
+}
+
+:root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount"]),
+:root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dd[data-testing="basket-amount"],
+:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount-net"]),
+:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dd[data-testing="basket-amount-net"] {
+  opacity: 0.6;
+}
+
+:root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount-net"]),
+:root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dd[data-testing="basket-amount-net"],
+:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount"]),
+:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dd[data-testing="basket-amount"] {
+  opacity: 1;
+}
+
+.cmp-totals .totalSum dt,
+.cmp-totals .totalSum dd {
+  transition: opacity 0.2s ease;
+}
+/* End Section: Basket preview totals visibility */


### PR DESCRIPTION
## Summary
- add the missing net, gross and VAT total fields to the basket preview so both totals stay visible
- hide or show the correct rows for the selected VAT mode and highlight the active grand total
- keep the MwSt preference persistent after adding items to the cart and sync the HTML attribute for styling

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e38d9237dc833197e9d27c2ed6f047