### PR TITLE
Hide Artikelpaket badge in product cards

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -33,6 +33,12 @@ body,
 }
 /* End Section: Artikel Preview Card Preis Styling */
 
+/* Section: Artikelpaket Badge ausblenden */
+.cmp-product-thumb .badge.badge-bundle {
+  display: none !important;
+}
+/* End Section: Artikelpaket Badge ausblenden */
+
 /* Section: Default plenty product card styling */
 .widget-item-grid .cmp-product-thumb {
   margin-bottom: 0 !important;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -19,6 +19,12 @@
 }
 /* End Section: Artikel Preview Card Preis Styling */
 
+/* Section: Artikelpaket Badge ausblenden */
+.cmp-product-thumb .badge.badge-bundle {
+  display: none !important;
+}
+/* End Section: Artikelpaket Badge ausblenden */
+
 /* Section: Default plenty product card styling */
 .widget-item-grid .cmp-product-thumb {
   margin-bottom: 0 !important;


### PR DESCRIPTION
## Summary
- hide the "Artikelpaket" badge by targeting the bundle badge element in both FH and SH stylesheets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e11eb6d0833186c738e0ef4f006b