### PR TITLE
Adjust header layout for mid-size viewports

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1706,6 +1706,27 @@ body,
   z-index: 0;
 }
 
+.fh-header__nav-scroll-wrapper {
+  position: relative;
+}
+
+.fh-header__nav-scroll-next {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.fh-header__nav-scroll-next-icon {
+  width: 18px;
+  height: 18px;
+}
+
+.fh-header__nav-scroll-indicator {
+  display: none;
+  pointer-events: none;
+}
+
 
 
 .fh-header__nav-inner {
@@ -2737,6 +2758,163 @@ body,
 
   .fh-header__dropdown {
     display: none !important;
+  }
+}
+
+@media (max-width: 1599.98px) and (min-width: 768px) {
+  .fh-header__main {
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas: none;
+    row-gap: 0;
+    padding: 20px 18px;
+    column-gap: 18px;
+  }
+
+  .fh-header__search-area {
+    display: flex;
+    grid-template-columns: none;
+    column-gap: 12px;
+    align-items: center;
+  }
+
+  .fh-header__search-input {
+    padding: 12px 52px 12px 24px;
+    font-size: 15px;
+  }
+
+  .fh-header__actions {
+    align-items: center;
+    gap: 14px;
+  }
+
+  .fh-header__mobile-close {
+    display: none;
+  }
+
+  .fh-header__basket {
+    justify-self: end;
+  }
+
+  .fh-header__basket-link {
+    width: auto;
+    min-width: 132px;
+    padding: 0 18px;
+    gap: 10px;
+    border-radius: 14px;
+  }
+
+  .fh-header__basket-total {
+    display: inline-flex;
+  }
+
+  .fh-header__nav {
+    position: relative;
+    top: auto;
+    left: auto;
+    width: 100%;
+    height: auto;
+    display: block;
+    overflow: visible;
+    transform: none;
+    padding: 0 0 16px;
+    background-color: transparent;
+  }
+
+  .fh-header__nav-inner {
+    max-width: 1600px;
+    padding: 0 18px;
+    margin: 0 auto;
+    overflow: visible;
+  }
+
+  .fh-header__nav-surface {
+    padding: 0 74px 0 10px;
+    border-radius: 14px;
+    border-color: var(--fh-nav-highlight-border-color, rgba(148, 163, 184, 0.5));
+    box-shadow: none;
+    overflow: hidden;
+  }
+
+  .fh-header__nav-highlight {
+    display: none;
+  }
+
+  .fh-header__nav-list {
+    flex-direction: row;
+    justify-content: flex-start;
+    gap: 12px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    padding: 0 68px 0 4px;
+    scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .fh-header__nav-list::-webkit-scrollbar {
+    display: none;
+  }
+
+  .fh-header__nav-item {
+    flex: 0 0 auto;
+    text-align: left;
+  }
+
+  .fh-header__nav-link {
+    padding: 14px 12px;
+    border-bottom: none;
+    font-size: 15px;
+    white-space: nowrap;
+  }
+
+  .fh-header__nav--submenu-open .fh-header__nav-list {
+    pointer-events: auto;
+  }
+
+  .fh-header__nav-scroll-wrapper {
+    position: relative;
+  }
+
+  .fh-header__nav-scroll-indicator {
+    position: absolute;
+    top: 4px;
+    right: 60px;
+    width: 44px;
+    height: calc(100% - 8px);
+    border-radius: 12px;
+    background: linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--fh-color-bright-blue) 60%, transparent) 0%,
+      color-mix(in srgb, var(--fh-color-bright-blue) 85%, transparent) 72%,
+      transparent 100%
+    );
+    opacity: 0.42;
+    display: none;
+    pointer-events: none;
+  }
+
+  .fh-header__nav-scroll-indicator.is-visible {
+    display: block;
+  }
+
+  .fh-header__nav-scroll-next {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    border: 1px solid var(--fh-color-bright-blue);
+    background: var(--fh-color-bright-blue);
+    color: #ffffff;
+    box-shadow: 0 6px 14px color-mix(in srgb, var(--fh-color-bright-blue) 16%, transparent);
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .fh-header__nav-scroll-next.is-visible {
+    display: inline-flex;
   }
 }
 

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -547,17 +547,18 @@
             </li>
             </ul>
           </div>
