### PR TITLE
Adjust header responsiveness to mobile at 1600px

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -294,8 +294,8 @@ body,
   margin: 0 auto;
   color: #1a1a1a;
   font-family: "Open Sans", Arial, sans-serif;
-  width: 1600px; /* Do not change this for Desktop viewport*/
-  max-width: 1600px; /* Do not change this for Desktop viewport*/
+  width: 100%;
+  max-width: 100%;
   --fh-top-bar-max-height: 72px;
   --fh-top-bar-padding-y: 14px;
 }
@@ -2439,14 +2439,7 @@ body,
   border-bottom: none;
 }
 
-@media (max-width: 1199.98px) {
-  .fh-header {
-    width: 100%;
-    max-width: 100%;
-  }
-}
-
-@media (max-width: 991.98px) {
+@media (max-width: 1599.98px) {
   .fh-header__top-bar {
     display: none;
   }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -297,8 +297,8 @@ body,
   margin: 0 auto;
   color: #1a1a1a;
   font-family: "Open Sans", Arial, sans-serif;
-  width: 1600px; /* Do not change this for Desktop viewport*/
-  max-width: 1600px; /* Do not change this for Desktop viewport*/
+  width: 100%;
+  max-width: 100%;
   --sh-top-bar-max-height: 72px;
   --sh-top-bar-padding-y: 14px;
 }
@@ -2455,14 +2455,7 @@ body,
   border-bottom: none;
 }
 
-@media (max-width: 1199.98px) {
-  .sh-header {
-    width: 100%;
-    max-width: 100%;
-  }
-}
-
-@media (max-width: 991.98px) {
+@media (max-width: 1599.98px) {
   .sh-header__top-bar {
     display: none;
   }


### PR DESCRIPTION
## Summary
- remove fixed 1600px header width caps so the top bar background spans the full viewport
- shift the header mobile layout breakpoint to 1599.98px for both FH and SH, removing intermediate breakpoint overrides

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692441b07c808331aa29184cc69d30be)