### PR TITLE
Adjust header responsive behavior at 1600px

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -294,8 +294,8 @@ body,
   margin: 0 auto;
   color: #1a1a1a;
   font-family: "Open Sans", Arial, sans-serif;
-  width: 1600px; /* Do not change this for Desktop viewport*/
-  max-width: 1600px; /* Do not change this for Desktop viewport*/
+  width: 100%;
+  max-width: 1600px;
   --fh-top-bar-max-height: 72px;
   --fh-top-bar-padding-y: 14px;
 }
@@ -2439,14 +2439,12 @@ body,
   border-bottom: none;
 }
 
-@media (max-width: 1199.98px) {
+@media (max-width: 1600px) {
   .fh-header {
     width: 100%;
     max-width: 100%;
   }
-}
 
-@media (max-width: 991.98px) {
   .fh-header__top-bar {
     display: none;
   }
@@ -2657,22 +2655,21 @@ body,
     border-bottom: 1px solid #e5e7eb;
     white-space: normal;
     justify-content: flex-start;
-  gap: 12px;
-}
+  }
 
-.fh-header__mobile-submenu-cta {
-  margin-top: 12px;
-  display: flex;
-  justify-content: flex-start;
-}
+  .fh-header__mobile-submenu-cta {
+    margin-top: 12px;
+    display: flex;
+    justify-content: flex-start;
+  }
 
-.fh-header__mobile-submenu-cta .schlossfinder {
-  justify-content: center;
-}
+  .fh-header__mobile-submenu-cta .schlossfinder {
+    justify-content: center;
+  }
 
-.schlossfinder--mobile {
-  width: auto;
-}
+  .schlossfinder--mobile {
+    width: auto;
+  }
 
   .fh-header__nav-icon {
     width: 24px;
@@ -2697,13 +2694,7 @@ body,
   .fh-header__dropdown {
     display: none !important;
   }
-}
 
-body.fh-mobile-menu-open {
-  overflow: hidden;
-}
-
-@media (max-width: 767.98px) {
   .fh-header__panel {
     right: auto;
     transform: translateX(calc(-50% - 8px));
@@ -2722,6 +2713,10 @@ body.fh-mobile-menu-open {
     right: auto;
     transform: translateX(calc(-50% + 8px)) rotate(45deg);
   }
+}
+
+body.fh-mobile-menu-open {
+  overflow: hidden;
 }
 /* End Section: FH Header Base Layout */
 
@@ -2755,6 +2750,7 @@ body.fh-mobile-menu-open {
 
 #page-header > div {
   max-width: 1600px;
+  width: 100%;
   margin-left: auto;
   margin-right: auto;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -297,8 +297,8 @@ body,
   margin: 0 auto;
   color: #1a1a1a;
   font-family: "Open Sans", Arial, sans-serif;
-  width: 1600px; /* Do not change this for Desktop viewport*/
-  max-width: 1600px; /* Do not change this for Desktop viewport*/
+  width: 100%;
+  max-width: 1600px;
   --sh-top-bar-max-height: 72px;
   --sh-top-bar-padding-y: 14px;
 }
@@ -2455,14 +2455,12 @@ body,
   border-bottom: none;
 }
 
-@media (max-width: 1199.98px) {
+@media (max-width: 1600px) {
   .sh-header {
     width: 100%;
     max-width: 100%;
   }
-}
 
-@media (max-width: 991.98px) {
   .sh-header__top-bar {
     display: none;
   }
@@ -2673,22 +2671,21 @@ body,
     border-bottom: 1px solid #e5e7eb;
     white-space: normal;
     justify-content: flex-start;
-  gap: 12px;
-}
+  }
 
-.sh-header__mobile-submenu-cta {
-  margin-top: 12px;
-  display: flex;
-  justify-content: flex-start;
-}
+  .sh-header__mobile-submenu-cta {
+    margin-top: 12px;
+    display: flex;
+    justify-content: flex-start;
+  }
 
-.sh-header__mobile-submenu-cta .schlossfinder {
-  justify-content: center;
-}
+  .sh-header__mobile-submenu-cta .schlossfinder {
+    justify-content: center;
+  }
 
-.schlossfinder--mobile {
-  width: auto;
-}
+  .schlossfinder--mobile {
+    width: auto;
+  }
 
   .sh-header__nav-icon {
     width: 24px;
@@ -2713,13 +2710,7 @@ body,
   .sh-header__dropdown {
     display: none !important;
   }
-}
 
-body.sh-mobile-menu-open {
-  overflow: hidden;
-}
-
-@media (max-width: 767.98px) {
   .sh-header__panel {
     right: auto;
     transform: translateX(calc(-50% - 8px));
@@ -2738,6 +2729,10 @@ body.sh-mobile-menu-open {
     right: auto;
     transform: translateX(calc(-50% + 8px)) rotate(45deg);
   }
+}
+
+body.sh-mobile-menu-open {
+  overflow: hidden;
 }
 /* End Section: sh Header Base Layout */
 
@@ -2771,6 +2766,7 @@ body.sh-mobile-menu-open {
 
 #page-header > div {
   max-width: 1600px;
+  width: 100%;
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
## Summary
- allow FH and SH header containers to shrink with the viewport instead of staying fixed at 1600px
- collapse header to the mobile layout (burger nav, hidden top bar, mobile panels) for any viewport 1600px and below via a single breakpoint
- ensure the sticky header wrapper uses full width for centering without clipping navigation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244802edf88331a6cd03dfbb79900d)