### PR TITLE
Hide header overlay on mobile navigation

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2810,7 +2810,7 @@ body.fh-mobile-menu-open {
   margin-right: auto;
 }
 
-@media (max-width: 991.98px) {
+@media (max-width: 1599.98px) {
   #page-header {
     background-color: var(--fh-color-surface) !important;
   }

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2809,6 +2809,16 @@ body.fh-mobile-menu-open {
   margin-left: auto;
   margin-right: auto;
 }
+
+@media (max-width: 991.98px) {
+  #page-header {
+    background-color: var(--fh-color-surface) !important;
+  }
+
+  #page-header::before {
+    display: none;
+  }
+}
 /* End Section: Page Header Background */
 
 /* Section: FH search input native control overrides */

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2623,6 +2623,12 @@ body,
     box-shadow: none;
   }
 
+  .fh-header__nav-surface::before,
+  .fh-header__nav-surface:hover::before,
+  .fh-header__nav-surface:has(.fh-header__nav-item.is-open)::before {
+    opacity: 0;
+  }
+
   .fh-header__mobile-close {
     display: inline-flex;
     margin: 0;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -2633,6 +2633,12 @@ body,
     box-shadow: none;
   }
 
+  .sh-header__nav-surface::before,
+  .sh-header__nav-surface:hover::before,
+  .sh-header__nav-surface:has(.sh-header__nav-item.is-open)::before {
+    opacity: 0;
+  }
+
   .sh-header__mobile-close {
     display: inline-flex;
     margin: 0;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -2820,7 +2820,7 @@ body.sh-mobile-menu-open {
   margin-right: auto;
 }
 
-@media (max-width: 991.98px) {
+@media (max-width: 1599.98px) {
   #page-header {
     background-color: var(--sh-color-surface) !important;
   }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -2819,6 +2819,16 @@ body.sh-mobile-menu-open {
   margin-left: auto;
   margin-right: auto;
 }
+
+@media (max-width: 991.98px) {
+  #page-header {
+    background-color: var(--sh-color-surface) !important;
+  }
+
+  #page-header::before {
+    display: none;
+  }
+}
 /* End Section: Page Header Background */
 
 /* Section: sh search input native control overrides */


### PR DESCRIPTION
## Summary
- hide the desktop header overlay when the mobile navigation is shown for both SH and FH stylesheets
- keep the header background solid on small screens to avoid the grey/blue tint in the mobile menu

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928512967fc8331adfdebb5e901d860)