### PR TITLE
Update SH header Dach- & Fassadenbau navigation links

### DIFF
--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -276,11 +276,12 @@
                     <div class="sh-header__dropdown-group">
                       <a href="/anwendungsgebiet/dach-fassadenbau/" class="sh-header__dropdown-link sh-header__dropdown-link--parent">Dach- &amp; Fassadenbau</a>
                       <div class="sh-header__dropdown-sublist">
-                        <a href="/anwendungsgebiet/dach-fassadenbau/blechverbinder/" class="sh-header__dropdown-sublink">Blechverbinder</a>
+                        <a href="/anwendungsgebiet/dach-fassadenbau/bohrschrauben/" class="sh-header__dropdown-sublink">Bohrschrauben</a>
                         <a href="/anwendungsgebiet/dach-fassadenbau/dachschrauben/" class="sh-header__dropdown-sublink">Dachschrauben</a>
                         <a href="/anwendungsgebiet/dach-fassadenbau/dicht-anschlussbaender/" class="sh-header__dropdown-sublink">Dicht- &amp; Anschlussbänder</a>
                         <a href="/anwendungsgebiet/dach-fassadenbau/fassadenschrauben/" class="sh-header__dropdown-sublink">Fassadenschrauben</a>
                         <a href="/anwendungsgebiet/dach-fassadenbau/klebeschaum-wdvs/" class="sh-header__dropdown-sublink">Klebeschaum / WDVS</a>
+                        <a href="/anwendungsgebiet/dach-fassadenbau/zubehoer/" class="sh-header__dropdown-sublink">Zubehör</a>
                       </div>
                     </div>
                   </div>
@@ -706,11 +707,12 @@
           </div>
           <ul class="sh-header__mobile-submenu-list">
             <li><a href="/anwendungsgebiet/dach-fassadenbau/" class="sh-header__mobile-submenu-link sh-header__mobile-submenu-link--all">Alle Dach- &amp; Fassadenbau-Produkte</a></li>
-            <li><a href="/anwendungsgebiet/dach-fassadenbau/blechverbinder/" class="sh-header__mobile-submenu-link">Blechverbinder</a></li>
+            <li><a href="/anwendungsgebiet/dach-fassadenbau/bohrschrauben/" class="sh-header__mobile-submenu-link">Bohrschrauben</a></li>
             <li><a href="/anwendungsgebiet/dach-fassadenbau/dachschrauben/" class="sh-header__mobile-submenu-link">Dachschrauben</a></li>
             <li><a href="/anwendungsgebiet/dach-fassadenbau/dicht-anschlussbaender/" class="sh-header__mobile-submenu-link">Dicht- &amp; Anschlussbänder</a></li>
             <li><a href="/anwendungsgebiet/dach-fassadenbau/fassadenschrauben/" class="sh-header__mobile-submenu-link">Fassadenschrauben</a></li>
             <li><a href="/anwendungsgebiet/dach-fassadenbau/klebeschaum-wdvs/" class="sh-header__mobile-submenu-link">Klebeschaum / WDVS</a></li>
+            <li><a href="/anwendungsgebiet/dach-fassadenbau/zubehoer/" class="sh-header__mobile-submenu-link">Zubehör</a></li>
           </ul>
         </div>
         <div class="sh-header__mobile-view sh-header__mobile-submenu-panel" id="sh-mobile-submenu-anwendungsgebiet-holzbau" data-sh-mobile-panel="anwendungsgebiet-holzbau" aria-hidden="true">


### PR DESCRIPTION
## Summary
- rename the Dach- & Fassadenbau subcategory to Bohrschrauben with correct link
- add Zubehör subcategory link to the Dach- & Fassadenbau menu
- keep mobile and desktop navigation lists alphabetically sorted

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69245b2e361c833187cd0969e20d09e7)