### PR TITLE
Default basket preview to gross totals for guests

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2504,25 +2504,25 @@ button[data-testing="quantity-btn-decrease"],
   display: none !important;
 }
 
-:root[data-fh-show-net-prices="gross"] .cmp-totals dd[data-testing="item-sum-net"],
-:root[data-fh-show-net-prices="gross"] .cmp-totals dd[data-testing="shipping-amount-net"],
-:root[data-fh-show-net-prices="gross"] .cmp-totals dt:has(+ dd[data-testing="item-sum-net"]),
-:root[data-fh-show-net-prices="gross"] .cmp-totals dt:has(+ dd[data-testing="shipping-amount-net"]) {
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals dd[data-testing="item-sum-net"],
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals dd[data-testing="shipping-amount-net"],
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals dt:has(+ dd[data-testing="item-sum-net"]),
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals dt:has(+ dd[data-testing="shipping-amount-net"]) {
   display: none !important;
 }
 
 :root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount"]),
 :root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dd[data-testing="basket-amount"],
-:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount-net"]),
-:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dd[data-testing="basket-amount-net"] {
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount-net"]),
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals .totalSum dd[data-testing="basket-amount-net"] {
   opacity: 0.6;
   font-weight: 400 !important;
 }
 
 :root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount-net"]),
 :root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dd[data-testing="basket-amount-net"],
-:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount"]),
-:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dd[data-testing="basket-amount"] {
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount"]),
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals .totalSum dd[data-testing="basket-amount"] {
   opacity: 1;
   font-weight: 700 !important;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -339,25 +339,25 @@ button[data-testing="quantity-btn-decrease"],
   display: none !important;
 }
 
-:root[data-fh-show-net-prices="gross"] .cmp-totals dd[data-testing="item-sum-net"],
-:root[data-fh-show-net-prices="gross"] .cmp-totals dd[data-testing="shipping-amount-net"],
-:root[data-fh-show-net-prices="gross"] .cmp-totals dt:has(+ dd[data-testing="item-sum-net"]),
-:root[data-fh-show-net-prices="gross"] .cmp-totals dt:has(+ dd[data-testing="shipping-amount-net"]) {
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals dd[data-testing="item-sum-net"],
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals dd[data-testing="shipping-amount-net"],
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals dt:has(+ dd[data-testing="item-sum-net"]),
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals dt:has(+ dd[data-testing="shipping-amount-net"]) {
   display: none !important;
 }
 
 :root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount"]),
 :root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dd[data-testing="basket-amount"],
-:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount-net"]),
-:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dd[data-testing="basket-amount-net"] {
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount-net"]),
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals .totalSum dd[data-testing="basket-amount-net"] {
   opacity: 0.6;
   font-weight: 400 !important;
 }
 
 :root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount-net"]),
 :root[data-fh-show-net-prices="net"] .cmp-totals .totalSum dd[data-testing="basket-amount-net"],
-:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount"]),
-:root[data-fh-show-net-prices="gross"] .cmp-totals .totalSum dd[data-testing="basket-amount"] {
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals .totalSum dt:has(+ dd[data-testing="basket-amount"]),
+:root:not([data-fh-show-net-prices="net"]) .cmp-totals .totalSum dd[data-testing="basket-amount"] {
   opacity: 1;
   font-weight: 700 !important;
 }


### PR DESCRIPTION
## Summary
- treat the absence of a net price attribute as a gross display
- hide net totals in basket preview for guests across both shop themes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4b11ea5f48331ae6e00cdc6135d8e