### PR TITLE
Fade nav highlight when dropdowns are active

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1763,6 +1763,12 @@ body,
     background-color 0.22s ease;
 }
 
+.fh-header__nav-surface:has(.fh-header__dropdown:hover) .fh-header__nav-highlight,
+.fh-header__nav-surface:has(.fh-header__nav-item.is-open) .fh-header__nav-highlight {
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
 .fh-header__nav-surface--highlight-intro .fh-header__nav-highlight {
   transition:
     opacity 0.22s ease,
@@ -1874,7 +1880,6 @@ body,
 
 .fh-header__dropdown {
   position: absolute;
-  top: 100%;
   left: 1px;
   right: 0;
   width: 100%;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1754,9 +1754,8 @@ body,
 .sh-header__nav-highlight {
   position: absolute;
   left: 0;
-  top: 6px;
   width: var(--sh-nav-highlight-width, 0px);
-  height: calc(100% - 12px);
+  height: 100%;
   transform: translateX(var(--sh-nav-highlight-x, 0px)) scaleX(var(--sh-nav-highlight-scale, 1));
   transform-origin: var(--sh-nav-highlight-origin, left);
   border-radius: 12px 12px 0 0;
@@ -1770,6 +1769,17 @@ body,
     opacity 0.22s ease,
     background-color 0.22s ease;
   pointer-events: none;
+}
+
+.sh-header__nav-surface:not(:hover) .sh-header__nav-highlight {
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.sh-header__nav-surface:has(.sh-header__dropdown:hover) .sh-header__nav-highlight,
+.sh-header__nav-surface:has(.sh-header__nav-item.is-open) .sh-header__nav-highlight {
+  opacity: 0;
+  transition: opacity 0.12s ease;
 }
 
 .sh-header__nav-surface--highlight-visible .sh-header__nav-highlight {
@@ -1891,8 +1901,7 @@ body,
 
 .sh-header__dropdown {
   position: absolute;
-  top: calc(100% - 2px);
-  left: 0;
+  left: 1px;
   right: 0;
   width: 100%;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- hide the nav highlight on FH and SH as soon as a dropdown opens or is hovered so the grey background fades out while using submenus
- remove the manual top offset from both FH and SH dropdown containers and align the 1px left adjustment

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925ae3561388331965c34ef42e1ed4c)