### PR TITLE
Refine FH header mid-width navigation layout

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1714,6 +1714,19 @@ body,
   margin: 0 auto;
 }
 
+.fh-header__nav-viewport {
+  position: relative;
+}
+
+.fh-header__nav-scroll-button {
+  display: none;
+}
+
+.fh-header__nav-scroll-icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
 .fh-header__mobile-close {
   display: none;
   align-items: center;
@@ -2762,6 +2775,199 @@ body.fh-mobile-menu-open {
     left: 59%;
     right: auto;
     transform: translateX(calc(-50% + 8px)) rotate(45deg);
+  }
+}
+
+@media (max-width: 1599.98px) and (min-width: 768px) {
+  .fh-header {
+    width: 100%;
+    padding-right: 0;
+  }
+
+  .fh-header__main {
+    grid-template-columns: auto minmax(320px, 1fr) auto;
+    grid-template-areas: "logo search actions";
+    row-gap: 0;
+    column-gap: 16px;
+    padding: 18px 24px 16px;
+  }
+
+  .fh-header__search-area {
+    grid-area: search;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    max-height: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .fh-header__actions {
+    column-gap: 16px;
+  }
+
+  .fh-header__burger {
+    display: inline-flex;
+  }
+
+  .fh-header__search-input {
+    padding: 12px 16px;
+    font-size: 15px;
+  }
+
+  .fh-header__icon-button {
+    width: 46px;
+    height: 46px;
+  }
+
+  .fh-header__basket {
+    justify-self: end;
+  }
+
+  .fh-header__basket-link {
+    min-width: 190px;
+    width: auto;
+    height: 48px;
+    padding: 12px 16px;
+    justify-content: center;
+    gap: 10px;
+  }
+
+  .fh-header__basket-total {
+    display: inline-flex;
+  }
+
+  .fh-header__nav {
+    position: relative;
+    top: auto;
+    left: auto;
+    height: auto;
+    transform: none;
+    padding: 0 24px 10px;
+    background-color: transparent;
+    overflow: visible;
+  }
+
+  .fh-header__nav-inner {
+    display: block;
+    flex: none;
+    overflow: visible;
+    max-width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+
+  .fh-header__nav-surface {
+    padding: 0;
+    border: 1px solid #e5e7eb;
+    border-radius: 14px 14px 0 0;
+    box-shadow: var(--fh-shadow-elevation-soft);
+    overflow: visible;
+  }
+
+  .fh-header__nav-surface::before {
+    display: none;
+  }
+
+  .fh-header__nav-surface::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 48px;
+    height: 100%;
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(49, 165, 240, 0.5));
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+  }
+
+  .fh-header__nav-surface--scrollable::after {
+    opacity: 0.9;
+  }
+
+  .fh-header__nav-surface--at-end::after {
+    opacity: 0;
+  }
+
+  .fh-header__nav-viewport {
+    overflow-x: auto;
+    overflow-y: visible;
+    padding: 0 56px 0 6px;
+    margin-right: -8px;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  .fh-header__nav-viewport::-webkit-scrollbar {
+    display: none;
+  }
+
+  .fh-header__nav-list {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    gap: 4px;
+    padding: 0 8px;
+    width: max-content;
+    min-width: 100%;
+    scroll-snap-type: x mandatory;
+  }
+
+  .fh-header__nav-item {
+    flex: 0 0 auto;
+    scroll-snap-align: start;
+  }
+
+  .fh-header__nav-link {
+    padding: 14px 16px;
+    border-bottom: none;
+    justify-content: center;
+  }
+
+  .fh-header__dropdown {
+    display: none;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateY(12px);
+  }
+
+  .fh-header__nav-item.is-open > .fh-header__dropdown {
+    display: block;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .fh-header__nav-scroll-button {
+    position: absolute;
+    top: 50%;
+    right: 10px;
+    transform: translateY(-50%);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    border: 1px solid #d5d5d5;
+    background: linear-gradient(180deg, #ffffff 0%, #eef3fd 100%);
+    color: var(--fh-color-bright-blue);
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.16);
+    z-index: 2;
+    cursor: pointer;
+    transition: opacity 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .fh-header__nav-scroll-button:disabled {
+    opacity: 0.5;
+    box-shadow: none;
+    cursor: not-allowed;
+  }
+
+  .fh-header__nav-surface--at-end .fh-header__nav-scroll-button {
+    opacity: 0.6;
   }
 }
 /* End Section: FH Header Base Layout */

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -250,7 +250,8 @@
           </div>
           <div class="fh-header__nav-surface" data-fh-desktop-nav-surface>
             <span class="fh-header__nav-highlight" aria-hidden="true"></span>
-            <ul class="nav fh-header__nav-list">
+            <div class="fh-header__nav-viewport" data-fh-nav-viewport>
+              <ul class="nav fh-header__nav-list">
             <li class="nav-item dropdown fh-header__nav-item">
               <a class="nav-link fh-header__nav-link" href="/schloesser" data-fh-mobile-submenu-target="schloesser" aria-controls="fh-mobile-submenu-schloesser" aria-expanded="false">
                 <span class="fh-header__nav-icon" aria-hidden="true">
@@ -544,7 +545,11 @@
                 </div>
               </div>
             </li>
-            </ul>
+              </ul>
+            </div>
+            <button type="button" class="fh-header__nav-scroll-button" aria-label="Weitere Kategorien" data-fh-nav-scroll-next>
+              <span aria-hidden="true" class="fh-header__nav-scroll-icon">›</span>
+            </button>
           </div>
         </div>
         <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-schloesser" data-fh-mobile-panel="schloesser" aria-hidden="true">

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -2173,6 +2173,97 @@ fhOnReady(function () {
 });
 // End Section: FH desktop navigation highlight & selection behaviour
 
+// Section: FH mid-breakpoint navigation horizontal scroll helper
+fhOnReady(function () {
+  const header = document.querySelector('[data-fh-header-root]');
+
+  if (!header) return;
+
+  const surface = header.querySelector('[data-fh-desktop-nav-surface]');
+  const viewport = surface ? surface.querySelector('[data-fh-nav-viewport]') : null;
+  const navList = viewport ? viewport.querySelector('.fh-header__nav-list') : null;
+  const scrollButton = surface ? surface.querySelector('[data-fh-nav-scroll-next]') : null;
+
+  if (!surface || !viewport || !navList || !scrollButton) return;
+
+  const scrollMedia = window.matchMedia('(max-width: 1599.98px) and (min-width: 768px)');
+  const raf =
+    typeof window.requestAnimationFrame === 'function'
+      ? window.requestAnimationFrame.bind(window)
+      : function (callback) {
+          return window.setTimeout(callback, 16);
+        };
+
+  let rafId = null;
+
+  function updateScrollState() {
+    rafId = null;
+
+    const inRange = scrollMedia.matches;
+    const hasOverflow = inRange && viewport.scrollWidth - viewport.clientWidth > 4;
+    const atStart = inRange && viewport.scrollLeft <= 4;
+    const atEnd =
+      inRange && viewport.scrollLeft >= viewport.scrollWidth - viewport.clientWidth - 4;
+
+    surface.classList.toggle('fh-header__nav-surface--scrollable', hasOverflow);
+    surface.classList.toggle('fh-header__nav-surface--at-start', atStart);
+    surface.classList.toggle('fh-header__nav-surface--at-end', atEnd && hasOverflow);
+
+    scrollButton.disabled = !hasOverflow;
+    scrollButton.hidden = !hasOverflow;
+  }
+
+  function requestScrollStateUpdate() {
+    if (rafId != null) return;
+
+    rafId = raf(updateScrollState);
+  }
+
+  function scrollToNextItem() {
+    if (!scrollMedia.matches) return;
+
+    const items = Array.prototype.slice.call(navList.querySelectorAll('.fh-header__nav-item'));
+
+    if (!items.length) return;
+
+    const currentLeft = viewport.scrollLeft;
+    const viewportRight = currentLeft + viewport.clientWidth;
+    let targetLeft = viewport.scrollWidth - viewport.clientWidth;
+
+    for (let index = 0; index < items.length; index += 1) {
+      const item = items[index];
+
+      if (!item) continue;
+
+      const itemRight = item.offsetLeft + item.offsetWidth;
+
+      if (itemRight > viewportRight + 1) {
+        targetLeft = item.offsetLeft;
+        break;
+      }
+    }
+
+    viewport.scrollTo({ left: targetLeft, behavior: 'smooth' });
+  }
+
+  function handleMediaChange() {
+    requestScrollStateUpdate();
+  }
+
+  scrollButton.addEventListener('click', scrollToNextItem);
+  viewport.addEventListener('scroll', requestScrollStateUpdate, { passive: true });
+  window.addEventListener('resize', requestScrollStateUpdate);
+
+  if (typeof scrollMedia.addEventListener === 'function') scrollMedia.addEventListener('change', handleMediaChange);
+  else if (typeof scrollMedia.addListener === 'function') scrollMedia.addListener(handleMediaChange);
+
+  const observer = new MutationObserver(requestScrollStateUpdate);
+  observer.observe(navList, { childList: true });
+
+  requestScrollStateUpdate();
+});
+// End Section: FH mid-breakpoint navigation horizontal scroll helper
+
 // Section: Restrict focus to the basket preview while it is open
 fhOnReady(function () {
   const body = document.body;


### PR DESCRIPTION
## Summary
- keep the FH header search row inline with the burger and action buttons between 1600px and 768px while restoring the full-width cart button
- allow the navigation bar to remain visible at mid-widths with horizontal scrolling, a blue overflow hint, and an arrow control
- add markup and JavaScript to support the scrollable navigation viewport without affecting larger or mobile viewports

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929539f5aa083318701f469fd11a826)