### PR TITLE
Remove dynamic desktop nav highlight line

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1695,19 +1695,7 @@ body,
 }
 
 .fh-header__nav-surface::before {
-  content: '';
-  position: absolute;
-  left: 1px;
-  right: 0;
-  top: 6px;
-  height: calc(100% - 6px);
-  background-color: #fafbfc;
-  border-radius: 12px 12px 0 0;
-  border: 1px solid var(--fh-nav-highlight-border-color, rgba(148, 163, 184, 0.5));
-  border-bottom: none;
-  opacity: 0;
-  transition: opacity 0.1s ease;
-  z-index: 0;
+  content: none;
 }
 
 
@@ -1754,24 +1742,7 @@ body,
 }
 
 .fh-header__nav-highlight {
-  position: absolute;
-  left: 0;
-  width: var(--fh-nav-highlight-width, 0px);
-  height: 100%;
-  transform: translateX(var(--fh-nav-highlight-x, 0px)) scaleX(var(--fh-nav-highlight-scale, 1));
-  transform-origin: var(--fh-nav-highlight-origin, left);
-  border-radius: 12px 12px 0 0;
-  background-color: var(--fh-nav-highlight-color, #fff);
-  border: 1px solid var(--fh-nav-highlight-border-color, rgba(148, 163, 184, 0.5));
-  border-bottom-color: transparent;
-  box-shadow: 0 6px 18px rgba(17, 24, 39, 0.05);
-  opacity: var(--fh-nav-highlight-opacity, 0);
-  transition:
-    width 0.32s cubic-bezier(0.22, 1, 0.36, 1),
-    opacity 0.12s ease-out,
-    background-color 0.22s ease;
-  pointer-events: none;
-  z-index: 1;
+  display: none;
 }
 
 .fh-header__nav-surface:has(.fh-header__dropdown:hover) .fh-header__nav-highlight {

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -1944,125 +1944,21 @@ fhOnReady(function () {
     }
 
     pendingHighlightItem = null;
+    highlightHasShown = false;
 
-    if (surface.classList.contains(HIGHLIGHT_VISIBLE_CLASS)) {
-      surface.classList.remove(HIGHLIGHT_INTRO_CLASS);
-      surface.classList.add(HIGHLIGHT_VISIBLE_CLASS);
-
-      surface.style.setProperty('--fh-nav-highlight-opacity', '0');
-      surface.style.setProperty('--fh-nav-highlight-scale', '0');
-
-      highlightHideTimeout = window.setTimeout(function () {
-        highlightHideTimeout = null;
-
-        surface.style.setProperty('--fh-nav-highlight-width', '0px');
-        surface.style.setProperty('--fh-nav-highlight-color', HOVER_INDICATOR_COLOR);
-        surface.style.setProperty('--fh-nav-highlight-border-color', HOVER_INDICATOR_BORDER);
-        surface.style.setProperty('--fh-nav-highlight-scale', '1');
-
-        surface.classList.remove(HIGHLIGHT_VISIBLE_CLASS);
-        surface.classList.remove(HIGHLIGHT_INTRO_CLASS);
-
-        highlightHasShown = false;
-      }, HIGHLIGHT_EXIT_DURATION);
-    } else {
-      surface.style.setProperty('--fh-nav-highlight-opacity', '0');
-      surface.style.setProperty('--fh-nav-highlight-width', '0px');
-      surface.style.setProperty('--fh-nav-highlight-color', HOVER_INDICATOR_COLOR);
-      surface.style.setProperty('--fh-nav-highlight-border-color', HOVER_INDICATOR_BORDER);
-      surface.style.setProperty('--fh-nav-highlight-scale', '1');
-
-      surface.classList.remove(HIGHLIGHT_VISIBLE_CLASS);
-      surface.classList.remove(HIGHLIGHT_INTRO_CLASS);
-
-      highlightHasShown = false;
-    }
+    surface.classList.remove(HIGHLIGHT_VISIBLE_CLASS);
+    surface.classList.remove(HIGHLIGHT_INTRO_CLASS);
+    surface.style.setProperty('--fh-nav-highlight-opacity', '0');
+    surface.style.setProperty('--fh-nav-highlight-width', '0px');
+    surface.style.setProperty('--fh-nav-highlight-scale', '0');
   }
 
-  function applyHighlightForItem(item) {
-    if (!isDesktop() || !item) {
-      clearHighlight();
-      return;
-    }
-
-    const link = getLink(item);
-
-    if (!link) {
-      clearHighlight();
-      return;
-    }
-
-    const surfaceRect = surface.getBoundingClientRect();
-    const linkRect = link.getBoundingClientRect();
-
-    if (surfaceRect.width <= 0 || linkRect.width <= 0) {
-      clearHighlight();
-      return;
-    }
-
-    const isSelected = selectedItem === item;
-    const isIntro = !highlightHasShown;
-    let width = linkRect.width * INDICATOR_RATIO;
-    let offset = linkRect.left - surfaceRect.left + (linkRect.width - width) / 2;
-    const maxWidth = surfaceRect.width;
-
-    width = Math.max(0, Math.min(width, maxWidth));
-    offset = Math.min(Math.max(offset, 0), Math.max(0, maxWidth - width));
-
-    if (isIntro) surface.classList.add(HIGHLIGHT_INTRO_CLASS);
-
-    surface.style.setProperty('--fh-nav-highlight-width', width.toFixed(2) + 'px');
-    surface.style.setProperty('--fh-nav-highlight-x', offset.toFixed(2) + 'px');
-    surface.style.setProperty('--fh-nav-highlight-color', isSelected ? SELECTED_INDICATOR_COLOR : HOVER_INDICATOR_COLOR);
-    surface.style.setProperty('--fh-nav-highlight-border-color', isSelected ? SELECTED_INDICATOR_BORDER : HOVER_INDICATOR_BORDER);
-    surface.style.setProperty('--fh-nav-highlight-opacity', '1');
-
-    if (isIntro) {
-      const itemIndex = navItems.indexOf(item);
-      const isFirstItem = itemIndex === 0;
-      const isLastItem = itemIndex === navItems.length - 1;
-
-      surface.style.setProperty('--fh-nav-highlight-origin', isFirstItem ? 'left' : isLastItem ? 'right' : 'center');
-      surface.style.setProperty('--fh-nav-highlight-scale', '0');
-
-      highlightHasShown = true;
-
-      raf(function () {
-        surface.classList.add(HIGHLIGHT_VISIBLE_CLASS);
-
-        raf(function () {
-          surface.style.setProperty('--fh-nav-highlight-scale', '1');
-
-          window.setTimeout(function () {
-            surface.classList.remove(HIGHLIGHT_INTRO_CLASS);
-          }, HIGHLIGHT_INTRO_EXIT_DELAY);
-        });
-      });
-    } else {
-      surface.classList.add(HIGHLIGHT_VISIBLE_CLASS);
-      surface.style.setProperty('--fh-nav-highlight-scale', '1');
-    }
+  function applyHighlightForItem() {
+    clearHighlight();
   }
 
-  function requestHighlight(item) {
-    if (highlightHideTimeout != null) {
-      window.clearTimeout(highlightHideTimeout);
-      highlightHideTimeout = null;
-    }
-
-    pendingHighlightItem = item;
-
-    if (!isDesktop()) {
-      clearHighlight();
-      return;
-    }
-
-    if (highlightFrame != null) return;
-
-    highlightFrame = raf(function () {
-      highlightFrame = null;
-      applyHighlightForItem(pendingHighlightItem);
-    });
+  function requestHighlight() {
+    clearHighlight();
   }
 
   function openItem(item) {

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -1944,125 +1944,21 @@ shOnReady(function () {
     }
 
     pendingHighlightItem = null;
+    highlightHasShown = false;
 
-    if (surface.classList.contains(HIGHLIGHT_VISIBLE_CLASS)) {
-      surface.classList.remove(HIGHLIGHT_INTRO_CLASS);
-      surface.classList.add(HIGHLIGHT_VISIBLE_CLASS);
-
-      surface.style.setProperty('--sh-nav-highlight-opacity', '0');
-      surface.style.setProperty('--sh-nav-highlight-scale', '0');
-
-      highlightHideTimeout = window.setTimeout(function () {
-        highlightHideTimeout = null;
-
-        surface.style.setProperty('--sh-nav-highlight-width', '0px');
-        surface.style.setProperty('--sh-nav-highlight-color', HOVER_INDICATOR_COLOR);
-        surface.style.setProperty('--sh-nav-highlight-border-color', HOVER_INDICATOR_BORDER);
-        surface.style.setProperty('--sh-nav-highlight-scale', '1');
-
-        surface.classList.remove(HIGHLIGHT_VISIBLE_CLASS);
-        surface.classList.remove(HIGHLIGHT_INTRO_CLASS);
-
-        highlightHasShown = false;
-      }, HIGHLIGHT_EXIT_DURATION);
-    } else {
-      surface.style.setProperty('--sh-nav-highlight-opacity', '0');
-      surface.style.setProperty('--sh-nav-highlight-width', '0px');
-      surface.style.setProperty('--sh-nav-highlight-color', HOVER_INDICATOR_COLOR);
-      surface.style.setProperty('--sh-nav-highlight-border-color', HOVER_INDICATOR_BORDER);
-      surface.style.setProperty('--sh-nav-highlight-scale', '1');
-
-      surface.classList.remove(HIGHLIGHT_VISIBLE_CLASS);
-      surface.classList.remove(HIGHLIGHT_INTRO_CLASS);
-
-      highlightHasShown = false;
-    }
+    surface.classList.remove(HIGHLIGHT_VISIBLE_CLASS);
+    surface.classList.remove(HIGHLIGHT_INTRO_CLASS);
+    surface.style.setProperty('--sh-nav-highlight-opacity', '0');
+    surface.style.setProperty('--sh-nav-highlight-width', '0px');
+    surface.style.setProperty('--sh-nav-highlight-scale', '0');
   }
 
-  function applyHighlightForItem(item) {
-    if (!isDesktop() || !item) {
-      clearHighlight();
-      return;
-    }
-
-    const link = getLink(item);
-
-    if (!link) {
-      clearHighlight();
-      return;
-    }
-
-    const surfaceRect = surface.getBoundingClientRect();
-    const linkRect = link.getBoundingClientRect();
-
-    if (surfaceRect.width <= 0 || linkRect.width <= 0) {
-      clearHighlight();
-      return;
-    }
-
-    const isSelected = selectedItem === item;
-    const isIntro = !highlightHasShown;
-    let width = linkRect.width * INDICATOR_RATIO;
-    let offset = linkRect.left - surfaceRect.left + (linkRect.width - width) / 2;
-    const maxWidth = surfaceRect.width;
-
-    width = Math.max(0, Math.min(width, maxWidth));
-    offset = Math.min(Math.max(offset, 0), Math.max(0, maxWidth - width));
-
-    if (isIntro) surface.classList.add(HIGHLIGHT_INTRO_CLASS);
-
-    surface.style.setProperty('--sh-nav-highlight-width', width.toFixed(2) + 'px');
-    surface.style.setProperty('--sh-nav-highlight-x', offset.toFixed(2) + 'px');
-    surface.style.setProperty('--sh-nav-highlight-color', isSelected ? SELECTED_INDICATOR_COLOR : HOVER_INDICATOR_COLOR);
-    surface.style.setProperty('--sh-nav-highlight-border-color', isSelected ? SELECTED_INDICATOR_BORDER : HOVER_INDICATOR_BORDER);
-    surface.style.setProperty('--sh-nav-highlight-opacity', '1');
-
-    if (isIntro) {
-      const itemIndex = navItems.indexOf(item);
-      const isFirstItem = itemIndex === 0;
-      const isLastItem = itemIndex === navItems.length - 1;
-
-      surface.style.setProperty('--sh-nav-highlight-origin', isFirstItem ? 'left' : isLastItem ? 'right' : 'center');
-      surface.style.setProperty('--sh-nav-highlight-scale', '0');
-
-      highlightHasShown = true;
-
-      raf(function () {
-        surface.classList.add(HIGHLIGHT_VISIBLE_CLASS);
-
-        raf(function () {
-          surface.style.setProperty('--sh-nav-highlight-scale', '1');
-
-          window.setTimeout(function () {
-            surface.classList.remove(HIGHLIGHT_INTRO_CLASS);
-          }, HIGHLIGHT_INTRO_EXIT_DELAY);
-        });
-      });
-    } else {
-      surface.classList.add(HIGHLIGHT_VISIBLE_CLASS);
-      surface.style.setProperty('--sh-nav-highlight-scale', '1');
-    }
+  function applyHighlightForItem() {
+    clearHighlight();
   }
 
-  function requestHighlight(item) {
-    if (highlightHideTimeout != null) {
-      window.clearTimeout(highlightHideTimeout);
-      highlightHideTimeout = null;
-    }
-
-    pendingHighlightItem = item;
-
-    if (!isDesktop()) {
-      clearHighlight();
-      return;
-    }
-
-    if (highlightFrame != null) return;
-
-    highlightFrame = raf(function () {
-      highlightFrame = null;
-      applyHighlightForItem(pendingHighlightItem);
-    });
+  function requestHighlight() {
+    clearHighlight();
   }
 
   function openItem(item) {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1711,19 +1711,7 @@ body,
 }
 
 .sh-header__nav-surface::before {
-  content: '';
-  position: absolute;
-  left: 1px;
-  right: 0;
-  top: 6px;
-  height: calc(100% - 6px);
-  background-color: #fafbfc;
-  border-radius: 12px 12px 0 0;
-  border: 1px solid var(--sh-nav-highlight-border-color, rgba(148, 163, 184, 0.5));
-  border-bottom: none;
-  opacity: 0;
-  transition: opacity 0.1s ease;
-  z-index: 0;
+  content: none;
 }
 
 
@@ -1770,24 +1758,7 @@ body,
 }
 
 .sh-header__nav-highlight {
-  position: absolute;
-  left: 0;
-  width: var(--sh-nav-highlight-width, 0px);
-  height: 100%;
-  transform: translateX(var(--sh-nav-highlight-x, 0px)) scaleX(var(--sh-nav-highlight-scale, 1));
-  transform-origin: var(--sh-nav-highlight-origin, left);
-  border-radius: 12px 12px 0 0;
-  background-color: var(--sh-nav-highlight-color, #fff);
-  border: 1px solid var(--sh-nav-highlight-border-color, rgba(148, 163, 184, 0.5));
-  border-bottom-color: transparent;
-  box-shadow: 0 6px 18px rgba(17, 24, 39, 0.05);
-  opacity: var(--sh-nav-highlight-opacity, 0);
-  transition:
-    width 0.32s cubic-bezier(0.22, 1, 0.36, 1),
-    opacity 0.12s ease-out,
-    background-color 0.22s ease;
-  pointer-events: none;
-  z-index: 1;
+  display: none;
 }
 
 .sh-header__nav-surface:has(.sh-header__dropdown:hover) .sh-header__nav-highlight {


### PR DESCRIPTION
## Summary
- disable the desktop navigation highlight logic so the underlining bar is never drawn
- keep navigation selection and dropdown interactions intact while clearing highlight state immediately

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926e1cf79cc8331ba82a0b7b55ccaaa)