### PR TITLE
Align SH nav highlight styling with FH

### DIFF
--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1715,8 +1715,9 @@ body,
   position: absolute;
   left: 1px;
   right: 0;
-  top: 6px;
-  height: calc(100% - 6px);
+  top: -1px;
+  width: 100%;
+  height: calc(100% + 1px);
   background-color: #fafbfc;
   border-radius: 12px 12px 0 0;
   border: 1px solid var(--sh-nav-highlight-border-color, rgba(148, 163, 184, 0.5));
@@ -1771,9 +1772,10 @@ body,
 
 .sh-header__nav-highlight {
   position: absolute;
+  top: -1px;
   left: 0;
   width: var(--sh-nav-highlight-width, 0px);
-  height: 100%;
+  height: calc(100% + 2px);
   transform: translateX(var(--sh-nav-highlight-x, 0px)) scaleX(var(--sh-nav-highlight-scale, 1));
   transform-origin: var(--sh-nav-highlight-origin, left);
   border-radius: 12px 12px 0 0;


### PR DESCRIPTION
## Summary
- adjust Schrauben-Hammer nav highlight overlay positioning to match Fenster-Hammer header updates
- extend nav highlight sizing to cover bar outline

## Testing
- not run (CSS changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69282a8f59dc83318af9b35df9326761)