### PR TITLE
Fix mid-size header overflow

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2779,11 +2779,11 @@ body,
 @media (max-width: 1599.98px) and (min-width: 768px) {
   .fh-header {
     position: relative;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 100vw;
-    max-width: 100vw;
-    margin: 0;
+    left: 0;
+    transform: none;
+    width: 100%;
+    max-width: 100%;
+    margin: 0 auto;
     padding: 0 20px;
     box-sizing: border-box;
   }
@@ -2860,9 +2860,9 @@ body,
   }
 
   .fh-header__nav-inner {
-    width: 100vw;
-    margin-left: calc(50% - 50vw);
-    margin-right: calc(50% - 50vw);
+    width: 100%;
+    margin-left: 0;
+    margin-right: 0;
     padding: 0 20px 14px;
     max-width: none;
   }


### PR DESCRIPTION
## Summary
- adjust mid-size header layout to avoid leftward overflow
- align navigation container to use full viewport width without offset

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929faee3f3c8331ab6b2e430389a2c3)