### PR TITLE
Fix header top bar background on mid-size viewports

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -294,7 +294,7 @@ body,
   margin: 0 auto;
   color: #1a1a1a;
   font-family: "Open Sans", Arial, sans-serif;
-  width: 1600px; /* Do not change this for Desktop viewport*/
+  width: min(100%, 1600px); /* Keep desktop layout capped without exceeding viewport width */
   max-width: 1600px; /* Do not change this for Desktop viewport*/
   --fh-top-bar-max-height: 72px;
   --fh-top-bar-padding-y: 14px;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -297,7 +297,7 @@ body,
   margin: 0 auto;
   color: #1a1a1a;
   font-family: "Open Sans", Arial, sans-serif;
-  width: 1600px; /* Do not change this for Desktop viewport*/
+  width: min(100%, 1600px); /* Keep desktop layout capped without exceeding viewport width */
   max-width: 1600px; /* Do not change this for Desktop viewport*/
   --sh-top-bar-max-height: 72px;
   --sh-top-bar-padding-y: 14px;


### PR DESCRIPTION
## Summary
- limit header container width to the viewport while retaining a 1600px cap to prevent gaps in the top benefits bar background on mid-size screens

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243c4375748331a2c1e3b3168d2a7a)