### PR TITLE
Clear stored basket preview when baskets emptied

### DIFF
--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -24,6 +24,14 @@ fhOnReady(function () {
     }
   }
 
+  function clearState() {
+    try {
+      sessionStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      /* Swallow storage errors (e.g., private mode). */
+    }
+  }
+
   function persistState(state) {
     try {
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
@@ -73,7 +81,8 @@ fhOnReady(function () {
 
   function captureStateFromDom() {
     const countNode = document.querySelector(COUNT_SELECTOR);
-    const quantity = toNumber(trimText(countNode));
+    const countText = trimText(countNode);
+    const quantity = toNumber(countText);
 
     const totals = document.querySelectorAll(TOTAL_SELECTOR + ', ' + SR_TOTAL_SELECTOR);
     let grossText = '';
@@ -91,7 +100,7 @@ fhOnReady(function () {
       }
     });
 
-    if (!quantity && !grossText && !netText) return null;
+    if (countText === '' && !grossText && !netText) return null;
 
     return { quantity, grossText, netText };
   }
@@ -103,6 +112,8 @@ fhOnReady(function () {
     const snapshot = captureStateFromDom();
     if (snapshot && snapshot.quantity > 0) {
       persistState(snapshot);
+    } else if (snapshot) {
+      clearState();
     }
   });
 

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -24,6 +24,14 @@ shOnReady(function () {
     }
   }
 
+  function clearState() {
+    try {
+      sessionStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      /* Swallow storage errors (e.g., private mode). */
+    }
+  }
+
   function persistState(state) {
     try {
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
@@ -73,7 +81,8 @@ shOnReady(function () {
 
   function captureStateFromDom() {
     const countNode = document.querySelector(COUNT_SELECTOR);
-    const quantity = toNumber(trimText(countNode));
+    const countText = trimText(countNode);
+    const quantity = toNumber(countText);
 
     const totals = document.querySelectorAll(TOTAL_SELECTOR + ', ' + SR_TOTAL_SELECTOR);
     let grossText = '';
@@ -91,7 +100,7 @@ shOnReady(function () {
       }
     });
 
-    if (!quantity && !grossText && !netText) return null;
+    if (countText === '' && !grossText && !netText) return null;
 
     return { quantity, grossText, netText };
   }
@@ -103,6 +112,8 @@ shOnReady(function () {
     const snapshot = captureStateFromDom();
     if (snapshot && snapshot.quantity > 0) {
       persistState(snapshot);
+    } else if (snapshot) {
+      clearState();
     }
   });
 


### PR DESCRIPTION
## Summary
- capture zero-quantity basket snapshots so empty states are observed
- remove stored basket preview data when the basket is emptied for FH and SH headers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f48c3de883319aa10bd91f8af80c)