-          <div class="fh-header__nav-scroll-indicator" data-fh-nav-scroll-indicator aria-hidden="true"></div>
-          <button type="button" class="fh-header__nav-scroll-next" data-fh-nav-scroll-next aria-label="Weitere Kategorien anzeigen">
-            <svg class="fh-header__nav-scroll-next-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <polyline points="8 4 16 12 8 20"></polyline>
-            </svg>
-          </button>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-schloesser" data-fh-mobile-panel="schloesser" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
+              <div class="fh-header__nav-scroll-indicator" data-fh-nav-scroll-indicator aria-hidden="true"></div>
+              <button type="button" class="fh-header__nav-scroll-next" data-fh-nav-scroll-next aria-label="Weitere Kategorien anzeigen">
+                <svg class="fh-header__nav-scroll-next-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <polyline points="8 4 16 12 8 20"></polyline>
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-schloesser" data-fh-mobile-panel="schloesser" aria-hidden="true">
+            <div class="fh-header__mobile-submenu-header">
+              <div class="fh-header__mobile-submenu-bar">
+                <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
                   <polyline points="15 18 9 12 15 6"></polyline>
                 </svg>

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -248,9 +248,10 @@
               </button>
             </div>
           </div>
-          <div class="fh-header__nav-surface" data-fh-desktop-nav-surface>
-            <span class="fh-header__nav-highlight" aria-hidden="true"></span>
-            <ul class="nav fh-header__nav-list">
+            <div class="fh-header__nav-scroll-wrapper">
+              <div class="fh-header__nav-surface" data-fh-desktop-nav-surface>
+                <span class="fh-header__nav-highlight" aria-hidden="true"></span>
+                <ul class="nav fh-header__nav-list">
             <li class="nav-item dropdown fh-header__nav-item">
               <a class="nav-link fh-header__nav-link" href="/schloesser" data-fh-mobile-submenu-target="schloesser" aria-controls="fh-mobile-submenu-schloesser" aria-expanded="false">
                 <span class="fh-header__nav-icon" aria-hidden="true">
@@ -546,6 +547,12 @@
             </li>
             </ul>
           </div>
+          <div class="fh-header__nav-scroll-indicator" data-fh-nav-scroll-indicator aria-hidden="true"></div>
+          <button type="button" class="fh-header__nav-scroll-next" data-fh-nav-scroll-next aria-label="Weitere Kategorien anzeigen">
+            <svg class="fh-header__nav-scroll-next-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="8 4 16 12 8 20"></polyline>
+            </svg>
+          </button>
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-schloesser" data-fh-mobile-panel="schloesser" aria-hidden="true">
           <div class="fh-header__mobile-submenu-header">

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -2173,6 +2173,80 @@ fhOnReady(function () {
 });
 // End Section: FH desktop navigation highlight & selection behaviour
 
