### PR TITLE
Adjust FH header navigation contrast and rounding

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1671,7 +1671,7 @@ body,
 }
 
 .fh-header__nav {
-  background-color: #ffffff;
+  background-color: #f3f5f8;
 }
 
 .fh-header__nav-surface {
@@ -1681,15 +1681,15 @@ body,
   --fh-nav-highlight-x: 0px;
   --fh-nav-highlight-width: 0px;
   --fh-nav-highlight-opacity: 0;
-  --fh-nav-highlight-color: #fff;
-  --fh-nav-highlight-border-color: rgba(203, 213, 225, 0.7);
+  --fh-nav-highlight-color: #ffffff;
+  --fh-nav-highlight-border-color: rgba(148, 163, 184, 0.6);
   --fh-nav-highlight-scale: 1;
   --fh-nav-highlight-origin: left;
-  background-color: #ffffff;
-  border: 1px solid transparent;
+  background: linear-gradient(180deg, #f7f9fc 0%, #eef2f6 100%);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   border-bottom: none;
   border-radius: 18px 18px 0 0;
-  box-shadow: none;
+  box-shadow: 0 18px 40px -30px rgba(15, 23, 42, 0.3);
 }
 
 
@@ -1742,11 +1742,11 @@ body,
   height: 100%;
   transform: translateX(var(--fh-nav-highlight-x, 0px)) scaleX(var(--fh-nav-highlight-scale, 1));
   transform-origin: var(--fh-nav-highlight-origin, left);
-  border-radius: 12px 12px 0 0;
+  border-radius: 14px 14px 0 0;
   background-color: var(--fh-nav-highlight-color, #fff);
-  border: 1px solid var(--fh-nav-highlight-border-color, rgba(148, 163, 184, 0.5));
+  border: 1px solid var(--fh-nav-highlight-border-color, rgba(148, 163, 184, 0.6));
   border-bottom-color: transparent;
-  box-shadow: 0 6px 18px rgba(17, 24, 39, 0.05);
+  box-shadow: 0 14px 30px -18px rgba(17, 24, 39, 0.16);
   opacity: var(--fh-nav-highlight-opacity, 0);
   transition:
     width 0.32s cubic-bezier(0.22, 1, 0.36, 1),
@@ -1798,13 +1798,27 @@ body,
   gap: 10px;
   width: 100%;
   padding: 16px 14px;
-  color: #1a1a1a;
+  color: #1f2937;
   text-decoration: none;
   white-space: nowrap;
   text-transform: uppercase;
   position: relative;
   z-index: 1;
-  transition: color 0.2s ease;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-bottom: none;
+  border-radius: 14px 14px 0 0;
+  background: linear-gradient(180deg, #f5f7fa 0%, #eef1f5 100%);
+  box-shadow:
+    inset 0 -1px 0 rgba(255, 255, 255, 0.7),
+    0 1px 0 rgba(255, 255, 255, 0.35);
+  transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.fh-header__nav-item:not(.is-selected) .fh-header__nav-link {
+  background: linear-gradient(180deg, #f4f6f9 0%, #eef1f5 100%);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.4),
+    0 1px 0 rgba(255, 255, 255, 0.3);
 }
 
 .fh-header__nav-icon {
@@ -1847,6 +1861,9 @@ body,
 .fh-header__nav-link:hover,
 .fh-header__nav-link:focus {
   color: var(--fh-color-dark-blue);
+  background: #ffffff;
+  border-color: rgba(148, 163, 184, 0.7);
+  box-shadow: 0 14px 30px -18px rgba(15, 23, 42, 0.24);
   text-decoration: none;
 }
 
@@ -1858,6 +1875,9 @@ body,
 
 .fh-header__nav-item.is-selected .fh-header__nav-link {
   color: var(--fh-color-bright-blue);
+  background-color: #ffffff;
+  border-color: rgba(148, 163, 184, 0.7);
+  box-shadow: 0 18px 40px -24px rgba(15, 23, 42, 0.26);
 }
 
 @media (min-width: 1600px) {
@@ -2702,25 +2722,29 @@ body,
   .fh-header__nav-link {
     padding: 18px 0;
     font-size: 18px;
+    border: none;
     border-bottom: 1px solid #e5e7eb;
+    border-radius: 0;
+    background: none;
+    box-shadow: none;
     white-space: normal;
     justify-content: flex-start;
-  gap: 12px;
-}
+    gap: 12px;
+  }
 
-.fh-header__mobile-submenu-cta {
-  margin-top: 12px;
-  display: flex;
-  justify-content: flex-start;
-}
+  .fh-header__mobile-submenu-cta {
+    margin-top: 12px;
+    display: flex;
+    justify-content: flex-start;
+  }
 
-.fh-header__mobile-submenu-cta .schlossfinder {
-  justify-content: center;
-}
+  .fh-header__mobile-submenu-cta .schlossfinder {
+    justify-content: center;
+  }
 
-.schlossfinder--mobile {
-  width: auto;
-}
+  .schlossfinder--mobile {
+    width: auto;
+  }
 
   .fh-header__nav-icon {
     width: 24px;

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1822,21 +1822,21 @@ body,
   text-transform: uppercase;
   position: relative;
   z-index: 1;
-  border: 1px solid rgba(148, 163, 184, 0.4);
+  border: 1px solid transparent;
   border-bottom: none;
   border-radius: 0;
-  background: linear-gradient(180deg, #f5f7fa 0%, #eef1f5 100%);
-  box-shadow:
-    inset 0 -1px 0 rgba(255, 255, 255, 0.7),
-    0 1px 0 rgba(255, 255, 255, 0.35);
+  background: none;
+  box-shadow: none;
   transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.fh-header__nav-item:not(.is-selected) .fh-header__nav-link {
+.fh-header__nav-surface:hover .fh-header__nav-link,
+.fh-header__nav-surface:focus-within .fh-header__nav-link {
   background: linear-gradient(180deg, #f4f6f9 0%, #eef1f5 100%);
   box-shadow:
     inset 0 0 0 1px rgba(255, 255, 255, 0.4),
     0 1px 0 rgba(255, 255, 255, 0.3);
+  border-color: rgba(148, 163, 184, 0.35);
 }
 
 .fh-header__nav-item:first-child .fh-header__nav-link {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1671,7 +1671,7 @@ body,
 }
 
 .fh-header__nav {
-  background-color: #f3f5f8;
+  background-color: transparent;
 }
 
 .fh-header__nav-surface {
@@ -1688,7 +1688,7 @@ body,
   background: transparent;
   border: 1px solid transparent;
   border-bottom: none;
-  border-radius: 18px 18px 0 0;
+  border-radius: 12px 12px 0 0;
   box-shadow: none;
   overflow: visible;
   isolation: isolate;

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1690,6 +1690,7 @@ body,
   border-bottom: none;
   border-radius: 18px 18px 0 0;
   box-shadow: 0 18px 40px -30px rgba(15, 23, 42, 0.3);
+  overflow: hidden;
 }
 
 
@@ -1806,7 +1807,7 @@ body,
   z-index: 1;
   border: 1px solid rgba(148, 163, 184, 0.4);
   border-bottom: none;
-  border-radius: 14px 14px 0 0;
+  border-radius: 0;
   background: linear-gradient(180deg, #f5f7fa 0%, #eef1f5 100%);
   box-shadow:
     inset 0 -1px 0 rgba(255, 255, 255, 0.7),
@@ -1819,6 +1820,14 @@ body,
   box-shadow:
     inset 0 0 0 1px rgba(255, 255, 255, 0.4),
     0 1px 0 rgba(255, 255, 255, 0.3);
+}
+
+.fh-header__nav-item:first-child .fh-header__nav-link {
+  border-top-left-radius: 14px;
+}
+
+.fh-header__nav-item:last-child .fh-header__nav-link {
+  border-top-right-radius: 14px;
 }
 
 .fh-header__nav-icon {
@@ -1865,6 +1874,7 @@ body,
   border-color: rgba(148, 163, 184, 0.7);
   box-shadow: 0 14px 30px -18px rgba(15, 23, 42, 0.24);
   text-decoration: none;
+  border-radius: 14px 14px 0 0;
 }
 
 .fh-header__nav-link:hover .fh-header__nav-text,
@@ -1878,6 +1888,7 @@ body,
   background-color: #ffffff;
   border-color: rgba(148, 163, 184, 0.7);
   box-shadow: 0 18px 40px -24px rgba(15, 23, 42, 0.26);
+  border-radius: 14px 14px 0 0;
 }
 
 @media (min-width: 1600px) {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1690,7 +1690,23 @@ body,
   border-bottom: none;
   border-radius: 18px 18px 0 0;
   box-shadow: 0 18px 40px -30px rgba(15, 23, 42, 0.3);
-  overflow: hidden;
+  overflow: visible;
+  isolation: isolate;
+}
+
+.fh-header__nav-surface::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(180deg, #f7f9fc 0%, #eef2f6 100%);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-bottom: none;
+  box-shadow:
+    inset 0 -1px 0 rgba(255, 255, 255, 0.45),
+    0 18px 40px -30px rgba(15, 23, 42, 0.18);
+  z-index: 0;
+  pointer-events: none;
 }
 
 
@@ -1726,7 +1742,7 @@ body,
   justify-content: space-between;
   gap: 0;
   position: relative;
-  z-index: 1;
+  z-index: 2;
   width: 100%;
   padding: 0;
   list-style: none;
@@ -1741,6 +1757,7 @@ body,
   left: 0;
   width: var(--fh-nav-highlight-width, 0px);
   height: 100%;
+  z-index: 1;
   transform: translateX(var(--fh-nav-highlight-x, 0px)) scaleX(var(--fh-nav-highlight-scale, 1));
   transform-origin: var(--fh-nav-highlight-origin, left);
   border-radius: 14px 14px 0 0;
@@ -1874,6 +1891,14 @@ body,
   border-color: rgba(148, 163, 184, 0.7);
   box-shadow: 0 14px 30px -18px rgba(15, 23, 42, 0.24);
   text-decoration: none;
+  border-radius: 14px 14px 0 0;
+}
+
+.fh-header__nav-item.is-open .fh-header__nav-link {
+  color: var(--fh-color-dark-blue);
+  background: #ffffff;
+  border-color: rgba(148, 163, 184, 0.7);
+  box-shadow: 0 14px 30px -18px rgba(15, 23, 42, 0.24);
   border-radius: 14px 14px 0 0;
 }
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1685,13 +1685,14 @@ body,
   --fh-nav-highlight-border-color: rgba(148, 163, 184, 0.6);
   --fh-nav-highlight-scale: 1;
   --fh-nav-highlight-origin: left;
-  background: linear-gradient(180deg, #f7f9fc 0%, #eef2f6 100%);
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: transparent;
+  border: 1px solid transparent;
   border-bottom: none;
   border-radius: 18px 18px 0 0;
-  box-shadow: 0 18px 40px -30px rgba(15, 23, 42, 0.3);
+  box-shadow: none;
   overflow: visible;
   isolation: isolate;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .fh-header__nav-surface::before {
@@ -1707,6 +1708,19 @@ body,
     0 18px 40px -30px rgba(15, 23, 42, 0.18);
   z-index: 0;
   pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+
+.fh-header__nav-surface:hover,
+.fh-header__nav-surface:focus-within {
+  border-color: rgba(148, 163, 184, 0.35);
+  box-shadow: 0 18px 40px -30px rgba(15, 23, 42, 0.3);
+}
+
+.fh-header__nav-surface:hover::before,
+.fh-header__nav-surface:focus-within::before {
+  opacity: 1;
 }
 
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1700,7 +1700,7 @@ body,
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(180deg, #f7f9fc 0%, #eef2f6 100%);
+  background: #ffffff;
   border: 1px solid rgba(148, 163, 184, 0.18);
   border-bottom: none;
   box-shadow:
@@ -1709,7 +1709,8 @@ body,
   z-index: 0;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 0.18s ease;
+  visibility: hidden;
+  transition: opacity 0.18s ease, visibility 0.18s ease;
 }
 
 .fh-header__nav-surface:hover,
@@ -1721,6 +1722,7 @@ body,
 .fh-header__nav-surface:hover::before,
 .fh-header__nav-surface:focus-within::before {
   opacity: 1;
+  visibility: visible;
 }
 
 
@@ -1774,7 +1776,7 @@ body,
   z-index: 1;
   transform: translateX(var(--fh-nav-highlight-x, 0px)) scaleX(var(--fh-nav-highlight-scale, 1));
   transform-origin: var(--fh-nav-highlight-origin, left);
-  border-radius: 14px 14px 0 0;
+  border-radius: 12px 12px 0 0;
   background-color: var(--fh-nav-highlight-color, #fff);
   border: 1px solid var(--fh-nav-highlight-border-color, rgba(148, 163, 184, 0.6));
   border-bottom-color: transparent;
@@ -1854,11 +1856,11 @@ body,
 }
 
 .fh-header__nav-item:first-child .fh-header__nav-link {
-  border-top-left-radius: 14px;
+  border-top-left-radius: 12px;
 }
 
 .fh-header__nav-item:last-child .fh-header__nav-link {
-  border-top-right-radius: 14px;
+  border-top-right-radius: 12px;
 }
 
 .fh-header__nav-icon {
@@ -1905,7 +1907,7 @@ body,
   border-color: rgba(148, 163, 184, 0.7);
   box-shadow: 0 14px 30px -18px rgba(15, 23, 42, 0.24);
   text-decoration: none;
-  border-radius: 14px 14px 0 0;
+  border-radius: 12px 12px 0 0;
 }
 
 .fh-header__nav-item.is-open .fh-header__nav-link {
@@ -1913,7 +1915,7 @@ body,
   background: #ffffff;
   border-color: rgba(148, 163, 184, 0.7);
   box-shadow: 0 14px 30px -18px rgba(15, 23, 42, 0.24);
-  border-radius: 14px 14px 0 0;
+  border-radius: 12px 12px 0 0;
 }
 
 .fh-header__nav-link:hover .fh-header__nav-text,
@@ -1927,7 +1929,7 @@ body,
   background-color: #ffffff;
   border-color: rgba(148, 163, 184, 0.7);
   box-shadow: 0 18px 40px -24px rgba(15, 23, 42, 0.26);
-  border-radius: 14px 14px 0 0;
+  border-radius: 12px 12px 0 0;
 }
 
 @media (min-width: 1600px) {


### PR DESCRIPTION
## Summary
- soften the FH header navigation surface with a muted gradient and clearer highlight borders
- add rounded, lightly bordered nav links that shift to bright white on hover/selection to emphasize hierarchy
- keep the mobile navigation flat by overriding new desktop-specific borders and backgrounds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925ed1025448331a77b7c2e07d40192)