### PR TITLE
Move FH mid-size header burger to nav bar

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2831,7 +2831,7 @@ body,
   }
 
   .fh-header__burger {
-    display: inline-flex;
+    display: none;
   }
 
   .fh-header__basket-link {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2832,7 +2832,12 @@ body,
   }
 
   .fh-header__burger {
-    display: none;
+    display: inline-flex;
+    position: absolute;
+    top: 0;
+    left: 20px;
+    transform: translateY(calc(100% + 10px));
+    z-index: 2;
   }
 
   .fh-header__basket-link {
@@ -2866,11 +2871,12 @@ body,
     margin-right: calc(50% - 50vw);
     padding: 0 20px 14px;
     max-width: none;
+    position: relative;
   }
 
   .fh-header__nav-surface {
     display: grid;
-    grid-template-columns: auto 1fr;
+    grid-template-columns: 1fr auto;
     padding: 10px 12px;
     gap: 12px;
     align-items: center;
@@ -2881,6 +2887,7 @@ body,
     width: 100%;
     box-sizing: border-box;
     position: relative;
+    padding-left: 72px;
   }
 
   .fh-header__nav-surface::before {
@@ -2920,35 +2927,35 @@ body,
     display: none;
   }
 
-  .fh-header__nav-scroll.is-scrollable::after {
-    display: block;
-  }
+    .fh-header__nav-scroll.is-scrollable::after {
+      display: block;
+    }
 
-  .fh-header__nav-list {
-    flex-direction: row;
-    gap: 12px;
-    justify-content: flex-start;
-    width: auto;
-    min-width: max-content;
-    padding: 0;
-  }
+    .fh-header__nav-list {
+      flex-direction: row;
+      gap: 12px;
+      justify-content: flex-start;
+      width: auto;
+      min-width: max-content;
+      padding: 0;
+    }
 
-  .fh-header__nav-item {
-    flex: none;
-    text-align: center;
-    scroll-snap-align: start;
-  }
+    .fh-header__nav-item {
+      flex: none;
+      text-align: center;
+      scroll-snap-align: start;
+    }
 
-  .fh-header__nav-link {
-    font-size: 15px;
-    border-bottom: none;
-    white-space: nowrap;
-    padding: 14px 12px;
-  }
+    .fh-header__nav-link {
+      font-size: 15px;
+      border-bottom: none;
+      white-space: nowrap;
+      padding: 14px 12px;
+    }
 
-  .fh-header__nav-burger {
-    display: inline-flex;
-  }
+    .fh-header__nav-burger {
+      display: none;
+    }
 
   .fh-header__nav-scroll-button {
     display: inline-flex;

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2814,9 +2814,10 @@ body,
 
   .fh-header__search-area {
     grid-area: search;
-    display: flex;
+    display: grid;
+    grid-template-columns: 1fr;
     align-items: center;
-    gap: 12px;
+    gap: 0;
     min-width: 0;
   }
 
@@ -2869,7 +2870,7 @@ body,
 
   .fh-header__nav-surface {
     display: grid;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto 1fr;
     padding: 10px 12px;
     gap: 12px;
     align-items: center;
@@ -2879,6 +2880,7 @@ body,
     box-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
     width: 100%;
     box-sizing: border-box;
+    position: relative;
   }
 
   .fh-header__nav-surface::before {
@@ -2895,7 +2897,7 @@ body,
     flex: 1 1 auto;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
-    padding-right: 72px;
+    padding-right: 60px;
     scroll-behavior: smooth;
     scrollbar-width: none;
     scroll-snap-type: x proximity;
@@ -2961,6 +2963,8 @@ body,
     box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
     flex-shrink: 0;
     flex: 0 0 auto;
+    grid-column: 2;
+    justify-self: end;
   }
 
   .basket-open .fh-header__nav {


### PR DESCRIPTION
## Summary
- hide the main header burger between 768px and 1599.98px so the menu toggle sits with the navigation bar
- keep the navigation bar spanning the remainder of the row for top categories

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bfcf7590c8331ada0ad843ee2d639)