### PR TITLE
Style default product cards thumbnails

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -33,6 +33,15 @@ body,
 }
 /* End Section: Artikel Preview Card Preis Styling */
 
+/* Section: Default plenty product card styling */
+.widget-item-grid .cmp-product-thumb {
+  margin-bottom: 0 !important;
+  border: solid;
+  border-radius: 6px;
+  border-color: #f6f6f6;
+}
+/* End Section: Default plenty product card styling */
+
 /* End Section: Custom Schriftarten + Preis Text Stylings */
 
 /* Section: FH Header Base Layout */

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -19,6 +19,15 @@
 }
 /* End Section: Artikel Preview Card Preis Styling */
 
+/* Section: Default plenty product card styling */
+.widget-item-grid .cmp-product-thumb {
+  margin-bottom: 0 !important;
+  border: solid;
+  border-radius: 6px;
+  border-color: #f6f6f6;
+}
+/* End Section: Default plenty product card styling */
+
 /* Section: Trustbadge ausblenden */
 .basket-open .widget_container_overlay,
 .basket-open #trustami-mobile-view,


### PR DESCRIPTION
## Summary
- add a shared section in both shop stylesheets for default plenty product cards
- style .cmp-product-thumb thumbnails with a light border, rounded corners, and no extra bottom margin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4c4d780e48331a630ecccfdba9f0a