### PR TITLE
Document plentyShop LTS 5.0.76 dependency versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,24 +9,80 @@ Ich möchte den Header und Footer für die Hammer-Shops (FH und SH) auf Basis vo
 * **Verknüpfung:** Alle Anpassungen in diesem Repo greifen in die bestehenden Ceres-Templates ein. Prüfe daher vor Änderungen, welche IDs, Klassen, Slots oder Komponenten Ceres bereits liefert, und stelle sicher, dass Custom CSS/JS sauber darauf aufsetzt.
 * **Priorität:** Header- und Footer-Rebuilds haben Vorrang gegenüber sonstigen Styling-Hacks. Ergänzende Funktionen (Countdown, Progressbars etc.) dürfen nur eingefügt werden, wenn sie mit dem neuen Aufbau kompatibel sind.
 
-## Technologiestack plentyShop LTS (2025)
+## Technologiestack plentyShop LTS 5.0.76
 
-| Layer / Area        | Framework / Tool        | Version / Note                                               | Purpose                                                   |
-|---------------------|-------------------------|--------------------------------------------------------------|-----------------------------------------------------------|
-| **Backend Runtime** | PHP                     | **PHP 8.0+** (frühere Docs 7.3/7.4, mittlerweile PHP 8)      | Core server-side logic, Plugin-System                      |
-| **Templating**      | Twig                    | v2+                                                          | View-Layer, trennt Logik und Design                        |
-| **Frontend JS**     | Vue.js                  | v2.x (Migration zu Vue 3 vorbereitet)                        | Reaktive Komponenten (Filter, Warenkorb, Checkout)         |
-| **Legacy JS**       | jQuery                  | 3.x                                                          | DOM-Manipulation, ältere Widgets                           |
-| **CSS Preprocessor**| SASS (SCSS Syntax)      | Aktuell (node-sass / dart-sass)                              | Pflegeleichte Stylesheets                                  |
-| **CSS Framework**   | Bootstrap               | 4.x                                                          | Responsives Grid und UI-Komponenten                        |
-| **Build System**    | Webpack                 | 4.x/5.x je nach Plugin-Version                               | Bündelt JS, kompiliert SASS → CSS, Asset-Pipeline          |
-| **Package Manager** | Node.js + npm           | Node 14+ / npm 6+ (versionsabhängig)                          | Dependency- & Build-Tooling                                |
-| **E-Commerce Core** | PlentyONE Plugin System | plentyShop LTS + IO Plugin                                   | Shop-Funktionen (Checkout, Warenkorb, Suche, etc.)         |
-| **Data Layer**      | REST API (Plentymarkets)| JSON-basierte REST-API                                       | Stellt Produkt-, Kunden-, Bestelldaten bereit              |
-| **SEO/Markup**      | Schema.org JSON-LD      | BreadcrumbList, Product Schema                               | Strukturierte Daten für Suchmaschinen                      |
-| **Trust/Widgets**   | Trusted Shops u. a.     | Drittanbieter-JS                                             | Reviews, Trustbadges, Rechtliches                          |
+Die folgende Übersicht fasst alle relevanten Versionen der offiziellen plentyShop-LTS-Plugins (Ceres & IO) in Release **5.0.76** zusammen und beschreibt, wofür sie genutzt werden.
 
