### PR TITLE
Expand mobile header breakpoint and full-width layout

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -294,8 +294,8 @@ body,
   margin: 0 auto;
   color: #1a1a1a;
   font-family: "Open Sans", Arial, sans-serif;
-  width: 1600px; /* Do not change this for Desktop viewport*/
-  max-width: 1600px; /* Do not change this for Desktop viewport*/
+  width: 100%;
+  max-width: 100%;
   --fh-top-bar-max-height: 72px;
   --fh-top-bar-padding-y: 14px;
 }
@@ -1689,7 +1689,7 @@ body,
 
 .fh-header__nav-inner {
   position: relative;
-  max-width: 1600px;
+  max-width: 100%;
   margin: 0 auto;
 }
 
@@ -2439,14 +2439,7 @@ body,
   border-bottom: none;
 }
 
-@media (max-width: 1199.98px) {
-  .fh-header {
-    width: 100%;
-    max-width: 100%;
-  }
-}
-
-@media (max-width: 991.98px) {
+@media (max-width: 1600px) {
   .fh-header__top-bar {
     display: none;
   }
@@ -2754,7 +2747,7 @@ body.fh-mobile-menu-open {
 }
 
 #page-header > div {
-  max-width: 1600px;
+  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -297,8 +297,8 @@ body,
   margin: 0 auto;
   color: #1a1a1a;
   font-family: "Open Sans", Arial, sans-serif;
-  width: 1600px; /* Do not change this for Desktop viewport*/
-  max-width: 1600px; /* Do not change this for Desktop viewport*/
+  width: 100%;
+  max-width: 100%;
   --sh-top-bar-max-height: 72px;
   --sh-top-bar-padding-y: 14px;
 }
@@ -1705,7 +1705,7 @@ body,
 
 .sh-header__nav-inner {
   position: relative;
-  max-width: 1600px;
+  max-width: 100%;
   margin: 0 auto;
 }
 
@@ -2455,14 +2455,7 @@ body,
   border-bottom: none;
 }
 
-@media (max-width: 1199.98px) {
-  .sh-header {
-    width: 100%;
-    max-width: 100%;
-  }
-}
-
-@media (max-width: 991.98px) {
+@media (max-width: 1600px) {
   .sh-header__top-bar {
     display: none;
   }
@@ -2770,7 +2763,7 @@ body.sh-mobile-menu-open {
 }
 
 #page-header > div {
-  max-width: 1600px;
+  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
## Summary
- remove fixed 1600px constraints on FH/SH headers so bars span the full viewport
- trigger the mobile header layout from 1600px downward to avoid clipped navigation elements

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692441b07c808331aa29184cc69d30be)