### PR TITLE
Hide primary burger on mid viewports

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2827,7 +2827,7 @@ body,
   }
 
   .fh-header__burger {
-    display: inline-flex;
+    display: none;
   }
 
   .fh-header__basket-link {


### PR DESCRIPTION
## Summary
- hide the primary header burger button on mid-size viewports to avoid duplicate menu toggles
- keep mobile visibility unchanged while leaving other header behavior intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9533ba888331a554934c4d55a6cb)