-## Primäre Referenzen & Ressourcen
+### Core & Laufzeit
+
+| Bereich | Komponente | Version | Nutzung & Umfang |
+| --- | --- | --- | --- |
+| Backend Runtime | PHP | `^7.3 \|\| ^8.0` | Mindestanforderung laut `plugin-io` für sämtliche Backend-Logik, Controller und Helper. |
+| Plenty Plugin Platform | plentyShop LTS (Ceres) | `5.0.76` | Standard-Storefront mit Twig/Vue-Templates, Ressourcen und Übersetzungen. |
+| Plenty Plugin Platform | IO-Plugin | `5.0.76` | Liefert Routing, Controller, Services und REST-Brücken für Ceres. |
+| Node.js Engine | Node.js | `14` | Erforderlich laut `package.json` (Ceres) für Build- und Tooling-Aufgaben. |
+| Paketmanager | npm | `6` (mit Node 14 gebündelt) | Installiert Frontend- und Build-Abhängigkeiten. |
+
+### Frontend-Laufzeitbibliotheken (Ceres `package.json`)
+
+| Layer | Bibliothek | Version | Einsatzgebiet |
+| --- | --- | --- | --- |
+| SPA-Komponenten | vue | `^2.6.12` | Reaktive Komponenten (Filter, Warenkorb, Checkout, Widgets). |
+| SPA-Komponenten | vue-template-compiler | `^2.6.12` | Kompiliert Vue-SFCs während des Builds. |
+| State Management | vuex | `^3.3.0` | Globale Statusverwaltung (Warenkorb, Login, Filter). |
+| SSR/Lazy Hydration | vue-lazy-hydration | `^2.0.0-beta.4` | Verzögert Vue-Mounting für bessere Performance. |
+| Listen-Rendering | vue-virtual-scroller | `^1.0.10` | Virtuelles Scrolling für lange Listen (z. B. Artikellisten). |
+| UI-Framework | bootstrap | `4.4.1` | Grid-System, Utility-Klassen und Basis-UI für das gesamte Theme. |
+| Legacy DOM | jquery | `^3.5.1` | Unterstützt ältere Widgets, DOM-Manipulation und jQuery-Plug-ins. |
+| Tooltips/Dropdowns | popper.js | `^1.16.1` | Positions-Engine für Bootstrap-Komponenten. |
+| Polyfills | core-js | `^3.6.5` | ECMAScript-Polyfills für ältere Browser. |
+| Datum/Zeiten | dayjs | `^1.8.26` | Datumsformatierung in Frontend-Komponenten. |
+| Feature Detection | detect-browser | `^4.8.0` | Browsererkennung für konditionales Verhalten. |
+| Assets | flag-icon-css | `^2.9.0` | Flaggen-Icons für Sprach-/Länderauswahl. |
+| Assets | font-awesome | `^4.6.3` | Icon-Schriften für UI-Elemente. |
+| Slider | owl.carousel | `2.2.0` | Karussell für Produkt-Slider & Teaser. |
+| Utilities | lodash | `^4.17.21` | Hilfsfunktionen (Debounce, Cloning, Collections). |
+| MIME Handling | mime-types | `^2.1.35` | Typzuordnung in Upload-/Download-Flows. |
+| Custom Events | custom-event-polyfill | `^1.0.0` | Polyfill für `CustomEvent` in älteren Browsern. |
+
+### Build-, QA- und Test-Tooling (Ceres `devDependencies`)
+
+| Tooling-Bereich | Paket | Version | Verwendung |
+| --- | --- | --- | --- |
+| Bundling | webpack | `^4.43.0` | Bündelt JS, kompiliert Assets (Client/Server/Styles). |
+| Bundling | webpack-cli | `^3.3.11` | CLI für Webpack-Builds. |
+| Bundling | webpack-fix-style-only-entries | `^0.3.1` | Entfernt leere JS-Dateien bei reinen Style-Entries. |
+| Bundling | webpack-require-from | `^1.8.1` | Lädt Assets relativ zur Shop-Domain. |
+| Transpilation | @babel/core | `^7.10.5` | ECMAScript-Transpilation. |
+| Transpilation | @babel/preset-env | `^7.9.6` | Ziel-Browser-Matrix. |
+| Transpilation | @babel/plugin-proposal-object-rest-spread | `^7.9.6` | Unterstützt moderne Syntax. |
+| Transpilation | @babel/plugin-syntax-dynamic-import | `^7.8.3` | Ermöglicht dynamische Imports. |
+| Loader | babel-loader | `^8.1.0` | Bindet Babel in Webpack ein. |
+| Styles | sass | `^1.49.9` | Dart-Sass-Compiler für SCSS. |
+| Styles | sass-loader | `^7.3.1` | Webpack-Loader für SCSS → CSS. |
+| Styles | postcss | `^8.4.31` | Nachbearbeitung (Autoprefixing etc.). |
+| Styles | postcss-loader | `^3.0.0` | Bindet PostCSS in Webpack ein. |
+| Styles | postcss-scss | `^1.0.5` | SCSS-Syntax-Support in PostCSS. |
+| Styles | autoprefixer | `^8.6.5` | Vendor-Prefixes für CSS. |
+| Styles | mini-css-extract-plugin | `^0.8.2` | Extrahiert CSS in Dateien. |
+| Styles | stylelint | `^14.16.1` | Linting für SCSS-Dateien. |
+| Styles | stylelint-config-twbs-bootstrap | `^7.0.0` | Bootstrap-spezifische Stylelint-Regeln. |
+| JS-Qualität | eslint | `^6.8.0` | JavaScript-Linting. |
+| JS-Qualität | eslint-config-google | `^0.13.0` | Regelset für ESLint. |
+| JS-Qualität | eslint-loader | `^2.2.1` | Integriert ESLint in Webpack. |
+| JS-Qualität | babel-eslint | `^10.1.0` | Parser für ESLint & moderne Syntax. |
+| Tools | copy-webpack-plugin | `^6.4.1` | Kopiert statische Assets. |
+| Tools | expose-loader | `^0.7.5` | Exponiert Module global (z. B. jQuery). |
+| Tools | glob | `^7.1.6` | Dateisuchen für Build-Skripte. |
+| Tools | del | `^2.2.0` | Löscht Build-Ordner. |
+| Tools | serialize-javascript | `^3.1.0` | Serialisiert Daten in Templates. |
+| Tools | q | `^1.5.1` | Promise-Hilfsbibliothek in Tools. |
+| Tools | esm | `^3.2.25` | ESM-Unterstützung für Node-Skripte. |
+| Testing | cypress | `^8.5.0` | E2E-Tests für Checkout & Storefront. |
+| Testing | cypress-file-upload | `^4.1.1` | File-Upload-Unterstützung in Tests. |
+| Testing | moment-locales-webpack-plugin | `^1.2.0` | Optimiert Moment.js-Lokalisierungen (Altbestand). |
+
+### Daten & Schnittstellen
 
 * **REST-API-Dokumentation:** https://developers.plentymarkets.com/en-gb/plentymarkets-rest-api/index.html – Ziehe diese Quelle immer heran, wenn du Datenflüsse, Endpunkte oder Datenstrukturen verstehen oder erweitern musst. Für reine CSS- oder HTML-Änderungen ist ein Blick in die API-Dokumentation in der Regel nicht erforderlich.
 * **IO-Plugin:** https://github.com/plentymarkets/plugin-io – Das IO-Plugin liefert wesentliche Shop-Funktionalitäten (Routing, Controller, Widgets). Prüfe vor komplexeren JS-Anpassungen, ob hier bereits passende Hooks oder Komponenten existieren. Bei kosmetischen Anpassungen kann dieses Nachschlagen entfallen.

