### PR TITLE
Enable touch hover behavior for wide header navigation

### DIFF
--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -2193,9 +2193,20 @@ fhOnReady(function () {
       link.addEventListener('click', function (event) {
         if (!isDesktop()) return;
 
+        const dropdown = getDropdown(item);
+        const alreadyOpen = currentOpenItem === item;
+        const touchHover = isTouchHoverEnabled(event) || hasTouchCapability();
+
         if (suppressedTouchClickItem === item) {
           suppressedTouchClickItem = null;
           event.preventDefault();
+          return;
+        }
+
+        if (touchHover && dropdown && !alreadyOpen) {
+          event.preventDefault();
+          suppressedTouchClickItem = item;
+          openItem(item);
           return;
         }
 

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -1901,12 +1901,24 @@ fhOnReady(function () {
     return desktopMedia.matches;
   }
 
+  function hasTouchCapability() {
+    return coarsePointerMedia.matches || 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+  }
+
   function isTouchPointer(event) {
     if (!event) return false;
 
     if (typeof event.pointerType === 'string') return event.pointerType === 'touch';
 
-    return coarsePointerMedia.matches;
+    return false;
+  }
+
+  function isTouchHoverEnabled(event) {
+    if (!isDesktop()) return false;
+
+    if (event && event.type === 'touchstart') return hasTouchCapability();
+
+    return isTouchPointer(event);
   }
 
   function getLink(item) {
@@ -2098,6 +2110,7 @@ fhOnReady(function () {
 
   function handleMediaChange(event) {
     if (!event.matches) {
+      suppressedTouchClickItem = null;
       closeCurrentItem();
       clearHighlight();
 
@@ -2140,9 +2153,7 @@ fhOnReady(function () {
 
     if (link) {
       link.addEventListener('pointerdown', function (event) {
-        if (!isDesktop()) return;
-
-        if (!isTouchPointer(event)) return;
+        if (!isTouchHoverEnabled(event)) return;
 
         const alreadyOpen = currentOpenItem === item;
 
@@ -2154,6 +2165,24 @@ fhOnReady(function () {
           suppressedTouchClickItem = null;
         }
       });
+
+      link.addEventListener(
+        'touchstart',
+        function (event) {
+          if (!isTouchHoverEnabled(event)) return;
+
+          const alreadyOpen = currentOpenItem === item;
+
+          if (dropdown && !alreadyOpen) {
+            event.preventDefault();
+            suppressedTouchClickItem = item;
+            openItem(item);
+          } else {
+            suppressedTouchClickItem = null;
+          }
+        },
+        { passive: false }
+      );
 
       link.addEventListener('focus', function () {
         if (!isDesktop()) return;

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -1867,6 +1867,7 @@ fhOnReady(function () {
   if (navItems.length === 0) return;
 
   const desktopMedia = window.matchMedia('(min-width: 1600px)');
+  const coarsePointerMedia = window.matchMedia('(pointer: coarse)');
   const raf =
     typeof window.requestAnimationFrame === 'function'
       ? window.requestAnimationFrame.bind(window)
@@ -1883,6 +1884,7 @@ fhOnReady(function () {
   let pendingHighlightItem = null;
   let highlightHasShown = false;
   let highlightHideTimeout = null;
+  let suppressedTouchClickItem = null;
 
   const HIGHLIGHT_VISIBLE_CLASS = 'fh-header__nav-surface--highlight-visible';
   const HIGHLIGHT_INTRO_CLASS = 'fh-header__nav-surface--highlight-intro';
@@ -2146,7 +2148,10 @@ fhOnReady(function () {
 
         if (dropdown && !alreadyOpen) {
           event.preventDefault();
+          suppressedTouchClickItem = item;
           openItem(item);
+        } else {
+          suppressedTouchClickItem = null;
         }
       });
 
@@ -2158,6 +2163,12 @@ fhOnReady(function () {
 
       link.addEventListener('click', function (event) {
         if (!isDesktop()) return;
+
+        if (suppressedTouchClickItem === item) {
+          suppressedTouchClickItem = null;
+          event.preventDefault();
+          return;
+        }
 
         if (event.button && event.button !== 0) return;
 

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -1092,6 +1092,7 @@ fhOnReady(function () {
   const closeButtons = header.querySelectorAll('[data-fh-mobile-menu-close]');
   const focusableSelectors = 'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
   const desktopMedia = window.matchMedia('(min-width: 1600px)');
+  const coarsePointerMedia = window.matchMedia('(pointer: coarse)');
   const panelContainer = menu.querySelector('[data-fh-mobile-views]');
   const panelElements = panelContainer
     ? Array.prototype.slice.call(panelContainer.querySelectorAll('[data-fh-mobile-panel]'))
@@ -1898,6 +1899,14 @@ fhOnReady(function () {
     return desktopMedia.matches;
   }
 
+  function isTouchPointer(event) {
+    if (!event) return false;
+
+    if (typeof event.pointerType === 'string') return event.pointerType === 'touch';
+
+    return coarsePointerMedia.matches;
+  }
+
   function getLink(item) {
     if (!item) return null;
 
@@ -2128,6 +2137,19 @@ fhOnReady(function () {
     });
 
     if (link) {
+      link.addEventListener('pointerdown', function (event) {
+        if (!isDesktop()) return;
+
+        if (!isTouchPointer(event)) return;
+
+        const alreadyOpen = currentOpenItem === item;
+
+        if (dropdown && !alreadyOpen) {
+          event.preventDefault();
+          openItem(item);
+        }
+      });
+
       link.addEventListener('focus', function () {
         if (!isDesktop()) return;
 

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -1901,12 +1901,24 @@ shOnReady(function () {
     return desktopMedia.matches;
   }
 
+  function hasTouchCapability() {
+    return coarsePointerMedia.matches || 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+  }
+
   function isTouchPointer(event) {
     if (!event) return false;
 
     if (typeof event.pointerType === 'string') return event.pointerType === 'touch';
 
-    return coarsePointerMedia.matches;
+    return false;
+  }
+
+  function isTouchHoverEnabled(event) {
+    if (!isDesktop()) return false;
+
+    if (event && event.type === 'touchstart') return hasTouchCapability();
+
+    return isTouchPointer(event);
   }
 
   function getLink(item) {
@@ -2098,6 +2110,7 @@ shOnReady(function () {
 
   function handleMediaChange(event) {
     if (!event.matches) {
+      suppressedTouchClickItem = null;
       closeCurrentItem();
       clearHighlight();
 
@@ -2140,9 +2153,7 @@ shOnReady(function () {
 
     if (link) {
       link.addEventListener('pointerdown', function (event) {
-        if (!isDesktop()) return;
-
-        if (!isTouchPointer(event)) return;
+        if (!isTouchHoverEnabled(event)) return;
 
         const alreadyOpen = currentOpenItem === item;
 
@@ -2154,6 +2165,24 @@ shOnReady(function () {
           suppressedTouchClickItem = null;
         }
       });
+
+      link.addEventListener(
+        'touchstart',
+        function (event) {
+          if (!isTouchHoverEnabled(event)) return;
+
+          const alreadyOpen = currentOpenItem === item;
+
+          if (dropdown && !alreadyOpen) {
+            event.preventDefault();
+            suppressedTouchClickItem = item;
+            openItem(item);
+          } else {
+            suppressedTouchClickItem = null;
+          }
+        },
+        { passive: false }
+      );
 
       link.addEventListener('focus', function () {
         if (!isDesktop()) return;

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -1867,6 +1867,7 @@ shOnReady(function () {
   if (navItems.length === 0) return;
 
   const desktopMedia = window.matchMedia('(min-width: 1600px)');
+  const coarsePointerMedia = window.matchMedia('(pointer: coarse)');
   const raf =
     typeof window.requestAnimationFrame === 'function'
       ? window.requestAnimationFrame.bind(window)
@@ -1883,6 +1884,7 @@ shOnReady(function () {
   let pendingHighlightItem = null;
   let highlightHasShown = false;
   let highlightHideTimeout = null;
+  let suppressedTouchClickItem = null;
 
   const HIGHLIGHT_VISIBLE_CLASS = 'sh-header__nav-surface--highlight-visible';
   const HIGHLIGHT_INTRO_CLASS = 'sh-header__nav-surface--highlight-intro';
@@ -2146,7 +2148,10 @@ shOnReady(function () {
 
         if (dropdown && !alreadyOpen) {
           event.preventDefault();
+          suppressedTouchClickItem = item;
           openItem(item);
+        } else {
+          suppressedTouchClickItem = null;
         }
       });
 
@@ -2158,6 +2163,12 @@ shOnReady(function () {
 
       link.addEventListener('click', function (event) {
         if (!isDesktop()) return;
+
+        if (suppressedTouchClickItem === item) {
+          suppressedTouchClickItem = null;
+          event.preventDefault();
+          return;
+        }
 
         if (event.button && event.button !== 0) return;
 

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -1092,6 +1092,7 @@ shOnReady(function () {
   const closeButtons = header.querySelectorAll('[data-sh-mobile-menu-close]');
   const focusableSelectors = 'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
   const desktopMedia = window.matchMedia('(min-width: 1600px)');
+  const coarsePointerMedia = window.matchMedia('(pointer: coarse)');
   const panelContainer = menu.querySelector('[data-sh-mobile-views]');
   const panelElements = panelContainer
     ? Array.prototype.slice.call(panelContainer.querySelectorAll('[data-sh-mobile-panel]'))
@@ -1898,6 +1899,14 @@ shOnReady(function () {
     return desktopMedia.matches;
   }
 
+  function isTouchPointer(event) {
+    if (!event) return false;
+
+    if (typeof event.pointerType === 'string') return event.pointerType === 'touch';
+
+    return coarsePointerMedia.matches;
+  }
+
   function getLink(item) {
     if (!item) return null;
 
@@ -2128,6 +2137,19 @@ shOnReady(function () {
     });
 
     if (link) {
+      link.addEventListener('pointerdown', function (event) {
+        if (!isDesktop()) return;
+
+        if (!isTouchPointer(event)) return;
+
+        const alreadyOpen = currentOpenItem === item;
+
+        if (dropdown && !alreadyOpen) {
+          event.preventDefault();
+          openItem(item);
+        }
+      });
+
       link.addEventListener('focus', function () {
         if (!isDesktop()) return;
 

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -2193,9 +2193,20 @@ shOnReady(function () {
       link.addEventListener('click', function (event) {
         if (!isDesktop()) return;
 
+        const dropdown = getDropdown(item);
+        const alreadyOpen = currentOpenItem === item;
+        const touchHover = isTouchHoverEnabled(event) || hasTouchCapability();
+
         if (suppressedTouchClickItem === item) {
           suppressedTouchClickItem = null;
           event.preventDefault();
+          return;
+        }
+
+        if (touchHover && dropdown && !alreadyOpen) {
+          event.preventDefault();
+          suppressedTouchClickItem = item;
+          openItem(item);
           return;
         }
 


### PR DESCRIPTION
## Summary
- detect coarse/touch pointers on wide viewports to reuse desktop navigation logic
- open header dropdowns on first touch and prevent navigation so touch acts like hover

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69295bc2d0a083318738903c821da0cc)