+// Section: FH navigation scroll assist for medium viewports
+fhOnReady(function () {
+  const header = document.querySelector('[data-fh-header-root]');
+
+  if (!header) return;
+
+  const navSurface = header.querySelector('[data-fh-desktop-nav-surface]');
+  const navList = navSurface ? navSurface.querySelector('.fh-header__nav-list') : null;
+  const scrollIndicator = header.querySelector('[data-fh-nav-scroll-indicator]');
+  const scrollNext = header.querySelector('[data-fh-nav-scroll-next]');
+  const media = window.matchMedia('(min-width: 768px) and (max-width: 1599.98px)');
+
+  if (!navSurface || !navList || !scrollIndicator || !scrollNext) return;
+
+  let isScrollable = false;
+
+  function getNavItems() {
+    return Array.prototype.slice.call(navList.querySelectorAll('.fh-header__nav-item'));
+  }
+
+  function isAtScrollEnd() {
+    return navList.scrollLeft + navList.clientWidth >= navList.scrollWidth - 1;
+  }
+
+  function updateIndicator() {
+    const visible = isScrollable && !isAtScrollEnd();
+
+    scrollIndicator.classList.toggle('is-visible', visible);
+    scrollNext.classList.toggle('is-visible', isScrollable);
+  }
+
+  function updateScrollableState() {
+    isScrollable = media.matches && navList.scrollWidth > navList.clientWidth + 4;
+
+    navSurface.classList.toggle('fh-header__nav-surface--scrollable', isScrollable);
+    updateIndicator();
+  }
+
+  function scrollToNextItem() {
+    if (!isScrollable) return;
+
+    const items = getNavItems();
+
+    if (items.length === 0) return;
+
+    const currentLeft = navList.scrollLeft;
+    let nextIndex = items.findIndex(function (item) {
+      return item.offsetLeft + item.offsetWidth > currentLeft + 2;
+    });
+    nextIndex = nextIndex === -1 ? items.length - 1 : nextIndex;
+
+    const targetItem = items[Math.min(nextIndex + 1, items.length - 1)];
+
+    if (!targetItem) return;
+
+    navList.scrollTo({ left: targetItem.offsetLeft, behavior: 'smooth' });
+  }
+
+  function handleMediaChange() {
+    updateScrollableState();
+    updateIndicator();
+  }
+
+  navList.addEventListener('scroll', updateIndicator, { passive: true });
+  scrollNext.addEventListener('click', scrollToNextItem);
+
+  if (typeof media.addEventListener === 'function') media.addEventListener('change', handleMediaChange); else if (typeof media.addListener === 'function') media.addListener(handleMediaChange);
+
+  window.addEventListener('resize', handleMediaChange);
+
+  updateScrollableState();
+});
+// End Section: FH navigation scroll assist for medium viewports
+
 // Section: Restrict focus to the basket preview while it is open
 fhOnReady(function () {
   const body = document.body;

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -1091,6 +1091,7 @@ fhOnReady(function () {
 
   const closeButtons = header.querySelectorAll('[data-fh-mobile-menu-close]');
   const focusableSelectors = 'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  const inlineNavMedia = window.matchMedia('(min-width: 768px)');
   const desktopMedia = window.matchMedia('(min-width: 1600px)');
   const panelContainer = menu.querySelector('[data-fh-mobile-views]');
   const panelElements = panelContainer
@@ -1614,7 +1615,7 @@ fhOnReady(function () {
     const skipFocus = !!(options && options.skipFocus === true);
 
     menu.classList.remove('fh-header__nav--open');
-    menu.setAttribute('aria-hidden', desktopMedia.matches ? 'false' : 'true');
+    menu.setAttribute('aria-hidden', inlineNavMedia.matches ? 'false' : 'true');
     document.body.classList.remove('fh-mobile-menu-open');
     clearPendingSelection();
     setExpandedState(false);
@@ -1734,6 +1735,10 @@ fhOnReady(function () {
 
   if (typeof desktopMedia.addEventListener === 'function') desktopMedia.addEventListener('change', handleBreakpointChange); else if (typeof desktopMedia.addListener === 'function') {
     desktopMedia.addListener(handleBreakpointChange);
+  }
+
+  if (typeof inlineNavMedia.addEventListener === 'function') inlineNavMedia.addEventListener('change', handleBreakpointChange); else if (typeof inlineNavMedia.addListener === 'function') {
+    inlineNavMedia.addListener(handleBreakpointChange);
   }
 
   closeMenu({ skipFocus: true });


### PR DESCRIPTION
## Summary
- Keep the header search bar inline between logo and actions from 768px to 1599px while keeping the burger menu and full basket styling
- Add a horizontal navigation scroll wrapper with gradient cue and arrow control for mid-size viewports
- Add JavaScript to detect overflow and drive the navigation scroll indicator and next-button behaviour

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929474fb2c48331bd707f871e869025)