### PR TITLE
Disable FH mobile submenus

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -268,7 +268,7 @@
             <div class="fh-header__nav-scroll" data-fh-nav-scroll>
               <ul class="nav fh-header__nav-list">
             <li class="nav-item dropdown fh-header__nav-item">
-              <a class="nav-link fh-header__nav-link" href="/schloesser" data-fh-mobile-submenu-target="schloesser" aria-controls="fh-mobile-submenu-schloesser" aria-expanded="false">
+              <a class="nav-link fh-header__nav-link" href="/schloesser">
                 <span class="fh-header__nav-icon" aria-hidden="true">
                   <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Schloesser_icon_2.svg" alt="">
                 </span>
@@ -322,7 +322,7 @@
               </div>
             </li>
             <li class="nav-item dropdown fh-header__nav-item">
-              <a class="nav-link fh-header__nav-link" href="/beschlaege" data-fh-mobile-submenu-target="beschlaege" aria-controls="fh-mobile-submenu-beschlaege" aria-expanded="false">
+              <a class="nav-link fh-header__nav-link" href="/beschlaege">
                 <span class="fh-header__nav-icon" aria-hidden="true">
                   <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Beschlaege_icon_2.svg" alt="">
                 </span>
@@ -357,7 +357,7 @@
               </div>
             </li>
             <li class="nav-item dropdown fh-header__nav-item">
-              <a class="nav-link fh-header__nav-link" href="/fenster-sicherheit/" data-fh-mobile-submenu-target="fenster-sicherheit" aria-controls="fh-mobile-submenu-fenster-sicherheit" aria-expanded="false">
+              <a class="nav-link fh-header__nav-link" href="/fenster-sicherheit/">
                 <span class="fh-header__nav-icon" aria-hidden="true">
                   <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Fenster_Sicherheit_icon_2.svg" alt="">
                 </span>
@@ -389,7 +389,7 @@
               </div>
             </li>
             <li class="nav-item dropdown fh-header__nav-item">
-              <a class="nav-link fh-header__nav-link" href="/terrasse" data-fh-mobile-submenu-target="gartenbau" aria-controls="fh-mobile-submenu-gartenbau" aria-expanded="false">
+              <a class="nav-link fh-header__nav-link" href="/terrasse">
                 <span class="fh-header__nav-icon" aria-hidden="true">
                   <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Gartnebau_icon.svg" alt="">
                 </span>
@@ -431,7 +431,7 @@
               </div>
             </li>
             <li class="nav-item dropdown fh-header__nav-item">
-              <a class="nav-link fh-header__nav-link" href="/chemische-befestigung" data-fh-mobile-submenu-target="bauchemie" aria-controls="fh-mobile-submenu-bauchemie" aria-expanded="false">
+              <a class="nav-link fh-header__nav-link" href="/chemische-befestigung">
                 <span class="fh-header__nav-icon" aria-hidden="true">
                   <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Bauchemie_icon.svg" alt="">
                 </span>
@@ -456,7 +456,7 @@
               </div>
             </li>
             <li class="nav-item dropdown fh-header__nav-item">
-              <a class="nav-link fh-header__nav-link" href="/zubehoer" data-fh-mobile-submenu-target="zubehoer" aria-controls="fh-mobile-submenu-zubehoer" aria-expanded="false">
+              <a class="nav-link fh-header__nav-link" href="/zubehoer">
                 <span class="fh-header__nav-icon" aria-hidden="true">
                   <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Zubehoer_icon_2.svg" alt="">
                 </span>
@@ -496,7 +496,7 @@
               </div>
             </li>
             <li class="nav-item dropdown fh-header__nav-item">
-              <a class="nav-link fh-header__nav-link" href="/top-marken" data-fh-mobile-submenu-target="marken" aria-controls="fh-mobile-submenu-marken" aria-expanded="false">
+              <a class="nav-link fh-header__nav-link" href="/top-marken">
                 <span class="fh-header__nav-icon" aria-hidden="true">
                   <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Marken_icon.svg" alt="">
                 </span>
@@ -542,7 +542,7 @@
               </div>
             </li>
             <li class="nav-item dropdown fh-header__nav-item">
-              <a class="nav-link fh-header__nav-link fh-header__nav-link--highlight" href="/aktion" data-fh-mobile-submenu-target="aktionen" aria-controls="fh-mobile-submenu-aktionen" aria-expanded="false">
+              <a class="nav-link fh-header__nav-link fh-header__nav-link--highlight" href="/aktion">
                 <span class="fh-header__nav-icon" aria-hidden="true">
                   <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Aktionen_icon_2.svg" alt="">
                 </span>
