### PR TITLE
Add hover background for FH header navigation

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1692,6 +1692,20 @@ body,
   box-shadow: none;
 }
 
+.fh-header__nav-surface::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 6px;
+  height: calc(100% - 10px);
+  background-color: #f7f7f8;
+  border-radius: 12px 12px 0 0;
+  opacity: 0;
+  transition: opacity 0.22s ease;
+  z-index: 0;
+}
+
 
 
 .fh-header__nav-inner {
@@ -1753,11 +1767,19 @@ body,
     opacity 0.12s ease-out,
     background-color 0.22s ease;
   pointer-events: none;
+  z-index: 1;
 }
 
 .fh-header__nav-surface:has(.fh-header__dropdown:hover) .fh-header__nav-highlight {
   background-color: #fff;
   transition-duration: 0.12s;
+}
+
+.fh-header__nav-surface:hover::before,
+.fh-header__nav-surface--highlight-visible::before,
+.fh-header__nav-surface:has(.fh-header__nav-item.is-open)::before,
+.fh-header__nav-surface:has(.fh-header__nav-item.is-selected)::before {
+  opacity: 1;
 }
 
 .fh-header__nav-surface--highlight-visible .fh-header__nav-highlight {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1702,7 +1702,7 @@ body,
   background-color: #f7f7f8;
   border-radius: 12px 12px 0 0;
   opacity: 0;
-  transition: opacity 0.22s ease;
+  transition: opacity 0.1s ease;
   z-index: 0;
 }
 
@@ -1776,9 +1776,7 @@ body,
 }
 
 .fh-header__nav-surface:hover::before,
-.fh-header__nav-surface--highlight-visible::before,
-.fh-header__nav-surface:has(.fh-header__nav-item.is-open)::before,
-.fh-header__nav-surface:has(.fh-header__nav-item.is-selected)::before {
+.fh-header__nav-surface:has(.fh-header__nav-item.is-open)::before {
   opacity: 1;
 }
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -917,7 +917,7 @@ body,
   width: 100%;
   padding: 14px 52px 14px 24px;
   border: 1px solid #d5d5d5;
-  border-radius: 18px;
+  border-radius: 14px;
   font-size: 15px;
   line-height: 1.4;
   color: var(--fh-color-navy-blue);
@@ -1697,8 +1697,8 @@ body,
   position: absolute;
   left: 1px;
   right: 0;
-  top: -6px;
-  height: calc(100% + 2px);
+  top: 6px;
+  height: calc(100% - 6px);
   background-color: #fafbfc;
   border-radius: 12px 12px 0 0;
   border: 1px solid var(--fh-nav-highlight-border-color, rgba(148, 163, 184, 0.5));

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1695,12 +1695,14 @@ body,
 .fh-header__nav-surface::before {
   content: '';
   position: absolute;
-  left: 0;
+  left: 1px;
   right: 0;
-  top: 6px;
-  height: calc(100% - 10px);
-  background-color: #f7f7f8;
+  top: -6px;
+  height: calc(100% + 2px);
+  background-color: #fafbfc;
   border-radius: 12px 12px 0 0;
+  border: 1px solid var(--fh-nav-highlight-border-color, rgba(148, 163, 184, 0.5));
+  border-bottom: none;
   opacity: 0;
   transition: opacity 0.1s ease;
   z-index: 0;


### PR DESCRIPTION
## Summary
- add a subtle light-grey hover background behind the FH desktop navigation
- ensure the new background appears alongside existing nav highlight states and stays behind interactive elements

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926d12809cc8331be8d5c6079d22cf6)