### PR TITLE
Guard basket figures until hydration

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1628,6 +1628,10 @@ body,
   background-color: var(--fh-color-bright-blue);
 }
 
+.fh-header__basket [v-cloak] {
+  visibility: hidden;
+}
+
 .fh-header__basket-count {
   position: absolute;
   top: -8px;

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -209,15 +209,15 @@
       </div>
       <div class="fh-basket-preview fh-header__basket">
         <a v-toggle-basket-preview href="#" class="toggle-basket-preview fh-header__basket-link" aria-label="Warenkorb">
-          <span class="fh-header__basket-count" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>
+          <span class="fh-header__basket-count" v-basket-item-quantity="$store.state.basket.data.itemQuantity" v-cloak>0</span>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="fh-header__basket-icon">
             <circle cx="9" cy="20" r="1.5" fill="currentColor"></circle>
             <circle cx="18" cy="20" r="1.5" fill="currentColor"></circle>
             <path d="M2.5 3h2l2.4 12.6a1.5 1.5 0 0 0 1.5 1.2H18a1.5 1.5 0 0 0 1.5-1.2L21 7H6"></path>
           </svg>
-          <span class="fh-header__basket-total" aria-hidden="true" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
+          <span class="fh-header__basket-total" aria-hidden="true" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum" v-cloak>0,00 €</span>
           <span class="fh-header__basket-total" aria-hidden="true" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
-          <span class="fh-header__sr-only" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
+          <span class="fh-header__sr-only" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum" v-cloak>0,00 €</span>
           <span class="fh-header__sr-only" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
         </a>
         <basket-preview

--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -209,15 +209,15 @@
       </div>
       <div class="sh-basket-preview sh-header__basket">
         <a v-toggle-basket-preview href="#" class="toggle-basket-preview sh-header__basket-link" aria-label="Warenkorb">
-          <span class="sh-header__basket-count" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>
+          <span class="sh-header__basket-count" v-basket-item-quantity="$store.state.basket.data.itemQuantity" v-cloak>0</span>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="sh-header__basket-icon">
             <circle cx="9" cy="20" r="1.5" fill="currentColor"></circle>
             <circle cx="18" cy="20" r="1.5" fill="currentColor"></circle>
             <path d="M2.5 3h2l2.4 12.6a1.5 1.5 0 0 0 1.5 1.2H18a1.5 1.5 0 0 0 1.5-1.2L21 7H6"></path>
           </svg>
-          <span class="sh-header__basket-total" aria-hidden="true" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
+          <span class="sh-header__basket-total" aria-hidden="true" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum" v-cloak>0,00 €</span>
           <span class="sh-header__basket-total" aria-hidden="true" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
-          <span class="sh-header__sr-only" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum">0,00 €</span>
+          <span class="sh-header__sr-only" v-if="!$store.state.basket.showNetPrices" v-basket-item-sum="$store.state.basket.data.itemSum" v-cloak>0,00 €</span>
           <span class="sh-header__sr-only" v-else v-cloak v-basket-item-sum="$store.state.basket.data.itemSumNet">0,00 €</span>
         </a>
         <basket-preview

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1644,6 +1644,10 @@ body,
   background-color: var(--sh-color-primary-red);
 }
 
+.sh-header__basket [v-cloak] {
+  visibility: hidden;
+}
+
 .sh-header__basket-count {
   position: absolute;
   top: -8px;


### PR DESCRIPTION
## Summary
- hide basket quantity and sum placeholders in FH and SH headers until Vue hydration
- add basket-specific v-cloak styling to prevent flashing of default values

## Testing
- Not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922e444ade88331814f25187c9ea880)