### PR TITLE
Make nav hover backgrounds transparent

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1700,12 +1700,9 @@ body,
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: #ffffff;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  border-bottom: none;
-  box-shadow:
-    inset 0 -1px 0 rgba(255, 255, 255, 0.45),
-    0 18px 40px -30px rgba(15, 23, 42, 0.18);
+  background: transparent;
+  border: none;
+  box-shadow: none;
   z-index: 0;
   pointer-events: none;
   opacity: 0;
@@ -1721,8 +1718,8 @@ body,
 
 .fh-header__nav-surface:hover::before,
 .fh-header__nav-surface:focus-within::before {
-  opacity: 1;
-  visibility: visible;
+  opacity: 0;
+  visibility: hidden;
 }
 
 
@@ -1848,11 +1845,10 @@ body,
 
 .fh-header__nav-surface:hover .fh-header__nav-link,
 .fh-header__nav-surface:focus-within .fh-header__nav-link {
-  background: linear-gradient(180deg, #f4f6f9 0%, #eef1f5 100%);
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.4),
-    0 1px 0 rgba(255, 255, 255, 0.3);
-  border-color: rgba(148, 163, 184, 0.35);
+  background: none;
+  box-shadow: none;
+  border-color: transparent;
+  color: #0f172a;
 }
 
 .fh-header__nav-item:first-child .fh-header__nav-link {


### PR DESCRIPTION
## Summary
- remove background, border, and shadow from the nav surface pseudo-element to keep the header navigation transparent
- simplify nav link hover/focus styles to avoid grey gradients while retaining a subtle color change

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926ca8240088331b025df7ffc604389)