### PR TITLE
Restore nav hover overlays while removing dropdown line indicators

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1913,29 +1913,11 @@ body,
 }
 
 .fh-header__dropdown::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 1px;
-  border-top: 1px solid var(--fh-nav-highlight-border-color, rgba(148, 163, 184, 0.5));
-  opacity: 0;
-  transition: opacity 0.18s ease;
-  pointer-events: none;
+  content: none;
 }
 
 .fh-header__dropdown::after {
-  content: '';
-  position: absolute;
-  left: calc(var(--fh-nav-highlight-x, 0px));
-  top: 0;
-  width: calc(var(--fh-nav-highlight-width, 0px));
-  height: 1px;
-  background-color: #ffffff;
-  opacity: 0;
-  transition: opacity 0.18s ease;
-  pointer-events: none;
+  content: none;
 }
 
 .fh-header__nav-item.is-open > .fh-header__dropdown::before,

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1929,36 +1929,11 @@ body,
 }
 
 .sh-header__dropdown::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 1px;
-  border-top: 1px solid var(--sh-nav-highlight-border-color, rgba(148, 163, 184, 0.5));
-  opacity: 0;
-  transition: opacity 0.18s ease;
-  pointer-events: none;
+  content: none;
 }
 
 .sh-header__dropdown::after {
-  content: '';
-  position: absolute;
-  left: calc(var(--sh-nav-highlight-x, 0px));
-  top: 0;
-  width: calc(var(--sh-nav-highlight-width, 0px));
-  height: 1px;
-  background-color: #ffffff;
-  opacity: 0;
-  transition: opacity 0.18s ease;
-  pointer-events: none;
-}
-
-.sh-header__nav-item.is-open > .sh-header__dropdown::before,
-.sh-header__nav-item.is-selected > .sh-header__dropdown::before,
-.sh-header__nav-item.is-open > .sh-header__dropdown::after,
-.sh-header__nav-item.is-selected > .sh-header__dropdown::after {
-  opacity: 1;
+  content: none;
 }
 
 .sh-header__dropdown-grid {


### PR DESCRIPTION
## Summary
- restore the desktop nav background and highlight overlays for both FH and SH headers
- keep highlight animations while removing the dropdown top line/indicator that caused the stray horizontal bar

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926e1cf79cc8331ba82a0b7b55ccaaa)