### PR TITLE
Fix FH header alignment on tablet widths

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2779,11 +2779,11 @@ body,
 @media (max-width: 1599.98px) and (min-width: 768px) {
   .fh-header {
     position: relative;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 100vw;
-    max-width: 100vw;
-    margin: 0;
+    left: auto;
+    transform: none;
+    width: 100%;
+    max-width: 1170px;
+    margin: 0 auto;
     padding: 0 20px;
     box-sizing: border-box;
   }
@@ -2794,9 +2794,9 @@ body,
   #page-header,
   #page-header > div {
     width: 100%;
-    max-width: 100%;
+    max-width: 1170px;
     padding: 0;
-    margin: 0;
+    margin: 0 auto;
     box-sizing: border-box;
   }
 
@@ -2860,11 +2860,11 @@ body,
   }
 
   .fh-header__nav-inner {
-    width: 100vw;
-    margin-left: calc(50% - 50vw);
-    margin-right: calc(50% - 50vw);
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
     padding: 0 20px 14px;
-    max-width: none;
+    max-width: 1170px;
   }
 
   .fh-header__nav-surface {


### PR DESCRIPTION
## Summary
- center the FH header container at tablet widths to match the 1170px layout
- constrain the navigation wrapper to avoid leftward overflow while keeping existing spacing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b5c239920833198eed86d5440b326)