### PR TITLE
Show crossprice values on product cards

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -87,10 +87,6 @@ body,
   font-size: 0.85rem;
   color: #6b7280;
 }
-
-.widget-item-grid .cmp-product-thumb .prices .crossprice {
-  display: none !important;
-}
 /* End Section: Artikel Preview Card Preis Layout */
 
 /* Section: Artikelpaket Badge ausblenden */

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -87,10 +87,6 @@ body,
   font-size: 0.85rem;
   color: #6b7280;
 }
-
-.widget-item-grid .cmp-product-thumb .prices .crossprice {
-  display: none !important;
-}
 /* End Section: Artikel Preview Card Preis Layout */
 
 /* Section: Artikelpaket Badge ausblenden */


### PR DESCRIPTION
## Summary
- remove the rule that hid `.crossprice` values in FH product card pricing
- remove the same hiding rule for SH product cards so cross prices render again

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69284efd5fe08331abfa8df015e58988)