### PR TITLE
Update wishlist price display with MwSt toggle support

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2131,10 +2131,12 @@ body.fh-search-overlay-open div[id^="trustbadge-container-"] {
 }
 
 .fh-header__wishlist-list .fh-wishlist-qty-box {
+  --fh-wishlist-qty-height: 52px;
+  --fh-wishlist-qty-button-size: calc(var(--fh-wishlist-qty-height) / 2);
   display: flex;
   align-items: stretch;
-  min-width: 122px;
-  height: 48px;
+  min-width: 116px;
+  height: var(--fh-wishlist-qty-height);
   border: 1px solid #cbd5e1;
   border-radius: 12px;
   overflow: hidden;
@@ -2144,7 +2146,7 @@ body.fh-search-overlay-open div[id^="trustbadge-container-"] {
 
 .fh-header__wishlist-list .fh-wishlist-qty-input {
   flex: 1 1 auto;
-  min-width: 60px;
+  min-width: 64px;
   border: none;
   background: #ffffff;
   font-weight: 600;
@@ -2162,13 +2164,15 @@ body.fh-search-overlay-open div[id^="trustbadge-container-"] {
 .fh-header__wishlist-list .fh-wishlist-qty-controls {
   display: flex;
   flex-direction: column;
-  width: 44px;
+  width: var(--fh-wishlist-qty-button-size);
+  height: 100%;
   border-left: 1px solid #cbd5e1;
   background: #f1f5f9;
 }
 
 .fh-header__wishlist-list .fh-wishlist-qty-controls .qty-btn {
-  flex: 1 1 50%;
+  flex: 0 0 var(--fh-wishlist-qty-button-size);
+  height: var(--fh-wishlist-qty-button-size);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2176,7 +2180,7 @@ body.fh-search-overlay-open div[id^="trustbadge-container-"] {
   background: transparent;
   color: var(--fh-color-dark-blue);
   font-weight: 600;
-  font-size: 1.2rem;
+  font-size: 1.05rem;
   line-height: 1;
   padding: 0;
   margin: 0;

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2123,39 +2123,72 @@ body.fh-search-overlay-open div[id^="trustbadge-container-"] {
   letter-spacing: 0.01em;
 }
 
-.fh-header__wishlist-list .fh-wishlist-item-base-price {
-  font-size: 0.8rem;
-  color: #64748b;
+.fh-header__wishlist-list .fh-wishlist-qty-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 0 0 auto;
 }
 
-.fh-header__wishlist-list .qty-box {
-  min-width: 128px;
-  height: 40px;
-  border: 1px solid #d8e2ef;
-  border-radius: 8px;
-  background-color: #ffffff;
+.fh-header__wishlist-list .fh-wishlist-qty-box {
+  display: flex;
+  align-items: stretch;
+  min-width: 122px;
+  height: 44px;
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
   overflow: hidden;
+  background-color: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
 }
 
-.fh-header__wishlist-list .qty-box .qty-input {
+.fh-header__wishlist-list .fh-wishlist-qty-box .qty-input {
+  flex: 1 1 56px;
+  min-width: 56px;
   border: none;
-  background: transparent;
+  background: #ffffff;
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 1rem;
   color: var(--fh-color-dark-blue);
-}
-
-.fh-header__wishlist-list .qty-box .qty-btn {
-  width: 36px;
-  border: none;
-  background: transparent;
-  color: var(--fh-color-dark-blue);
+  text-align: center;
   padding: 0;
 }
 
-.fh-header__wishlist-list .qty-box .qty-btn.disabled,
-.fh-header__wishlist-list .qty-box .qty-btn:disabled {
+.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn {
+  flex: 0 0 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: #f1f5f9;
+  color: var(--fh-color-dark-blue);
+  font-weight: 600;
+  font-size: 1.2rem;
+  padding: 0;
+  margin: 0;
+  line-height: 1;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn:first-child {
+  border-right: 1px solid #cbd5e1;
+}
+
+.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn:last-child {
+  border-left: 1px solid #cbd5e1;
+}
+
+.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn:hover,
+.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn:focus {
+  background: var(--fh-color-bright-blue);
+  color: #ffffff;
+}
+
+.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn.disabled,
+.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn:disabled {
+  background: #f8fafc;
   color: #94a3b8;
+  cursor: not-allowed;
 }
 /* End Section: FH Wishlist flyout styling */
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2134,7 +2134,7 @@ body.fh-search-overlay-open div[id^="trustbadge-container-"] {
   display: flex;
   align-items: stretch;
   min-width: 122px;
-  height: 44px;
+  height: 48px;
   border: 1px solid #cbd5e1;
   border-radius: 12px;
   overflow: hidden;
@@ -2142,9 +2142,9 @@ body.fh-search-overlay-open div[id^="trustbadge-container-"] {
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
 }
 
-.fh-header__wishlist-list .fh-wishlist-qty-box .qty-input {
-  flex: 1 1 56px;
-  min-width: 56px;
+.fh-header__wishlist-list .fh-wishlist-qty-input {
+  flex: 1 1 auto;
+  min-width: 60px;
   border: none;
   background: #ffffff;
   font-weight: 600;
@@ -2152,41 +2152,50 @@ body.fh-search-overlay-open div[id^="trustbadge-container-"] {
   color: var(--fh-color-dark-blue);
   text-align: center;
   padding: 0;
+  outline: none;
 }
 
-.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn {
-  flex: 0 0 44px;
+.fh-header__wishlist-list .fh-wishlist-qty-input:focus {
+  box-shadow: inset 0 0 0 2px var(--fh-color-bright-blue);
+}
+
+.fh-header__wishlist-list .fh-wishlist-qty-controls {
+  display: flex;
+  flex-direction: column;
+  width: 44px;
+  border-left: 1px solid #cbd5e1;
+  background: #f1f5f9;
+}
+
+.fh-header__wishlist-list .fh-wishlist-qty-controls .qty-btn {
+  flex: 1 1 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   border: none;
-  background: #f1f5f9;
+  background: transparent;
   color: var(--fh-color-dark-blue);
   font-weight: 600;
   font-size: 1.2rem;
+  line-height: 1;
   padding: 0;
   margin: 0;
-  line-height: 1;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn:first-child {
-  border-right: 1px solid #cbd5e1;
+.fh-header__wishlist-list .fh-wishlist-qty-controls .qty-btn + .qty-btn {
+  border-top: 1px solid #cbd5e1;
 }
 
-.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn:last-child {
-  border-left: 1px solid #cbd5e1;
-}
-
-.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn:hover,
-.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn:focus {
+.fh-header__wishlist-list .fh-wishlist-qty-controls .qty-btn:hover,
+.fh-header__wishlist-list .fh-wishlist-qty-controls .qty-btn:focus {
   background: var(--fh-color-bright-blue);
   color: #ffffff;
 }
 
-.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn.disabled,
-.fh-header__wishlist-list .fh-wishlist-qty-box .qty-btn:disabled {
-  background: #f8fafc;
+.fh-header__wishlist-list .fh-wishlist-qty-controls .qty-btn.disabled,
+.fh-header__wishlist-list .fh-wishlist-qty-controls .qty-btn:disabled {
+  background: transparent;
   color: #94a3b8;
   cursor: not-allowed;
 }

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2114,6 +2114,51 @@ body.fh-search-overlay-open div[id^="trustbadge-container-"] {
 }
 /* End Section: Merkliste Button Styling */
 
+/* Section: FH Wishlist flyout styling */
+.fh-header__wishlist-list .fh-wishlist-item-price {
+  color: var(--fh-color-bright-blue);
+  font-family: "industry", sans-serif;
+  font-weight: 600;
+  font-size: 1.1rem;
+  letter-spacing: 0.01em;
+}
+
+.fh-header__wishlist-list .fh-wishlist-item-base-price {
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.fh-header__wishlist-list .qty-box {
+  min-width: 128px;
+  height: 40px;
+  border: 1px solid #d8e2ef;
+  border-radius: 8px;
+  background-color: #ffffff;
+  overflow: hidden;
+}
+
+.fh-header__wishlist-list .qty-box .qty-input {
+  border: none;
+  background: transparent;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--fh-color-dark-blue);
+}
+
+.fh-header__wishlist-list .qty-box .qty-btn {
+  width: 36px;
+  border: none;
+  background: transparent;
+  color: var(--fh-color-dark-blue);
+  padding: 0;
+}
+
+.fh-header__wishlist-list .qty-box .qty-btn.disabled,
+.fh-header__wishlist-list .qty-box .qty-btn:disabled {
+  color: #94a3b8;
+}
+/* End Section: FH Wishlist flyout styling */
+
 /* Section: Body Top Margin Fix */
 div.widget.widget-grid.widget-two-col.row.mt-5 {
   margin-top: 1rem !important;

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -2225,6 +2225,9 @@ fhOnReady(function () {
       increaseButton.setAttribute('data-testing', 'quantity-btn-increase');
       increaseButton.textContent = '+';
 
+      const quantityControls = document.createElement('div');
+      quantityControls.className = 'qty-controls fh-wishlist-qty-controls';
+
       function formatQuantityDisplay(value) {
         if (Number.isInteger(value)) return String(value);
 
@@ -2366,9 +2369,10 @@ fhOnReady(function () {
           });
       });
 
-      qtyBox.appendChild(decreaseButton);
       qtyBox.appendChild(quantityInput);
-      qtyBox.appendChild(increaseButton);
+      quantityControls.appendChild(increaseButton);
+      quantityControls.appendChild(decreaseButton);
+      qtyBox.appendChild(quantityControls);
       quantityWrapper.appendChild(qtyBox);
 
       updateQuantity(normalizeQuantity(currentQuantity));

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -1968,36 +1968,6 @@ fhOnReady(function () {
     };
   }
 
-  function getBasePrice(item) {
-    if (!item || !item.prices) return '';
-
-    if (item.prices.specialOffer && item.prices.specialOffer.basePrice) {
-      const basePrice = item.prices.specialOffer.basePrice;
-
-      if (typeof basePrice === 'string') {
-        const normalized = basePrice.replace(/\s+/g, '').toLowerCase();
-
-        if (normalized === 'n/a') return '';
-      }
-
-      return basePrice;
-    }
-
-    if (item.prices.default && item.prices.default.basePrice) {
-      const basePrice = item.prices.default.basePrice;
-
-      if (typeof basePrice === 'string') {
-        const normalized = basePrice.replace(/\s+/g, '').toLowerCase();
-
-        if (normalized === 'n/a') return '';
-      }
-
-      return basePrice;
-    }
-
-    return '';
-  }
-
   function getRemoveWishListActionName(store) {
     return resolveStoreAction(store, ['wishList/removeWishListItem', 'removeWishListItem']);
   }
@@ -2057,22 +2027,6 @@ fhOnReady(function () {
         element.textContent = formatPrice(getUnitPrice(item));
       });
 
-      const basePriceElements = list.querySelectorAll('[data-fh-wishlist-base-price]');
-
-      basePriceElements.forEach(function (element) {
-        if (!element || !element.__fhWishlistItem) return;
-
-        const item = element.__fhWishlistItem;
-        const baseText = getBasePrice(item);
-
-        if (baseText) {
-          element.textContent = baseText;
-          element.style.display = '';
-        } else {
-          element.textContent = '';
-          element.style.display = 'none';
-        }
-      });
     };
 
     runUpdate();
@@ -2206,21 +2160,6 @@ fhOnReady(function () {
 
       priceLine.appendChild(priceValue);
 
-      const basePriceText = getBasePrice(item);
-      const basePrice = document.createElement('span');
-      basePrice.className = 'fh-wishlist-item-base-price';
-      basePrice.setAttribute('data-fh-wishlist-base-price', 'base');
-      basePrice.__fhWishlistItem = item;
-      basePrice.style.whiteSpace = 'nowrap';
-      if (basePriceText) {
-        basePrice.textContent = basePriceText;
-        basePrice.style.display = '';
-      } else {
-        basePrice.textContent = '';
-        basePrice.style.display = 'none';
-      }
-      priceLine.appendChild(basePrice);
-
       const actionRow = document.createElement('div');
       actionRow.style.display = 'flex';
       actionRow.style.alignItems = 'center';
@@ -2260,64 +2199,31 @@ fhOnReady(function () {
       const quantityPrecision = Math.min(6, Math.max(getDecimalPlaces(minQuantity), getDecimalPlaces(intervalQuantity)));
 
       const quantityWrapper = document.createElement('div');
-      quantityWrapper.className = 'fh-wishlist-qty-wrapper d-flex align-items-center';
-      quantityWrapper.style.gap = '8px';
-      quantityWrapper.style.flex = '0 0 auto';
+      quantityWrapper.className = 'fh-wishlist-qty-wrapper';
 
       const qtyBox = document.createElement('div');
-      qtyBox.className = 'qty-box d-flex align-items-stretch';
-      qtyBox.style.height = '40px';
-      qtyBox.style.border = '1px solid #d8e2ef';
-      qtyBox.style.borderRadius = '8px';
-      qtyBox.style.backgroundColor = '#ffffff';
-      qtyBox.style.overflow = 'hidden';
+      qtyBox.className = 'qty-box fh-wishlist-qty-box';
 
       const decreaseButton = document.createElement('button');
       decreaseButton.type = 'button';
-      decreaseButton.className = 'btn qty-btn btn-appearance d-flex align-items-center justify-content-center';
+      decreaseButton.className = 'qty-btn fh-wishlist-qty-btn';
       decreaseButton.setAttribute('aria-label', 'Menge verringern');
       decreaseButton.setAttribute('data-testing', 'quantity-btn-decrease');
-      decreaseButton.style.width = '36px';
-      decreaseButton.style.height = '100%';
-      decreaseButton.style.border = 'none';
-      decreaseButton.style.background = 'transparent';
-      decreaseButton.style.color = 'var(--fh-color-dark-blue)';
-
-      const decreaseIcon = document.createElement('i');
-      decreaseIcon.className = 'fa fa-minus default-float';
-      decreaseIcon.setAttribute('aria-hidden', 'true');
-      decreaseButton.appendChild(decreaseIcon);
+      decreaseButton.textContent = '−';
 
       const quantityInput = document.createElement('input');
-      quantityInput.className = 'qty-input text-center';
+      quantityInput.className = 'qty-input fh-wishlist-qty-input';
       quantityInput.type = 'text';
       quantityInput.setAttribute('aria-label', 'Menge wählen');
+      quantityInput.setAttribute('inputmode', quantityPrecision > 0 ? 'decimal' : 'numeric');
       quantityInput.disabled = !isSaleable(item);
-      quantityInput.style.height = '100%';
-      quantityInput.style.width = '56px';
-      quantityInput.style.border = 'none';
-      quantityInput.style.background = 'transparent';
-      quantityInput.style.fontSize = '14px';
-      quantityInput.style.fontWeight = '600';
-      quantityInput.style.padding = '0';
-      quantityInput.style.color = 'var(--fh-color-dark-blue)';
-      quantityInput.style.textAlign = 'center';
 
       const increaseButton = document.createElement('button');
       increaseButton.type = 'button';
-      increaseButton.className = 'btn qty-btn btn-appearance d-flex align-items-center justify-content-center';
+      increaseButton.className = 'qty-btn fh-wishlist-qty-btn';
       increaseButton.setAttribute('aria-label', 'Menge erhöhen');
       increaseButton.setAttribute('data-testing', 'quantity-btn-increase');
-      increaseButton.style.width = '36px';
-      increaseButton.style.height = '100%';
-      increaseButton.style.border = 'none';
-      increaseButton.style.background = 'transparent';
-      increaseButton.style.color = 'var(--fh-color-dark-blue)';
-
-      const increaseIcon = document.createElement('i');
-      increaseIcon.className = 'fa fa-plus default-float';
-      increaseIcon.setAttribute('aria-hidden', 'true');
-      increaseButton.appendChild(increaseIcon);
+      increaseButton.textContent = '+';
 
       function formatQuantityDisplay(value) {
         if (Number.isInteger(value)) return String(value);


### PR DESCRIPTION
## Summary
- propagate MwSt toggle updates to the wishlist flyout so MwSt preferences adjust saved item prices
- align the wishlist price typography and color with the product detail styling and keep base price text in sync
- rebuild the wishlist quantity selector to mirror the product page control and refresh its styles

## Testing
- Manual preview via Playwright screenshot (wishlist-preview.png)


------
https://chatgpt.com/codex/tasks/task_e_68e39aaa347c83318ec22a0b2b56548e