--- a/Documentation/ceres-tech-stack.md
+++ b/Documentation/ceres-tech-stack.md
@@ -1,0 +1,17 @@
+# Ceres Frontend Framework References (Stand: plentyShop LTS 2025)
+
+Um offene Fragen zur eingesetzten Frontend-Technologie des offiziellen plentyShop-LTS-Themes schnell beantworten zu können, lohnt sich ein Blick in das `package.json` des Ceres-Plugins.
+
+```json
+{
+  "dependencies": {
+    "vue": "^2.6.12"
+  }
+}
+```
+
+- **Vue.js:** In der aktuellen Stable-Version (`v5.0.76`) ist als reguläre Abhängigkeit `"vue": "^2.6.12"` eingetragen. Damit wird Vue 2.6 (konkret 2.6.12 und kompatible Patch-Releases) vom Buildsystem installiert.
+
+> Quelle: [`plugin-ceres/package.json`](../../plugin-ceres/package.json)
+
+Dieser Abgleich ist besonders wichtig, wenn neue Komponenten oder externe Bibliotheken integriert werden sollen. Er verhindert, dass versehentlich Vue-3-spezifische Syntax oder Tailwind-spezifische Utility-Klassen in das LTS-Theme gelangen.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,80 @@ Dieses Repository sammelt alle CSS- und JavaScript-Anpassungen, mit denen wir di
   3. Änderungen an diesem Repository müssen mit den jeweiligen Twig- und Vue-Komponenten aus Ceres abgeglichen werden, damit IDs, Klassen und Slots korrekt angesprochen werden.
 * **Priorität:** Wenn Entscheidungen zwischen Inline-Anpassungen hier und nativen Ceres-Funktionen zu treffen sind, gilt: Header- und Footer-Neubauten haben Vorrang, danach greifen zusätzliche Styles oder Skripte.
 
