### PR TITLE
Add hover shadow to FH header navigation

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1692,6 +1692,7 @@ body,
   border-bottom: none;
   border-radius: 18px 18px 0 0;
   box-shadow: none;
+  transition: box-shadow 0.24s ease;
 }
 
 .fh-header__nav-surface::before {
@@ -1708,6 +1709,10 @@ body,
   opacity: 0;
   transition: opacity 0.1s ease;
   z-index: 0;
+}
+
+.fh-header__nav:hover .fh-header__nav-surface {
+  box-shadow: 0 12px 24px -12px rgba(30, 41, 59, 0.28);
 }
 
 
@@ -2624,6 +2629,10 @@ body,
 
   .fh-header__nav-surface:hover {
     border: none;
+    box-shadow: none;
+  }
+
+  .fh-header__nav:hover .fh-header__nav-surface {
     box-shadow: none;
   }
 


### PR DESCRIPTION
## Summary
- add hover transition and shadow to FH navigation surface to emphasize active category layering
- keep mobile navigation styles unaffected by clearing hover shadow in small-screen overrides

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692828eb77608331a7200b94a40c8df1)