### PR TITLE
Add hover border color for FH product cards

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -47,6 +47,10 @@ body,
   border-color: #f6f6f6;
   padding: 12px;
 }
+
+.widget-item-grid .cmp-product-thumb:hover {
+  border-color: var(--fh-color-bright-blue);
+}
 /* End Section: Default plenty product card styling */
 
 /* End Section: Custom Schriftarten + Preis Text Stylings */


### PR DESCRIPTION
## Summary
- update FH product thumb styling to use the bright blue brand color on hover for grid items

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4ed9ade288331a810f5809ed22800