### PR TITLE
Add contextual info cards for key shop content

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -11,6 +11,10 @@
   --fh-color-body-surface: #fbfbfb; /* Subtle light grey body background */
   --fh-color-input-surface: #f3f4f6; /* Soft grey for input backgrounds */
   --fh-shadow-elevation-soft: 0 24px 48px -32px rgba(15, 23, 42, 0.35); /* Modern diffused shadow */
+  --hs-info-accent-color: var(--fh-color-navy-blue);
+  --hs-info-accent-highlight: var(--fh-color-bright-blue);
+  --hs-info-header-bg: #e5e7eb;
+  --hs-info-body-color: #374151;
 }
 
 body,
@@ -2705,3 +2709,192 @@ button[data-testing="quantity-btn-decrease"],
   transition: opacity 0.2s ease, font-weight 0.2s ease;
 }
 /* End Section: Basket preview totals visibility */
+
+/* Section: Contextual info card component */
+.hs-info-target {
+  position: relative;
+  --hs-info-trigger-size: 28px;
+  --hs-info-trigger-gap: 0.75rem;
+}
+
+.hs-info-target[data-hs-info-inline="true"] {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--hs-info-trigger-gap);
+  padding-right: 0;
+}
+
+.hs-info-target[data-hs-info-inline="false"] {
+  padding-right: calc(var(--hs-info-trigger-size) + var(--hs-info-trigger-gap));
+}
+
+.hs-info-card {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  z-index: 40;
+}
+
+.hs-info-target[data-hs-info-inline="true"] .hs-info-card {
+  position: relative;
+  top: auto;
+  right: auto;
+  transform: none;
+}
+
+.hs-info-card__trigger {
+  width: var(--hs-info-trigger-size);
+  height: var(--hs-info-trigger-size);
+  border-radius: 999px;
+  border: 1px solid rgba(31, 41, 55, 0.35);
+  background: var(--hs-info-surface, var(--fh-color-surface));
+  color: var(--hs-info-accent-color);
+  font-size: 1rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.1);
+}
+
+.hs-info-card__trigger:hover,
+.hs-info-card__trigger:focus {
+  outline: none;
+  border-color: var(--hs-info-accent-highlight);
+  color: var(--hs-info-accent-highlight);
+  box-shadow: 0 10px 20px rgba(49, 165, 240, 0.18);
+}
+
+.hs-info-card__trigger[aria-expanded="true"] {
+  border-color: var(--hs-info-accent-highlight);
+  color: var(--hs-info-accent-highlight);
+}
+
+.hs-info-card__panel {
+  position: absolute;
+  min-width: 260px;
+  max-width: 320px;
+  border-radius: 14px;
+  background: var(--hs-info-surface, var(--fh-color-surface));
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: var(--hs-info-shadow, var(--fh-shadow-elevation-soft));
+  overflow: hidden;
+  opacity: 0;
+  visibility: hidden;
+  transform-origin: top left;
+  transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+  z-index: 45;
+}
+
+.hs-info-card__panel.is-visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+.hs-info-card__panel--right {
+  top: 50%;
+  left: calc(100% + 14px);
+  transform: translateY(-50%) scale(0.96);
+}
+
+.hs-info-card__panel--top {
+  bottom: calc(100% + 14px);
+  left: 50%;
+  transform: translate(-50%, -6%) scale(0.96);
+}
+
+.hs-info-card__panel.is-visible.hs-info-card__panel--right {
+  transform: translateY(-50%) scale(1);
+}
+
+.hs-info-card__panel.is-visible.hs-info-card__panel--top {
+  transform: translate(-50%, 0) scale(1);
+}
+
+.hs-info-card__header {
+  background: var(--hs-info-header-bg);
+  color: var(--hs-info-accent-color);
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.hs-info-card__close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.hs-info-card__title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1.35;
+}
+
+.hs-info-card__body {
+  padding: 1rem;
+  color: var(--hs-info-body-color);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.hs-info-card__body strong {
+  color: var(--hs-info-accent-color);
+}
+
+.hs-info-card-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, visibility 0.2s ease;
+  z-index: 999;
+}
+
+.hs-info-card-overlay.is-active {
+  opacity: 1;
+  visibility: visible;
+}
+
+@media (min-width: 768px) {
+  .hs-info-card-overlay {
+    display: none;
+  }
+}
+
+@media (max-width: 767px) {
+  .hs-info-target[data-hs-info-inline="false"] {
+    padding-right: 0;
+  }
+
+  .hs-info-card {
+    position: static;
+    transform: none;
+  }
+
+  .hs-info-card__panel {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(0.94);
+    width: min(360px, calc(100% - 32px));
+    max-width: 90vw;
+    z-index: 1000;
+  }
+
+  .hs-info-card__panel.is-visible {
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+/* End Section: Contextual info card component */

--- a/Javascript/FH - Javascript am Ende der Seite.js
+++ b/Javascript/FH - Javascript am Ende der Seite.js
@@ -3161,6 +3161,236 @@ fhOnReady(function () {
   waitForCountdownDiv();
   setInterval(waitForCountdownDiv, 1000);
 })();
+
+// Section: Contextual info cards
+fhOnReady(function () {
+  var configs = [
+    {
+      target: '#cutoff-countdown',
+      title: 'Bestell-Countdown',
+      body: '<p>Wir versprechen Ihnen, dass Ihr Paket noch am selben Arbeitstag unser Lager verlässt, sofern Sie bis 13:00 Uhr Ihre bezahlte Bestellung bei uns aufgeben.</p><p>Dies ist unser <strong>Hammer Versandversprechen</strong>.</p>',
+      placement: 'right',
+      inline: false,
+    },
+    {
+      target: '.free-shipping-bar__label',
+      title: 'Gratisversand-Balken',
+      body: '<p>Sie erhalten kostenlosen Standardversand via DHL (1-3 Tage reguläre Lieferzeit), wenn Ihr Brutto-Warenwert 150&nbsp;Euro erreicht hat.</p><p>Gratisversand ist nur für Lieferungen nach Deutschland verfügbar.</p>',
+      placement: 'top',
+      inline: true,
+    },
+    {
+      target: '.fh-header__customer-contact-heading',
+      title: 'Ihr Ansprechpartner',
+      body: '<p>Da Sie ein besonders geschätzter Kunde von uns sind, erhalten Sie direkten Zugriff zu einem unserer Produktexperten &amp; Kundenbetreuer.</p><p>Wenden Sie sich gerne direkt an Ihren Ansprechpartner, um exklusiven Zugriff auf besondere Angebote und mehr zu erhalten.</p>',
+      placement: 'right',
+      inline: false,
+    },
+    {
+      target: '.fh-header__panel-title',
+      title: 'Merkliste',
+      body: '<p>Wenn Sie nicht eingeloggt sind, wird Ihre Merkliste im Browser gespeichert.</p><p>Eingeloggt dagegen sicher in Ihrem Kundenkonto – jeweils bis Sie die Einträge oder Daten löschen.</p>',
+      placement: 'right',
+      inline: false,
+    },
+  ];
+
+  if (!configs.length) return;
+
+  var registry = window.hsInfoCardRegistry;
+
+  if (!registry || !registry.overlay || !registry.overlay.isConnected) {
+    var overlay = document.createElement('div');
+    overlay.className = 'hs-info-card-overlay';
+    overlay.setAttribute('data-hs-info-overlay', 'true');
+    overlay.setAttribute('hidden', '');
+    document.body.appendChild(overlay);
+
+    registry = {
+      overlay: overlay,
+      activeCard: null,
+    };
+
+    overlay.addEventListener('click', function () {
+      if (registry.activeCard && typeof registry.activeCard.close === 'function') {
+        registry.activeCard.close();
+      }
+    });
+  }
+
+  window.hsInfoCardRegistry = registry;
+
+  var idCounter = 0;
+
+  configs.forEach(function (config) {
+    createInfoCard(config);
+  });
+
+  function createInfoCard(config) {
+    var target = document.querySelector(config.target);
+
+    if (!target) return;
+    if (target.querySelector(':scope > .hs-info-card')) return;
+
+    var inlinePlacement = !!config.inline;
+
+    target.classList.add('hs-info-target');
+    target.setAttribute('data-hs-info-inline', inlinePlacement ? 'true' : 'false');
+
+    var container = document.createElement('div');
+    container.className = 'hs-info-card';
+
+    var trigger = document.createElement('button');
+    trigger.type = 'button';
+    trigger.className = 'hs-info-card__trigger';
+    trigger.setAttribute('aria-expanded', 'false');
+    trigger.setAttribute('aria-label', config.title + ' – weitere Informationen');
+
+    var triggerIcon = document.createElement('span');
+    triggerIcon.setAttribute('aria-hidden', 'true');
+    triggerIcon.textContent = 'ℹ️';
+    trigger.appendChild(triggerIcon);
+
+    idCounter += 1;
+    var panelId = 'hs-info-card-panel-' + idCounter;
+    var titleId = 'hs-info-card-title-' + idCounter;
+
+    trigger.setAttribute('aria-controls', panelId);
+
+    var panel = document.createElement('div');
+    var panelPlacement = config.placement === 'top' ? 'top' : 'right';
+    panel.className = 'hs-info-card__panel hs-info-card__panel--' + panelPlacement;
+    panel.id = panelId;
+    panel.setAttribute('role', 'dialog');
+    panel.setAttribute('aria-modal', 'false');
+    panel.setAttribute('aria-hidden', 'true');
+    panel.setAttribute('aria-labelledby', titleId);
+
+    var header = document.createElement('div');
+    header.className = 'hs-info-card__header';
+
+    var closeButton = document.createElement('button');
+    closeButton.type = 'button';
+    closeButton.className = 'hs-info-card__close';
+    closeButton.setAttribute('aria-label', 'Information schließen');
+    closeButton.textContent = '×';
+
+    var titleElement = document.createElement('div');
+    titleElement.className = 'hs-info-card__title';
+    titleElement.id = titleId;
+    titleElement.textContent = config.title;
+
+    header.appendChild(closeButton);
+    header.appendChild(titleElement);
+
+    var body = document.createElement('div');
+    body.className = 'hs-info-card__body';
+    body.innerHTML = config.body;
+
+    panel.appendChild(header);
+    panel.appendChild(body);
+
+    container.appendChild(trigger);
+    container.appendChild(panel);
+
+    target.appendChild(container);
+
+    var isOpen = false;
+    var isPinned = false;
+
+    var api = {
+      close: closeCard,
+    };
+
+    function openCard(pinned) {
+      if (isOpen && pinned && isPinned) return;
+
+      if (registry.activeCard && registry.activeCard !== api && typeof registry.activeCard.close === 'function') {
+        registry.activeCard.close();
+      }
+
+      isOpen = true;
+      if (pinned) isPinned = true;
+
+      trigger.setAttribute('aria-expanded', 'true');
+      panel.classList.add('is-visible');
+      panel.setAttribute('aria-hidden', 'false');
+
+      registry.activeCard = api;
+
+      if (window.matchMedia('(max-width: 767px)').matches) {
+        registry.overlay.classList.add('is-active');
+        registry.overlay.removeAttribute('hidden');
+      }
+
+      document.addEventListener('pointerdown', handleDocumentPointer, true);
+      document.addEventListener('keydown', handleKeydown, true);
+    }
+
+    function closeCard() {
+      if (!isOpen) return;
+
+      isOpen = false;
+      isPinned = false;
+
+      trigger.setAttribute('aria-expanded', 'false');
+      panel.classList.remove('is-visible');
+      panel.setAttribute('aria-hidden', 'true');
+
+      if (registry.activeCard === api) {
+        registry.activeCard = null;
+      }
+
+      if (!registry.activeCard && registry.overlay) {
+        registry.overlay.classList.remove('is-active');
+        if (!registry.overlay.hasAttribute('hidden')) {
+          registry.overlay.setAttribute('hidden', '');
+        }
+      }
+
+      document.removeEventListener('pointerdown', handleDocumentPointer, true);
+      document.removeEventListener('keydown', handleKeydown, true);
+    }
+
+    function handleDocumentPointer(event) {
+      if (!isOpen) return;
+      if (container.contains(event.target)) return;
+      closeCard();
+    }
+
+    function handleKeydown(event) {
+      if (!isOpen) return;
+      if (event.key === 'Escape' || event.key === 'Esc') {
+        event.preventDefault();
+        closeCard();
+        trigger.focus();
+      }
+    }
+
+    container.addEventListener('mouseenter', function () {
+      if (!isPinned) openCard(false);
+    });
+
+    container.addEventListener('mouseleave', function () {
+      if (!isPinned) closeCard();
+    });
+
+    trigger.addEventListener('click', function (event) {
+      event.preventDefault();
+      if (isPinned) {
+        closeCard();
+      } else {
+        openCard(true);
+      }
+    });
+
+    closeButton.addEventListener('click', function (event) {
+      event.preventDefault();
+      closeCard();
+    });
+  }
+});
+// End Section: Contextual info cards
 // End Section: Bestell-Versand Countdown Code
 
 // Section: Versand Icons ändern & einfügen (läuft auf ALLEN Seiten inkl. Checkout)

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -2,6 +2,17 @@
 
 @import url("https://use.typekit.net/lwl7tyw.css");
 
+:root {
+  --hs-info-accent-color: #8c1c13;
+  --hs-info-accent-highlight: #f20000;
+  --hs-info-header-bg: #f3f4f6;
+  --hs-info-body-color: #3f3f46;
+  --hs-info-trigger-size: 28px;
+  --hs-info-trigger-gap: 0.75rem;
+  --hs-info-surface: #ffffff;
+  --hs-info-shadow: 0 24px 48px -32px rgba(15, 23, 42, 0.35);
+}
+
 .price.h1 {
   font-family: "industry", sans-serif;
   font-weight: 600;
@@ -522,3 +533,192 @@ button[data-testing="quantity-btn-decrease"],
   transition: opacity 0.2s ease, font-weight 0.2s ease;
 }
 /* End Section: Basket preview totals visibility */
+
+/* Section: Contextual info card component */
+.hs-info-target {
+  position: relative;
+  --hs-info-trigger-size: 28px;
+  --hs-info-trigger-gap: 0.75rem;
+}
+
+.hs-info-target[data-hs-info-inline="true"] {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--hs-info-trigger-gap);
+  padding-right: 0;
+}
+
+.hs-info-target[data-hs-info-inline="false"] {
+  padding-right: calc(var(--hs-info-trigger-size) + var(--hs-info-trigger-gap));
+}
+
+.hs-info-card {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  z-index: 40;
+}
+
+.hs-info-target[data-hs-info-inline="true"] .hs-info-card {
+  position: relative;
+  top: auto;
+  right: auto;
+  transform: none;
+}
+
+.hs-info-card__trigger {
+  width: var(--hs-info-trigger-size);
+  height: var(--hs-info-trigger-size);
+  border-radius: 999px;
+  border: 1px solid rgba(124, 45, 18, 0.35);
+  background: var(--hs-info-surface);
+  color: var(--hs-info-accent-color);
+  font-size: 1rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.1);
+}
+
+.hs-info-card__trigger:hover,
+.hs-info-card__trigger:focus {
+  outline: none;
+  border-color: var(--hs-info-accent-highlight);
+  color: var(--hs-info-accent-highlight);
+  box-shadow: 0 10px 20px rgba(242, 0, 0, 0.18);
+}
+
+.hs-info-card__trigger[aria-expanded="true"] {
+  border-color: var(--hs-info-accent-highlight);
+  color: var(--hs-info-accent-highlight);
+}
+
+.hs-info-card__panel {
+  position: absolute;
+  min-width: 260px;
+  max-width: 320px;
+  border-radius: 14px;
+  background: var(--hs-info-surface);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: var(--hs-info-shadow);
+  overflow: hidden;
+  opacity: 0;
+  visibility: hidden;
+  transform-origin: top left;
+  transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+  z-index: 45;
+}
+
+.hs-info-card__panel.is-visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+.hs-info-card__panel--right {
+  top: 50%;
+  left: calc(100% + 14px);
+  transform: translateY(-50%) scale(0.96);
+}
+
+.hs-info-card__panel--top {
+  bottom: calc(100% + 14px);
+  left: 50%;
+  transform: translate(-50%, -6%) scale(0.96);
+}
+
+.hs-info-card__panel.is-visible.hs-info-card__panel--right {
+  transform: translateY(-50%) scale(1);
+}
+
+.hs-info-card__panel.is-visible.hs-info-card__panel--top {
+  transform: translate(-50%, 0) scale(1);
+}
+
+.hs-info-card__header {
+  background: var(--hs-info-header-bg);
+  color: var(--hs-info-accent-color);
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.hs-info-card__close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.hs-info-card__title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1.35;
+}
+
+.hs-info-card__body {
+  padding: 1rem;
+  color: var(--hs-info-body-color);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.hs-info-card__body strong {
+  color: var(--hs-info-accent-color);
+}
+
+.hs-info-card-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease, visibility 0.2s ease;
+  z-index: 999;
+}
+
+.hs-info-card-overlay.is-active {
+  opacity: 1;
+  visibility: visible;
+}
+
+@media (min-width: 768px) {
+  .hs-info-card-overlay {
+    display: none;
+  }
+}
+
+@media (max-width: 767px) {
+  .hs-info-target[data-hs-info-inline="false"] {
+    padding-right: 0;
+  }
+
+  .hs-info-card {
+    position: static;
+    transform: none;
+  }
+
+  .hs-info-card__panel {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(0.94);
+    width: min(360px, calc(100% - 32px));
+    max-width: 90vw;
+    z-index: 1000;
+  }
+
+  .hs-info-card__panel.is-visible {
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+/* End Section: Contextual info card component */


### PR DESCRIPTION
## Summary
- add shared styling for contextual info cards with modal presentation on mobile
- render reusable info-card triggers for countdown, free shipping, contact, and wishlist hints
- add overlay and close handling so cards can be dismissed via icon, close button, or clicking outside

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e51300f9648331af98ae83f278d6a1