### PR TITLE
Align header nav styling with dropdowns

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1685,9 +1685,14 @@ body,
   --fh-nav-highlight-scale: 1;
   --fh-nav-highlight-origin: left;
   background-color: #ffffff;
-  border: 1px solid #e4e4e4;
+  border: 1px solid transparent;
   border-bottom: none;
   border-radius: 18px 18px 0 0;
+  box-shadow: none;
+}
+
+.fh-header__nav-surface:hover {
+  border-color: #e4e4e4;
   box-shadow: 0 18px 36px -18px rgba(0, 0, 0, 0.16);
 }
 
@@ -2576,6 +2581,11 @@ body,
     padding: 0;
     border: none;
     border-radius: 0;
+    box-shadow: none;
+  }
+
+  .fh-header__nav-surface:hover {
+    border: none;
     box-shadow: none;
   }
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -865,7 +865,6 @@ body,
   grid-template-columns: auto 1fr auto;
   align-items: center;
   padding: 26px 32px 22px;
-  border-bottom: 1px solid #e2e2e2;
   background-color: #ffffff;
   column-gap: 20px;
 }
@@ -1685,6 +1684,11 @@ body,
   --fh-nav-highlight-color: #4b5563;
   --fh-nav-highlight-scale: 1;
   --fh-nav-highlight-origin: left;
+  background-color: #ffffff;
+  border: 1px solid #e4e4e4;
+  border-bottom: none;
+  border-radius: 18px 18px 0 0;
+  box-shadow: 0 18px 36px -18px rgba(0, 0, 0, 0.16);
 }
 
 .fh-header__nav-inner {
@@ -2570,6 +2574,9 @@ body,
 
   .fh-header__nav-surface {
     padding: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
   }
 
   .fh-header__mobile-close {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1701,9 +1701,14 @@ body,
   --sh-nav-highlight-scale: 1;
   --sh-nav-highlight-origin: left;
   background-color: #ffffff;
-  border: 1px solid #e4e4e4;
+  border: 1px solid transparent;
   border-bottom: none;
   border-radius: 18px 18px 0 0;
+  box-shadow: none;
+}
+
+.sh-header__nav-surface:hover {
+  border-color: #e4e4e4;
   box-shadow: 0 18px 36px -18px rgba(0, 0, 0, 0.16);
 }
 
@@ -2592,6 +2597,11 @@ body,
     padding: 0;
     border: none;
     border-radius: 0;
+    box-shadow: none;
+  }
+
+  .sh-header__nav-surface:hover {
+    border: none;
     box-shadow: none;
   }
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -873,7 +873,6 @@ body,
   grid-template-columns: auto 1fr auto;
   align-items: center;
   padding: 26px 32px 22px;
-  border-bottom: 1px solid #e2e2e2;
   background-color: #ffffff;
   column-gap: 20px;
 }
@@ -1701,6 +1700,11 @@ body,
   --sh-nav-highlight-color: #4b5563;
   --sh-nav-highlight-scale: 1;
   --sh-nav-highlight-origin: left;
+  background-color: #ffffff;
+  border: 1px solid #e4e4e4;
+  border-bottom: none;
+  border-radius: 18px 18px 0 0;
+  box-shadow: 0 18px 36px -18px rgba(0, 0, 0, 0.16);
 }
 
 .sh-header__nav-inner {
@@ -2586,6 +2590,9 @@ body,
 
   .sh-header__nav-surface {
     padding: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
   }
 
   .sh-header__mobile-close {


### PR DESCRIPTION
## Summary
- remove the separating line above the navigation in both FH and SH headers
- give the desktop navigation surfaces the same border, radius, and shadow styling as the submenus while leaving mobile navs unchanged

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692555b66cdc8331bbec3d2dddc1b5da)