-### Relevante Dokumentation & Ressourcen
+## Technologie-Stack plentyShop LTS 5.0.76
+
+Die Version **5.0.76** der offiziellen plentyShop-LTS-Plugins (Ceres & IO) bildet den Referenzstand für alle Arbeiten in diesem Repository. Die folgenden Tabellen listen sämtliche relevanten Komponenten, deren Version sowie Einsatz und Reichweite auf.
+
+### Core & Laufzeit
+
+| Bereich | Komponente | Version | Nutzung & Umfang |
+| --- | --- | --- | --- |
+| Backend Runtime | PHP | `^7.3 \|\| ^8.0` | Mindestanforderung laut `plugin-io`; betreibt Controller, Services und Logikschichten. |
+| Plenty Plugin Platform | plentyShop LTS (Ceres) | `5.0.76` | Standard-Storefront inkl. Twig-/Vue-Templates, Assets und Übersetzungen. |
+| Plenty Plugin Platform | IO-Plugin | `5.0.76` | Liefert Routing, Controller, REST-Brücken und Basisfunktionen für Ceres. |
+| Node.js Engine | Node.js | `14` | Erforderlich laut `package.json` (Ceres) für Build-Skripte und Tooling. |
+| Paketmanager | npm | `6` (Node 14) | Installiert/verwaltet alle Frontend-Abhängigkeiten und Build-Tools. |
+
+### Frontend-Laufzeitbibliotheken (Ceres `package.json`)
+
+| Layer | Bibliothek | Version | Einsatzgebiet |
+| --- | --- | --- | --- |
+| SPA-Komponenten | vue | `^2.6.12` | Reaktive UI-Komponenten in der Storefront (Filter, Warenkorb, Checkout). |
+| SPA-Komponenten | vue-template-compiler | `^2.6.12` | Kompiliert Vue-Komponenten während des Builds. |
+| State Management | vuex | `^3.3.0` | Globaler Zustand (Warenkorb, Kundendaten, Facetten). |
+| SSR/Lazy Hydration | vue-lazy-hydration | `^2.0.0-beta.4` | Verzögert Vue-Mounting zur Performance-Optimierung. |
+| Listen-Rendering | vue-virtual-scroller | `^1.0.10` | Virtuelle Listen für große Datenmengen (Produktlisten etc.). |
+| UI-Framework | bootstrap | `4.4.1` | Grid, Utilities und Basis-Komponenten für das Theme. |
+| Legacy DOM | jquery | `^3.5.1` | DOM-Manipulation & Legacy-Widgets, solange Vue-Migration noch läuft. |
+| Tooltips/Dropdowns | popper.js | `^1.16.1` | Positions-Engine für Bootstrap-Elemente. |
+| Polyfills | core-js | `^3.6.5` | ECMAScript-Polyfills für ältere Browser. |
+| Datum/Zeiten | dayjs | `^1.8.26` | Datum-/Zeitformatierung für Frontend-Komponenten. |
+| Feature Detection | detect-browser | `^4.8.0` | Browsererkennung zur Feature-Steuerung. |
+| Assets | flag-icon-css | `^2.9.0` | Flaggen-Icons z. B. für Sprach-/Länderauswahl. |
+| Assets | font-awesome | `^4.6.3` | Icon-Font für UI-Bausteine. |
+| Slider | owl.carousel | `2.2.0` | Karussell für Teaser und Produkt-Slider. |
+| Utilities | lodash | `^4.17.21` | Utility-Funktionen (Debounce, Clone, Collections). |
+| MIME Handling | mime-types | `^2.1.35` | Typzuordnung für Upload-/Download-Flows. |
+| Custom Events | custom-event-polyfill | `^1.0.0` | Polyfill für `CustomEvent` in nicht unterstützten Browsern. |
+
+### Build-, QA- und Test-Tooling (Ceres `devDependencies`)
+
+| Tooling-Bereich | Paket | Version | Verwendung |
+| --- | --- | --- | --- |
+| Bundling | webpack | `^4.43.0` | Bündelt Client-, Server- und Style-Assets. |
+| Bundling | webpack-cli | `^3.3.11` | CLI für Webpack-Builds. |
+| Bundling | webpack-fix-style-only-entries | `^0.3.1` | Entfernt leere JS-Outputs bei reinen Style-Entries. |
+| Bundling | webpack-require-from | `^1.8.1` | Läd Assets relativ zum Shop-Host. |
+| Transpilation | @babel/core | `^7.10.5` | ECMAScript-Transpilation. |
+| Transpilation | @babel/preset-env | `^7.9.6` | Ziel-Browser-Definition für Babel. |
+| Transpilation | @babel/plugin-proposal-object-rest-spread | `^7.9.6` | Aktiviert Objekt-Rest/Spread-Syntax. |
+| Transpilation | @babel/plugin-syntax-dynamic-import | `^7.8.3` | Unterstützt dynamische Imports. |
+| Loader | babel-loader | `^8.1.0` | Bindet Babel in Webpack ein. |
+| Styles | sass | `^1.49.9` | Dart-Sass-Compiler für SCSS. |
+| Styles | sass-loader | `^7.3.1` | Bindet Sass in Webpack ein. |
+| Styles | postcss | `^8.4.31` | Post-Processing (z. B. Autoprefixing). |
+| Styles | postcss-loader | `^3.0.0` | Verknüpft PostCSS mit Webpack. |
+| Styles | postcss-scss | `^1.0.5` | SCSS-Syntax-Support für PostCSS. |
+| Styles | autoprefixer | `^8.6.5` | Vendor-Prefixes für CSS-Ausgaben. |
+| Styles | mini-css-extract-plugin | `^0.8.2` | Extrahiert CSS in eigene Dateien. |
+| Styles | stylelint | `^14.16.1` | SCSS-Linting. |
+| Styles | stylelint-config-twbs-bootstrap | `^7.0.0` | Bootstrap-spezifische Stylelint-Regeln. |
+| JS-Qualität | eslint | `^6.8.0` | JavaScript-Linting. |
+| JS-Qualität | eslint-config-google | `^0.13.0` | Vordefiniertes Regelset für ESLint. |
+| JS-Qualität | eslint-loader | `^2.2.1` | Integriert ESLint in Webpack. |
+| JS-Qualität | babel-eslint | `^10.1.0` | Parser für moderne JS-Syntax im Linter. |
+| Tools | copy-webpack-plugin | `^6.4.1` | Kopiert statische Assets in den Build. |
+| Tools | expose-loader | `^0.7.5` | Exponiert Module global (z. B. jQuery). |
+| Tools | glob | `^7.1.6` | Dateisuchen in Build-Skripten. |
+| Tools | del | `^2.2.0` | Löscht Build-Verzeichnisse. |
+| Tools | serialize-javascript | `^3.1.0` | Serialisiert Daten in Templates. |
+| Tools | q | `^1.5.1` | Promise-Utility in Node-Skripten. |
+| Tools | esm | `^3.2.25` | ESM-Unterstützung für Node-Skripte. |
+| Testing | cypress | `^8.5.0` | E2E-Tests der Storefront. |
+| Testing | cypress-file-upload | `^4.1.1` | Upload-Unterstützung in Cypress-Tests. |
+| Testing | moment-locales-webpack-plugin | `^1.2.0` | Reduziert Moment.js-Lokalisierungen (Altbestand). |
+
+### Referenzen & Ressourcen
 
 * **plentyShop LTS / Ceres:** https://github.com/plentymarkets/plugin-ceres – Maßgeblich für Layouts, Slots und Komponenten. Bei strukturellen Änderungen (neue Blöcke, erweiterte Vue-Logik etc.) ist ein Abgleich Pflicht; bei rein optischen Anpassungen genügt in der Regel das lokale Wissen über die bestehende Struktur.
 * **IO-Plugin:** https://github.com/plentymarkets/plugin-io – Ergänzt das Frontend um Controller, Routing und Widgets. Ziehe die Doku bzw. den Code heran, wenn du neue Funktionen, Datenbindungen oder API-Aufrufe planst. Für reine CSS- oder HTML-Korrekturen muss das IO-Plugin meist nicht konsultiert werden.


### PR DESCRIPTION
## Summary
- expand `AGENTS.md` with the full technology stack for plentyShop LTS 5.0.76, covering runtime, frontend, tooling and test dependencies
- mirror the 5.0.76 component/version overview in the repository README so contributors know which libraries are in use and what they power

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e63c00302483318197fb0c5fb45e90