### PR TITLE
Adjust top bar background alignment

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -328,10 +328,10 @@ body,
   content: "";
   position: absolute;
   top: 0;
-  left: 50%;
+  left: calc(50% - 50vw);
   width: 100vw;
   height: 100%;
-  transform: translateX(-50%);
+  transform: none;
   background: linear-gradient(90deg, var(--fh-color-navy-blue), var(--fh-color-dark-blue));
   z-index: -1;
   pointer-events: none;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -331,10 +331,10 @@ body,
   content: "";
   position: absolute;
   top: 0;
-  left: 50%;
+  left: calc(50% - 50vw);
   width: 100vw;
   height: 100%;
-  transform: translateX(-50%);
+  transform: none;
   background: linear-gradient(
     90deg,
     var(--sh-color-secondary-red),


### PR DESCRIPTION
## Summary
- revert the header container width to the original desktop setting so overall layout remains unchanged
- realign the top bar background pseudo-element to anchor to the viewport and cover the full width on mid-size screens

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243c4375748331a2c1e3b3168d2a7a)