@@ -566,394 +566,6 @@
               <span aria-hidden="true" class="fh-header__nav-scroll-icon">➜</span>
             </button>
           </div>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-schloesser" data-fh-mobile-panel="schloesser" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                <span>Zurück</span>
-              </button>
-              <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
-                <span class="fh-header__sr-only">Navigation schließen</span>
-                <svg aria-hidden="true" class="fh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div class="fh-header__mobile-submenu-title">Schlösser</div>
-            <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-            <p class="fh-header__mobile-submenu-description">Passende Lösungen für Haustüren, Wohnungstüren, Zimmer und Tore: Entdecken Sie robuste Schlösser, elektrische Türöffner sowie Profilzylinder inklusive Zubehör für maximale Sicherheit.</p>
-            <div class="fh-header__mobile-submenu-cta">
-              <a href="/schlossfinder" class="schlossfinder schlossfinder--mobile">Schlossfinder</a>
-            </div>
-          </div>
-          <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/schloesser" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Schlösser</a></li>
-            <li><a href="/schloesser/einsteckschloesser-fuer-metalltore" class="fh-header__mobile-submenu-link">Einsteckschlösser</a></li>
-            <li><a href="/schloesser/elektrische-tueroeffner" class="fh-header__mobile-submenu-link">Elektrische Türöffner</a></li>
-            <li><a href="/schloesser/fh-schloesser" class="fh-header__mobile-submenu-link">FH-Schlösser</a></li>
-            <li><button type="button" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--has-children" data-fh-mobile-submenu-target="garagentorschloesser" aria-controls="fh-mobile-submenu-garagentorschloesser" aria-expanded="false">Garagentorschlösser</button></li>
-            <li><a href="/schloesser/haustuerschloesser" class="fh-header__mobile-submenu-link">Haustürschlösser</a></li>
-            <li><a href="/kaesten" class="fh-header__mobile-submenu-link">Kästen</a></li>
-            <li><a href="/schloesser/kastenschloesser" class="fh-header__mobile-submenu-link">Kastenschlösser</a></li>
-            <li><a href="/schloesser/korridortuerschloesser" class="fh-header__mobile-submenu-link">Korridortürschlösser</a></li>
-            <li><a href="/profilzylinder" class="fh-header__mobile-submenu-link">Profilzylinder</a></li>
-            <li><a href="/schloesser/riegelschloesser/" class="fh-header__mobile-submenu-link">Riegelschlösser</a></li>
-            <li><a href="/schloesser/rohrrahmenschloesser" class="fh-header__mobile-submenu-link">Rohrrahmenschlösser</a></li>
-            <li><a href="/schloesser/schiebetuerschloesser" class="fh-header__mobile-submenu-link">Schiebtürschlösser</a></li>
-            <li><a href="/schloesser/schliessbleche" class="fh-header__mobile-submenu-link">Schließbleche</a></li>
-            <li><a href="/schloesser/vorhaengeschloesser" class="fh-header__mobile-submenu-link">Vorhängeschlösser</a></li>
-            <li><a href="/schloesser/wc-tuer-schloesser" class="fh-header__mobile-submenu-link">WC-Tür-Schlösser</a></li>
-            <li><a href="/schloesser/wohnungstuerschloesser" class="fh-header__mobile-submenu-link">Wohnungstürschlösser</a></li>
-            <li><a href="/schloesser/zimmertuerschloesser" class="fh-header__mobile-submenu-link">Zimmertürschlösser</a></li>
-            <li><a href="/schloesser/zubehoer-fuer-schloss-und-tor" class="fh-header__mobile-submenu-link">Zubehör für Schloss und Tor</a></li>
-          </ul>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-fenster-sicherheit" data-fh-mobile-panel="fenster-sicherheit" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                <span>Zurück</span>
-              </button>
-              <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
-                <span class="fh-header__sr-only">Navigation schließen</span>
-                <svg aria-hidden="true" class="fh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div class="fh-header__mobile-submenu-title">Fenster &amp; Sicherheit</div>
-            <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-          </div>
-          <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/fenster-sicherheit/" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Fenster &amp; Sicherheit</a></li>
-            <li><a href="/fenster-sicherheit/fensterbankschrauben/" class="fh-header__mobile-submenu-link">Fensterbankschrauben</a></li>
-            <li><a href="/fenster-sicherheit/fenstergriffe/" class="fh-header__mobile-submenu-link">Fenstergriffe</a></li>
-            <li><a href="/fensterleisten/" class="fh-header__mobile-submenu-link">Fensterleisten</a></li>
-            <li><a href="/fenster-sicherheit/fenstermontageschrauben/" class="fh-header__mobile-submenu-link">Fenstermontageschrauben</a></li>
-            <li><a href="/fenster-sicherheit/fenstersicherungen/" class="fh-header__mobile-submenu-link">Fenstersicherungen</a></li>
-            <li><a href="/fenster-sicherheit/keile/" class="fh-header__mobile-submenu-link">Keile</a></li>
-            <li><a href="/fenster-sicherheit/kompriband-fugendichtband/" class="fh-header__mobile-submenu-link">Kompriband / Fugendichtband</a></li>
-            <li><a href="/schloesser/vorhaengeschloesser/" class="fh-header__mobile-submenu-link">Vorhängeschlösser</a></li>
-          </ul>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-beschlaege" data-fh-mobile-panel="beschlaege" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                <span>Zurück</span>
-              </button>
-              <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
-                <span class="fh-header__sr-only">Navigation schließen</span>
-                <svg aria-hidden="true" class="fh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div class="fh-header__mobile-submenu-title">Beschläge</div>
-            <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-          </div>
-          <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/griffe-und-tuerdruecker" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Beschläge</a></li>
-            <li><a href="/klemmen/glasklemmen" class="fh-header__mobile-submenu-link">Glasklemmen</a></li>
-            <li><button type="button" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--has-children" data-fh-mobile-submenu-target="griffe-und-tuerdruecker" aria-controls="fh-mobile-submenu-griffe-und-tuerdruecker" aria-expanded="false">Griffe &amp; Türdrücker</button></li>
-            <li><a href="/rosetten" class="fh-header__mobile-submenu-link">Rosetten</a></li>
-            <li><a href="/schilder" class="fh-header__mobile-submenu-link">Schilder</a></li>
-          </ul>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-gartenbau" data-fh-mobile-panel="gartenbau" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                <span>Zurück</span>
-              </button>
-              <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
-                <span class="fh-header__sr-only">Navigation schließen</span>
-                <svg aria-hidden="true" class="fh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div class="fh-header__mobile-submenu-title">Gartenbau</div>
-            <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-          </div>
-          <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/terrasse" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Gartenbau-Produkte</a></li>
-            <li><a href="/terrasse/holzschutzband" class="fh-header__mobile-submenu-link">Holzschutzband</a></li>
-            <li><button type="button" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--has-children" data-fh-mobile-submenu-target="sichtschutz" aria-controls="fh-mobile-submenu-sichtschutz" aria-expanded="false">Sichtschutz</button></li>
-            <li><button type="button" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--has-children" data-fh-mobile-submenu-target="terrassenschrauben" aria-controls="fh-mobile-submenu-terrassenschrauben" aria-expanded="false">Terrassenschrauben</button></li>
-            <li><a href="/terrasse/terrassen-unterkonstruktion" class="fh-header__mobile-submenu-link">Terrassen-Unterkonstruktion</a></li>
-          </ul>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-bauchemie" data-fh-mobile-panel="bauchemie" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                <span>Zurück</span>
-              </button>
-              <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
-                <span class="fh-header__sr-only">Navigation schließen</span>
-                <svg aria-hidden="true" class="fh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div class="fh-header__mobile-submenu-title">Bauchemie</div>
-            <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-          </div>
-          <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/chemische-befestigung" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Bauchemie</a></li>
-            <li><a href="/chemische-befestigung/kleben-dichten" class="fh-header__mobile-submenu-link">Kleben &amp; Dichten</a></li>
-            <li><a href="/chemische-befestigung/schaum" class="fh-header__mobile-submenu-link">Schaum</a></li>
-            <li><a href="/chemische-befestigung/zubehoer-chemische-befestigung" class="fh-header__mobile-submenu-link">Zubehör Chemische Befestigung</a></li>
-          </ul>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-zubehoer" data-fh-mobile-panel="zubehoer" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                <span>Zurück</span>
-              </button>
-              <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
-                <span class="fh-header__sr-only">Navigation schließen</span>
-                <svg aria-hidden="true" class="fh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div class="fh-header__mobile-submenu-title">Zubehör</div>
-            <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-          </div>
-          <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/zubehoer" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Zubehör-Produkte</a></li>
-            <li><a href="/zubehoer/arbeitshandschuhe/" class="fh-header__mobile-submenu-link">Arbeitshandschuhe</a></li>
-            <li><a href="/zubehoer/betriebsmittel/" class="fh-header__mobile-submenu-link">Betriebsmittel</a></li>
-            <li><a href="/zubehoer/bit" class="fh-header__mobile-submenu-link">Bits</a></li>
-            <li><button type="button" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--has-children" data-fh-mobile-submenu-target="bohrer" aria-controls="fh-mobile-submenu-bohrer" aria-expanded="false">Bohrer</button></li>
-            <li><a href="/zubehoer/dampfbremsen" class="fh-header__mobile-submenu-link">Dampfbremsen</a></li>
-            <li><a href="/zubehoer/klebebaender" class="fh-header__mobile-submenu-link">Klebebänder</a></li>
-            <li><a href="/zubehoer/malerzubehoer/" class="fh-header__mobile-submenu-link">Malerzubehör</a></li>
-            <li><a href="/zubehoer/schleifen-trennen/" class="fh-header__mobile-submenu-link">Schleifen-Trennen</a></li>
-            <li><a href="/zubehoer/werkzeug" class="fh-header__mobile-submenu-link">Werkzeug</a></li>
-          </ul>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-bohrer" data-fh-mobile-panel="bohrer" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zur Kategorie Bohrer">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                <span>Zurück</span>
-              </button>
-              <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
-                <span class="fh-header__sr-only">Navigation schließen</span>
-                <svg aria-hidden="true" class="fh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div class="fh-header__mobile-submenu-title">Bohrer</div>
-            <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-          </div>
-          <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/zubehoer/bohrer/" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Bohrer</a></li>
-            <li><a href="https://www.fenster-hammer.de/zubehoer/bohrer/holzbohrer/" class="fh-header__mobile-submenu-link">Holzbohrer</a></li>
-            <li><a href="https://www.fenster-hammer.de/zubehoer/bohrer/metallbohrer/" class="fh-header__mobile-submenu-link">Metallbohrer</a></li>
-            <li><a href="https://www.fenster-hammer.de/zubehoer/bohrer/sds-plus-hammerbohrer/" class="fh-header__mobile-submenu-link">SDS-Plus Hammerbohrer</a></li>
-          </ul>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-marken" data-fh-mobile-panel="marken" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                <span>Zurück</span>
-              </button>
-              <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
-                <span class="fh-header__sr-only">Navigation schließen</span>
-                <svg aria-hidden="true" class="fh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div class="fh-header__mobile-submenu-title">Marken</div>
-            <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-          </div>
-          <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/top-marken" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Marken</a></li>
-            <li><a href="/top-marken/abus" class="fh-header__mobile-submenu-link">ABUS</a></li>
-            <li><a href="/top-marken/bever" class="fh-header__mobile-submenu-link">BEVER</a></li>
-            <li><a href="/top-marken/eff-eff" class="fh-header__mobile-submenu-link">EFF EFF</a></li>
-            <li><a href="/top-marken/index" class="fh-header__mobile-submenu-link">INDEX</a></li>
-            <li><a href="/top-marken/intra-tec" class="fh-header__mobile-submenu-link">INTRA-TEC</a></li>
-            <li><a href="/top-marken/pica" class="fh-header__mobile-submenu-link">Pica</a></li>
-            <li><a href="/top-marken/screwrebel" class="fh-header__mobile-submenu-link">SCREWREBEL</a></li>
-            <li><a href="/top-marken/wera" class="fh-header__mobile-submenu-link">WERA</a></li>
-          </ul>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-aktionen" data-fh-mobile-panel="aktionen" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zum Hauptmenü">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                <span>Zurück</span>
-              </button>
-              <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
-                <span class="fh-header__sr-only">Navigation schließen</span>
-                <svg aria-hidden="true" class="fh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div class="fh-header__mobile-submenu-title">Aktionen</div>
-            <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-          </div>
-          <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/aktion" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Aktionen</a></li>
-            <li><a href="/aktion" class="fh-header__mobile-submenu-link">Aktuelle Aktionen</a></li>
-          </ul>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-griffe-und-tuerdruecker" data-fh-mobile-panel="griffe-und-tuerdruecker" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zur Kategorie Griffe &amp; Türdrücker">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                <span>Zurück</span>
-              </button>
-              <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
-                <span class="fh-header__sr-only">Navigation schließen</span>
-                <svg aria-hidden="true" class="fh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div class="fh-header__mobile-submenu-title">Griffe &amp; Türdrücker</div>
-            <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-          </div>
-          <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/griffe-und-tuerdruecker" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Griffe &amp; Türdrücker</a></li>
-            <li><a href="/griffe-und-tuerdruecker/tuerdruecker/" class="fh-header__mobile-submenu-link">Türdrücker</a></li>
-            <li><a href="/griffe-und-tuerdruecker/tuergarnituren/" class="fh-header__mobile-submenu-link">Türgarnituren</a></li>
-            <li><a href="/griffe-und-tuerdruecker/tuerknaeufe/" class="fh-header__mobile-submenu-link">Türknäufe</a></li>
-          </ul>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-sichtschutz" data-fh-mobile-panel="sichtschutz" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zur Kategorie Sichtschutz">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                <span>Zurück</span>
-              </button>
-              <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
-                <span class="fh-header__sr-only">Navigation schließen</span>
-                <svg aria-hidden="true" class="fh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div class="fh-header__mobile-submenu-title">Sichtschutz</div>
-            <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-          </div>
-          <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/sichtschutz" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Sichtschutz-Produkte</a></li>
-            <li><a href="/sichtschutz?facets=230" class="fh-header__mobile-submenu-link">Fleece</a></li>
-            <li><a href="/sichtschutz?facets=228" class="fh-header__mobile-submenu-link">PP (Polypropylen)</a></li>
-            <li><a href="/sichtschutz?facets=229" class="fh-header__mobile-submenu-link">PVC (Polyvinylchlorid)</a></li>
-          </ul>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-terrassenschrauben" data-fh-mobile-panel="terrassenschrauben" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zur Kategorie Terrassenschrauben">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                <span>Zurück</span>
-              </button>
-              <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
-                <span class="fh-header__sr-only">Navigation schließen</span>
-                <svg aria-hidden="true" class="fh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div class="fh-header__mobile-submenu-title">Terrassenschrauben</div>
-            <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-          </div>
-          <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/terrasse" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Terrassenschrauben</a></li>
-            <li><a href="/terrasse/a2-edelstahlschrauben" class="fh-header__mobile-submenu-link">A2 Edelstahlschrauben</a></li>
-            <li><a href="/terrasse/a4-edelstahlschrauben" class="fh-header__mobile-submenu-link">A4 Edelstahlschrauben</a></li>
-            <li><a href="/terrasse/c1-edelstahlschrauben" class="fh-header__mobile-submenu-link">C1 Edelstahlschrauben</a></li>
-          </ul>
-        </div>
-        <div class="fh-header__mobile-view fh-header__mobile-submenu-panel" id="fh-mobile-submenu-garagentorschloesser" data-fh-mobile-panel="garagentorschloesser" aria-hidden="true">
-          <div class="fh-header__mobile-submenu-header">
-            <div class="fh-header__mobile-submenu-bar">
-              <button type="button" class="fh-header__mobile-submenu-back" data-fh-mobile-submenu-back aria-label="Zurück zur Kategorie Garagentorschlösser">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="fh-header__mobile-submenu-back-icon">
-                  <polyline points="15 18 9 12 15 6"></polyline>
-                </svg>
-                <span>Zurück</span>
-              </button>
-              <button type="button" class="fh-header__mobile-close" data-fh-mobile-menu-close aria-label="Menü schließen">
-                <span class="fh-header__sr-only">Navigation schließen</span>
-                <svg aria-hidden="true" class="fh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <line x1="18" y1="6" x2="6" y2="18"></line>
-                  <line x1="6" y1="6" x2="18" y2="18"></line>
-                </svg>
-              </button>
-            </div>
-            <div class="fh-header__mobile-submenu-title">Garagentorschlösser</div>
-            <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-          </div>
-          <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/schloesser/garagentorschloesser" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Garagentorschlösser</a></li>
-            <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-oben-schliessend" class="fh-header__mobile-submenu-link">mit Riegel nach oben</a></li>
-            <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-unten-schliessend" class="fh-header__mobile-submenu-link">mit Riegel nach unten</a></li>
-            <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-seitlich-schliessend" class="fh-header__mobile-submenu-link">mit seitlich ausfahrenden Riegeln</a></li>
-            <li><a href="/schloesser/garagentorschloesser/garagentorschloesser-oben-und-unten-schliessend" class="fh-header__mobile-submenu-link">oben und unten schließend</a></li>
-            <li><a href="/schloesser/garagentorschloesser/griffe-und-schilder/" class="fh-header__mobile-submenu-link">Zubehör für Gargentorschlösser</a></li>
-          </ul>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove mobile submenu triggers from FH header top-level links so taps navigate directly
- drop mobile submenu panel markup to eliminate mobile-only submenu styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c189902ac8331957f9f377da0e39b)