### PR TITLE
Refine nav item hover border connection

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1681,7 +1681,8 @@ body,
   --fh-nav-highlight-x: 0px;
   --fh-nav-highlight-width: 0px;
   --fh-nav-highlight-opacity: 0;
-  --fh-nav-highlight-color: #4b5563;
+  --fh-nav-highlight-color: rgba(244, 246, 248, 0.96);
+  --fh-nav-highlight-border-color: rgba(203, 213, 225, 0.7);
   --fh-nav-highlight-scale: 1;
   --fh-nav-highlight-origin: left;
   background-color: #ffffff;
@@ -1691,10 +1692,7 @@ body,
   box-shadow: none;
 }
 
-.fh-header__nav-surface:hover {
-  border-color: #e4e4e4;
-  box-shadow: 0 18px 36px -18px rgba(0, 0, 0, 0.16);
-}
+
 
 .fh-header__nav-inner {
   position: relative;
@@ -1724,7 +1722,7 @@ body,
 
 .fh-header__nav-list {
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   gap: 0;
   position: relative;
   z-index: 1;
@@ -1740,13 +1738,16 @@ body,
 .fh-header__nav-highlight {
   position: absolute;
   left: 0;
-  bottom: 10px;
+  top: 6px;
   width: var(--fh-nav-highlight-width, 0px);
-  height: 4px;
+  height: calc(100% - 12px);
   transform: translateX(var(--fh-nav-highlight-x, 0px)) scaleX(var(--fh-nav-highlight-scale, 1));
   transform-origin: var(--fh-nav-highlight-origin, left);
-  border-radius: 999px;
-  background-color: var(--fh-nav-highlight-color, #4b5563);
+  border-radius: 12px 12px 0 0;
+  background-color: var(--fh-nav-highlight-color, rgba(229, 231, 235, 0.92));
+  border: 1px solid var(--fh-nav-highlight-border-color, rgba(148, 163, 184, 0.5));
+  border-bottom-color: transparent;
+  box-shadow: 0 6px 18px rgba(17, 24, 39, 0.05);
   opacity: var(--fh-nav-highlight-opacity, 0);
   transition:
     width 0.32s cubic-bezier(0.22, 1, 0.36, 1),
@@ -1777,21 +1778,12 @@ body,
 }
 
 .fh-header__nav-highlight::after {
-  content: "";
-  position: absolute;
-  left: 50%;
-  bottom: -6px;
-  transform: translateX(-50%);
-  width: 0;
-  height: 0;
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  border-top: 8px solid var(--fh-nav-highlight-color, #4b5563);
+  content: none;
 }
 
 .fh-header__nav-item {
   position: static;
-  flex: 1;
+  flex: 1 1 0;
   text-align: center;
 }
 
@@ -1801,7 +1793,7 @@ body,
   justify-content: center;
   gap: 10px;
   width: 100%;
-  padding: 18px 12px;
+  padding: 16px 14px;
   color: #1a1a1a;
   text-decoration: none;
   white-space: nowrap;
@@ -1854,6 +1846,13 @@ body,
   text-decoration: none;
 }
 
+.fh-header__nav-link:hover .fh-header__nav-text,
+.fh-header__nav-link:focus .fh-header__nav-text,
+.fh-header__nav-item.is-open .fh-header__nav-text,
+.fh-header__nav-item.is-selected .fh-header__nav-text {
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.9);
+}
+
 .fh-header__nav-item.is-open .fh-header__nav-link {
   color: var(--fh-color-dark-blue);
 }
@@ -1882,8 +1881,8 @@ body,
   width: 100%;
   margin: 0 auto;
   padding: 32px 48px;
-  border: 1px solid #e4e4e4;
-  border-top: none;
+  border: 1px solid var(--fh-nav-highlight-border-color, #e4e4e4);
+  border-top: 1px solid var(--fh-nav-highlight-border-color, #e4e4e4);
   border-radius: 0 0 18px 18px;
   background-color: #ffffff;
   box-shadow: 0 18px 36px -18px rgba(0, 0, 0, 0.16);

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -1890,9 +1890,11 @@ fhOnReady(function () {
   const HIGHLIGHT_INTRO_EXIT_DELAY = 460;
   const HIGHLIGHT_EXIT_DURATION = 420;
 
-  const HOVER_INDICATOR_RATIO = 0.6;
-  const HOVER_INDICATOR_COLOR = '#4b5563';
-  const SELECTED_INDICATOR_COLOR = '#000000';
+  const INDICATOR_RATIO = 1;
+  const HOVER_INDICATOR_COLOR = 'rgba(244, 246, 248, 0.96)';
+  const SELECTED_INDICATOR_COLOR = 'rgba(233, 236, 239, 0.98)';
+  const HOVER_INDICATOR_BORDER = 'rgba(203, 213, 225, 0.7)';
+  const SELECTED_INDICATOR_BORDER = 'rgba(148, 163, 184, 0.6)';
 
   function isDesktop() {
     return desktopMedia.matches;
@@ -1955,6 +1957,7 @@ fhOnReady(function () {
 
         surface.style.setProperty('--fh-nav-highlight-width', '0px');
         surface.style.setProperty('--fh-nav-highlight-color', HOVER_INDICATOR_COLOR);
+        surface.style.setProperty('--fh-nav-highlight-border-color', HOVER_INDICATOR_BORDER);
         surface.style.setProperty('--fh-nav-highlight-scale', '1');
 
         surface.classList.remove(HIGHLIGHT_VISIBLE_CLASS);
@@ -1966,6 +1969,7 @@ fhOnReady(function () {
       surface.style.setProperty('--fh-nav-highlight-opacity', '0');
       surface.style.setProperty('--fh-nav-highlight-width', '0px');
       surface.style.setProperty('--fh-nav-highlight-color', HOVER_INDICATOR_COLOR);
+      surface.style.setProperty('--fh-nav-highlight-border-color', HOVER_INDICATOR_BORDER);
       surface.style.setProperty('--fh-nav-highlight-scale', '1');
 
       surface.classList.remove(HIGHLIGHT_VISIBLE_CLASS);
@@ -1997,9 +2001,8 @@ fhOnReady(function () {
     }
 
     const isSelected = selectedItem === item;
-    const ratio = isSelected ? 1 : HOVER_INDICATOR_RATIO;
     const isIntro = !highlightHasShown;
-    let width = linkRect.width * ratio;
+    let width = linkRect.width * INDICATOR_RATIO;
     let offset = linkRect.left - surfaceRect.left + (linkRect.width - width) / 2;
     const maxWidth = surfaceRect.width;
 
@@ -2011,6 +2014,7 @@ fhOnReady(function () {
     surface.style.setProperty('--fh-nav-highlight-width', width.toFixed(2) + 'px');
     surface.style.setProperty('--fh-nav-highlight-x', offset.toFixed(2) + 'px');
     surface.style.setProperty('--fh-nav-highlight-color', isSelected ? SELECTED_INDICATOR_COLOR : HOVER_INDICATOR_COLOR);
+    surface.style.setProperty('--fh-nav-highlight-border-color', isSelected ? SELECTED_INDICATOR_BORDER : HOVER_INDICATOR_BORDER);
     surface.style.setProperty('--fh-nav-highlight-opacity', '1');
 
     if (isIntro) {

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -1890,9 +1890,11 @@ shOnReady(function () {
   const HIGHLIGHT_INTRO_EXIT_DELAY = 460;
   const HIGHLIGHT_EXIT_DURATION = 420;
 
-  const HOVER_INDICATOR_RATIO = 0.6;
-  const HOVER_INDICATOR_COLOR = '#4b5563';
-  const SELECTED_INDICATOR_COLOR = '#000000';
+  const INDICATOR_RATIO = 1;
+  const HOVER_INDICATOR_COLOR = 'rgba(244, 246, 248, 0.96)';
+  const SELECTED_INDICATOR_COLOR = 'rgba(233, 236, 239, 0.98)';
+  const HOVER_INDICATOR_BORDER = 'rgba(203, 213, 225, 0.7)';
+  const SELECTED_INDICATOR_BORDER = 'rgba(148, 163, 184, 0.6)';
 
   function isDesktop() {
     return desktopMedia.matches;
@@ -1955,6 +1957,7 @@ shOnReady(function () {
 
         surface.style.setProperty('--sh-nav-highlight-width', '0px');
         surface.style.setProperty('--sh-nav-highlight-color', HOVER_INDICATOR_COLOR);
+        surface.style.setProperty('--sh-nav-highlight-border-color', HOVER_INDICATOR_BORDER);
         surface.style.setProperty('--sh-nav-highlight-scale', '1');
 
         surface.classList.remove(HIGHLIGHT_VISIBLE_CLASS);
@@ -1966,6 +1969,7 @@ shOnReady(function () {
       surface.style.setProperty('--sh-nav-highlight-opacity', '0');
       surface.style.setProperty('--sh-nav-highlight-width', '0px');
       surface.style.setProperty('--sh-nav-highlight-color', HOVER_INDICATOR_COLOR);
+      surface.style.setProperty('--sh-nav-highlight-border-color', HOVER_INDICATOR_BORDER);
       surface.style.setProperty('--sh-nav-highlight-scale', '1');
 
       surface.classList.remove(HIGHLIGHT_VISIBLE_CLASS);
@@ -1997,9 +2001,8 @@ shOnReady(function () {
     }
 
     const isSelected = selectedItem === item;
-    const ratio = isSelected ? 1 : HOVER_INDICATOR_RATIO;
     const isIntro = !highlightHasShown;
-    let width = linkRect.width * ratio;
+    let width = linkRect.width * INDICATOR_RATIO;
     let offset = linkRect.left - surfaceRect.left + (linkRect.width - width) / 2;
     const maxWidth = surfaceRect.width;
 
@@ -2011,6 +2014,7 @@ shOnReady(function () {
     surface.style.setProperty('--sh-nav-highlight-width', width.toFixed(2) + 'px');
     surface.style.setProperty('--sh-nav-highlight-x', offset.toFixed(2) + 'px');
     surface.style.setProperty('--sh-nav-highlight-color', isSelected ? SELECTED_INDICATOR_COLOR : HOVER_INDICATOR_COLOR);
+    surface.style.setProperty('--sh-nav-highlight-border-color', isSelected ? SELECTED_INDICATOR_BORDER : HOVER_INDICATOR_BORDER);
     surface.style.setProperty('--sh-nav-highlight-opacity', '1');
 
     if (isIntro) {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1697,7 +1697,8 @@ body,
   --sh-nav-highlight-x: 0px;
   --sh-nav-highlight-width: 0px;
   --sh-nav-highlight-opacity: 0;
-  --sh-nav-highlight-color: #4b5563;
+  --sh-nav-highlight-color: rgba(244, 246, 248, 0.96);
+  --sh-nav-highlight-border-color: rgba(203, 213, 225, 0.7);
   --sh-nav-highlight-scale: 1;
   --sh-nav-highlight-origin: left;
   background-color: #ffffff;
@@ -1707,10 +1708,7 @@ body,
   box-shadow: none;
 }
 
-.sh-header__nav-surface:hover {
-  border-color: #e4e4e4;
-  box-shadow: 0 18px 36px -18px rgba(0, 0, 0, 0.16);
-}
+
 
 .sh-header__nav-inner {
   position: relative;
@@ -1740,7 +1738,7 @@ body,
 
 .sh-header__nav-list {
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   gap: 0;
   position: relative;
   z-index: 1;
@@ -1756,13 +1754,16 @@ body,
 .sh-header__nav-highlight {
   position: absolute;
   left: 0;
-  bottom: 10px;
+  top: 6px;
   width: var(--sh-nav-highlight-width, 0px);
-  height: 4px;
+  height: calc(100% - 12px);
   transform: translateX(var(--sh-nav-highlight-x, 0px)) scaleX(var(--sh-nav-highlight-scale, 1));
   transform-origin: var(--sh-nav-highlight-origin, left);
-  border-radius: 999px;
-  background-color: var(--sh-nav-highlight-color, #4b5563);
+  border-radius: 12px 12px 0 0;
+  background-color: var(--sh-nav-highlight-color, rgba(229, 231, 235, 0.92));
+  border: 1px solid var(--sh-nav-highlight-border-color, rgba(148, 163, 184, 0.5));
+  border-bottom-color: transparent;
+  box-shadow: 0 6px 18px rgba(17, 24, 39, 0.05);
   opacity: var(--sh-nav-highlight-opacity, 0);
   transition:
     width 0.32s cubic-bezier(0.22, 1, 0.36, 1),
@@ -1793,21 +1794,12 @@ body,
 }
 
 .sh-header__nav-highlight::after {
-  content: "";
-  position: absolute;
-  left: 50%;
-  bottom: -6px;
-  transform: translateX(-50%);
-  width: 0;
-  height: 0;
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  border-top: 8px solid var(--sh-nav-highlight-color, #4b5563);
+  content: none;
 }
 
 .sh-header__nav-item {
   position: static;
-  flex: 1;
+  flex: 1 1 0;
   text-align: center;
 }
 
@@ -1817,7 +1809,7 @@ body,
   justify-content: center;
   gap: 10px;
   width: 100%;
-  padding: 18px 12px;
+  padding: 16px 14px;
   color: #1a1a1a;
   text-decoration: none;
   white-space: nowrap;
@@ -1870,6 +1862,13 @@ body,
   text-decoration: none;
 }
 
+.sh-header__nav-link:hover .sh-header__nav-text,
+.sh-header__nav-link:focus .sh-header__nav-text,
+.sh-header__nav-item.is-open .sh-header__nav-text,
+.sh-header__nav-item.is-selected .sh-header__nav-text {
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.9);
+}
+
 .sh-header__nav-item.is-open .sh-header__nav-link {
   color: var(--sh-color-dark);
 }
@@ -1898,8 +1897,8 @@ body,
   width: 100%;
   margin: 0 auto;
   padding: 32px 48px;
-  border: 1px solid #e4e4e4;
-  border-top: none;
+  border: 1px solid var(--sh-nav-highlight-border-color, #e4e4e4);
+  border-top: 1px solid var(--sh-nav-highlight-border-color, #e4e4e4);
   border-radius: 0 0 18px 18px;
   background-color: #ffffff;
   box-shadow: 0 18px 36px -18px rgba(0, 0, 0, 0.16);


### PR DESCRIPTION
## Summary
- open the nav hover indicator on the bottom while rounding the top corners so it encloses only the active item
- remove surface-wide hover borders and use the indicator’s border color for dropdown panels to keep a single continuous frame per item

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692561577c308331b4ac83896f66315b)