### PR TITLE
Add reusable account menu HTML snippet

### DIFF
--- a/Header/FH-Account-Menu-Snippet.html
+++ b/Header/FH-Account-Menu-Snippet.html
@@ -1,0 +1,253 @@
+<!--
+  Standalone account navigation snippet based on the header account dropdown.
+  Copy this block into account related layouts to reuse the same structure
+  and data attributes that power the interactive behaviour.
+-->
+<nav class="fh-account-menu-container position-relative" data-fh-account-menu-container>
+  <button
+    type="button"
+    aria-haspopup="true"
+    aria-expanded="false"
+    aria-controls="fh-account-menu"
+    aria-label="Ihr Konto"
+    data-fh-account-menu-toggle
+    class="fh-header__icon-button"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.6"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="fh-header__icon"
+      aria-hidden="true"
+    >
+      <path d="M12 12c2.8 0 5-2.2 5-5s-2.2-5-5-5-5 2.2-5 5 2.2 5 5 5z"></path>
+      <path d="M4.2 21.4c.5-3.6 3.8-6.4 7.8-6.4s7.3 2.8 7.8 6.4"></path>
+    </svg>
+  </button>
+
+  <div
+    id="fh-account-menu"
+    data-fh-account-menu
+    aria-hidden="true"
+    class="fh-header__panel fh-header__panel--account"
+  >
+    <div class="fh-header__panel-arrow"></div>
+
+    <div v-if="!$store.getters.isLoggedIn">
+      <div class="fh-header__panel-title mb-3">Ihr Konto</div>
+      <a
+        href="#login"
+        data-toggle="modal"
+        data-target="#login"
+        data-fh-login-trigger
+        class="fh-header__account-login"
+      >
+        Anmelden
+      </a>
+      <div class="fh-header__panel-inline my-3 fh-header__panel-text">
+        <span>oder</span>
+        <a
+          href="#registration"
+          data-toggle="modal"
+          data-target="#registration"
+          data-fh-registration-trigger
+          class="fh-header__account-register"
+        >
+          Registrieren
+        </a>
+      </div>
+      <div class="fh-header__panel-divider my-3"></div>
+      <div class="fh-header__panel-stack mb-3 text-body">
+        <div class="fh-header__panel-subtitle">Vorteile:</div>
+        <ul class="fh-header__panel-list">
+          <li>Gemerkte Adressdaten</li>
+          <li>Hammer Punkte sammeln</li>
+          <li>Einfacher Service</li>
+          <li>Bestellungen verfolgen</li>
+          <li>Bestehende Merkliste</li>
+          <li>Persönlicher Ansprechpartner*</li>
+        </ul>
+      </div>
+    </div>
+
+    <div v-else>
+      <div class="fh-header__panel-stack mb-3 text-body">
+        <div class="fh-header__panel-title">
+          <span
+            v-if="
+              $store.state.user &&
+              $store.state.user.userData &&
+              $store.state.user.userData.lastName &&
+              (({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) ||
+                $store.state.user.userData.formOfAddress ||
+                $store.state.user.userData.title)
+            "
+            v-cloak
+          >
+            <span class="fh-account-greeting" data-default-greeting="Hallo,">Hallo,</span>
+            <span
+              v-text="
+                ((
+                  ({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) ||
+                  $store.state.user.userData.formOfAddress ||
+                  $store.state.user.userData.title
+                ) +
+                  ' ' +
+                  $store.state.user.userData.lastName)
+              "
+              v-cloak
+            ></span>
+          </span>
+          <span v-else v-cloak>Hallo</span>
+        </div>
+        <div class="fh-header__panel-text">Schön, dass Sie wieder da sind!</div>
+        <div
+          class="fh-header__price-toggle"
+          data-fh-price-toggle-root
+          v-if="$store.getters.isLoggedIn"
+        >
+          <div class="fh-header__price-toggle-row">
+            <button
+              type="button"
+              class="fh-header__price-toggle-button is-active"
+              data-fh-price-toggle
+              role="switch"
+              aria-checked="true"
+              aria-label="Preise mit Mehrwertsteuer anzeigen"
+            >
+              <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="gross"
+                >inkl. MwSt.</span
+              >
+              <span class="fh-header__price-toggle-option" data-fh-price-toggle-option="net"
+                >exkl. MwSt.</span
+              >
+              <span class="fh-header__price-toggle-handle" aria-hidden="true"></span>
+            </button>
+            <span
+              class="fh-header__price-toggle-note fh-header__price-toggle-status"
+              data-fh-price-toggle-note
+            >
+              Preise mit MwSt
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        class="fh-header__customer-segment"
+        v-if="
+          $store.state.user &&
+          $store.state.user.userData &&
+          [1, 12, 16, 21].includes(Number($store.state.user.userData.classId))
+        "
+      >
+        <div
+          class="fh-header__customer-contact fh-header__customer-contact--standard"
+          v-if="Number($store.state.user.userData.classId) === 1"
+          v-cloak
+        >
+          <span class="fh-header__customer-contact-label">Ansprechpartner:</span>
+          <span class="fh-header__customer-contact-name">Standard</span>
+        </div>
+        <div
+          class="fh-header__customer-contact fh-header__customer-contact--personal"
+          v-else-if="Number($store.state.user.userData.classId) === 12"
+          v-cloak
+        >
+          <div class="fh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+          <div class="fh-header__customer-contact-name">Ulrich Vorländer</div>
+          <div class="fh-header__customer-contact-role">Produktexperte &amp; Kundenbetreuer</div>
+          <a href="#" class="fh-header__contact-button">Direkt kontaktieren</a>
+        </div>
+        <div
+          class="fh-header__customer-contact fh-header__customer-contact--personal"
+          v-else-if="Number($store.state.user.userData.classId) === 16"
+          v-cloak
+        >
+          <div class="fh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+          <div class="fh-header__customer-contact-name">Andreas Fischermann</div>
+          <div class="fh-header__customer-contact-role">Produktexperte &amp; Kundenbetreuer</div>
+          <a href="#" class="fh-header__contact-button">Direkt kontaktieren</a>
+        </div>
+        <div
+          class="fh-header__customer-contact fh-header__customer-contact--personal"
+          v-else-if="Number($store.state.user.userData.classId) === 21"
+          v-cloak
+        >
+          <div class="fh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+          <div class="fh-header__customer-contact-name">Gabriele Sprenger</div>
+          <div class="fh-header__customer-contact-role">Produktexperte &amp; Kundenbetreuer</div>
+          <a href="#" class="fh-header__contact-button">Direkt kontaktieren</a>
+        </div>
+      </div>
+
+      <div class="fh-header__panel-divider mb-3"></div>
+      <div
+        class="fh-header__panel-contact"
+        v-if="
+          !(
+            $store.state.user &&
+            $store.state.user.userData &&
+            [12, 16, 21].includes(Number($store.state.user.userData.classId))
+          )
+        "
+      >
+        <div class="fh-header__panel-contact-label">Fragen? Sie erreichen uns hier:</div>
+        <div class="fh-header__panel-contact-line">
+          <a href="tel:02204910980" class="fh-header__panel-contact-chip">
+            <span class="fh-header__panel-contact-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <path
+                  d="M4.9 3A1.9 1.9 0 0 1 6.8 1.1l2.3.4a1.9 1.9 0 0 1 1.5 1.6l.3 2.5a1.9 1.9 0 0 1-.6 1.6L8.9 8.5a10.6 10.6 0 0 0 6.6 6.6l1.3-1.4a1.9 1.9 0 0 1 1.6-.6l2.5.3a1.9 1.9 0 0 1 1.6 1.5l.4 2.3a1.9 1.9 0 0 1-1.9 1.9h-.2A16.6 16.6 0 0 1 3.5 4.9v-.2Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+            <span class="fh-header__panel-contact-text">02204 910 980</span>
+          </a>
+          <span class="fh-header__panel-contact-separator">oder</span>
+        </div>
+        <div class="fh-header__panel-contact-line">
+          <a href="mailto:service@fenster-hammer.de" class="fh-header__panel-contact-chip">
+            <span class="fh-header__panel-contact-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <path
+                  d="M3 6.75A2.75 2.75 0 0 1 5.75 4h12.5A2.75 2.75 0 0 1 21 6.75v10.5A2.75 2.75 0 0 1 18.25 20H5.75A2.75 2.75 0 0 1 3 17.25Zm2.75-.25a.75.75 0 0 0-.75.75v.26l7 4.38 7-4.38V7.25a.75.75 0 0 0-.75-.75Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+            <span class="fh-header__panel-contact-text">service@fenster-hammer.de</span>
+          </a>
+        </div>
+      </div>
+
+      <nav class="fh-header__panel-links mb-3">
+        <a href="/my-account" class="fh-header__panel-link">Kontoübersicht</a>
+        <a href="/kontoeinstellungen" class="fh-header__panel-link">Kontoeinstellungen</a>
+        <a href="/bestellungen" class="fh-header__panel-link">Meine Bestellungen</a>
+        <a href="/hammer-praemien" class="fh-header__panel-link">Hammer Punkte einlösen</a>
+      </nav>
+      <div
+        class="fh-header__panel-text fh-header__account-type"
+        v-if="$store.state.user && $store.state.user.userData && $store.state.user.userData.classId != null"
+        v-cloak
+      >
+        <span v-if="Number($store.state.user.userData.classId) === 1">Konto: Standardkonto</span>
+        <span v-else>Konto: Firmenkunde</span>
+      </div>
+      <div
+        class="fh-header__panel-text fh-header__customer-id"
+        v-if="$store.state.user && $store.state.user.userData && $store.state.user.userData.id"
+        v-cloak
+      >
+        Kunden-ID: <span v-text="$store.state.user.userData.id"></span>
+      </div>
+      <a href="#" v-logout data-fh-account-close class="fh-header__logout">Abmelden</a>
+    </div>
+  </div>
+</nav>


### PR DESCRIPTION
## Summary
- add a standalone HTML snippet that mirrors the header account dropdown for reuse on account pages

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e6655a10cc83318bca1150726e2364