### PR TITLE
Add reverse navigation arrow to FH mid-size header

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2865,7 +2865,7 @@ body,
 
   .fh-header__nav-surface {
     display: grid;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto 1fr auto auto;
     padding: 10px 12px;
     gap: 12px;
     align-items: center;
@@ -2901,19 +2901,32 @@ body,
     display: none;
   }
 
+  .fh-header__nav-scroll::before,
   .fh-header__nav-scroll::after {
     content: '';
     position: absolute;
     top: 0;
-    right: 0;
     width: 50px;
     height: 100%;
-    background: linear-gradient(90deg, rgba(49, 165, 240, 0) 0%, rgba(49, 165, 240, 0.85) 100%);
     pointer-events: none;
     display: none;
   }
 
-  .fh-header__nav-scroll.is-scrollable::after {
+  .fh-header__nav-scroll::before {
+    left: 0;
+    background: linear-gradient(90deg, rgba(49, 165, 240, 0.85) 0%, rgba(49, 165, 240, 0) 100%);
+  }
+
+  .fh-header__nav-scroll::after {
+    right: 0;
+    background: linear-gradient(90deg, rgba(49, 165, 240, 0) 0%, rgba(49, 165, 240, 0.85) 100%);
+  }
+
+  .fh-header__nav-scroll.is-scrollable-left::before {
+    display: block;
+  }
+
+  .fh-header__nav-scroll.is-scrollable-right::after {
     display: block;
   }
 
@@ -2977,7 +2990,15 @@ body,
   .fh-header__nav-scroll-icon {
     font-size: 18px;
     line-height: 1;
+    transform: none;
+  }
+
+  .fh-header__nav-scroll-button--next .fh-header__nav-scroll-icon {
     transform: translateX(1px);
+  }
+
+  .fh-header__nav-scroll-button--prev .fh-header__nav-scroll-icon {
+    transform: rotate(180deg) translateX(1px);
   }
 
   .fh-header__mobile-close {

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -265,6 +265,9 @@
                 <line x1="3" y1="18" x2="21" y2="18"></line>
               </svg>
             </button>
+            <button type="button" class="fh-header__nav-scroll-button fh-header__nav-scroll-button--prev" data-fh-nav-scroll-prev aria-label="Vorherige Kategorien anzeigen">
+              <span aria-hidden="true" class="fh-header__nav-scroll-icon">➜</span>
+            </button>
             <div class="fh-header__nav-scroll" data-fh-nav-scroll>
               <ul class="nav fh-header__nav-list">
             <li class="nav-item dropdown fh-header__nav-item">
@@ -562,7 +565,7 @@
             </li>
               </ul>
             </div>
-            <button type="button" class="fh-header__nav-scroll-button" data-fh-nav-scroll-next aria-label="Weitere Kategorien anzeigen">
+            <button type="button" class="fh-header__nav-scroll-button fh-header__nav-scroll-button--next" data-fh-nav-scroll-next aria-label="Weitere Kategorien anzeigen">
               <span aria-hidden="true" class="fh-header__nav-scroll-icon">➜</span>
             </button>
           </div>

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -1081,21 +1081,32 @@ fhOnReady(function () {
 // Section: FH desktop navigation scroll helper (768px–1599.98px)
 fhOnReady(function () {
   const navScroll = document.querySelector('[data-fh-nav-scroll]');
-  const navScrollButton = document.querySelector('[data-fh-nav-scroll-next]');
+  const navScrollNextButton = document.querySelector('[data-fh-nav-scroll-next]');
+  const navScrollPrevButton = document.querySelector('[data-fh-nav-scroll-prev]');
 
-  if (!navScroll || !navScrollButton) return;
+  if (!navScroll || !navScrollNextButton || !navScrollPrevButton) return;
 
   const mediaQuery = window.matchMedia('(max-width: 1599.98px) and (min-width: 768px)');
 
   function setScrollableState() {
     const hasOverflow = mediaQuery.matches && (navScroll.scrollWidth - navScroll.clientWidth > 2);
+    const atStart = navScroll.scrollLeft <= 1;
+    const atEnd = navScroll.scrollLeft >= (navScroll.scrollWidth - navScroll.clientWidth - 1);
 
     navScroll.classList.toggle('is-scrollable', hasOverflow);
+    navScroll.classList.toggle('is-scrollable-left', hasOverflow && !atStart);
+    navScroll.classList.toggle('is-scrollable-right', hasOverflow && !atEnd);
 
-    if (hasOverflow) {
-      navScrollButton.removeAttribute('disabled');
+    if (hasOverflow && !atEnd) {
+      navScrollNextButton.removeAttribute('disabled');
     } else {
-      navScrollButton.setAttribute('disabled', 'disabled');
+      navScrollNextButton.setAttribute('disabled', 'disabled');
+    }
+
+    if (hasOverflow && !atStart) {
+      navScrollPrevButton.removeAttribute('disabled');
+    } else {
+      navScrollPrevButton.setAttribute('disabled', 'disabled');
     }
 
     if (!mediaQuery.matches) {
@@ -1136,11 +1147,40 @@ fhOnReady(function () {
     }
   }
 
+  function scrollToPreviousItem() {
+    if (!mediaQuery.matches) return;
+
+    const items = getNavItems();
+
+    if (items.length === 0) return;
+
+    const viewportLeft = navScroll.scrollLeft;
+    let previousItem = null;
+
+    for (let index = items.length - 1; index >= 0; index -= 1) {
+      const item = items[index];
+
+      if (item.offsetLeft < viewportLeft - 2) {
+        previousItem = item;
+        break;
+      }
+    }
+
+    const targetLeft = previousItem ? previousItem.offsetLeft : 0;
+
+    if (typeof navScroll.scrollTo === 'function') {
+      navScroll.scrollTo({ left: targetLeft, behavior: 'smooth' });
+    } else {
+      navScroll.scrollLeft = targetLeft;
+    }
+  }
+
   function handleMediaChange() {
     setScrollableState();
   }
 
-  navScrollButton.addEventListener('click', scrollToNextItem);
+  navScrollNextButton.addEventListener('click', scrollToNextItem);
+  navScrollPrevButton.addEventListener('click', scrollToPreviousItem);
 
   navScroll.addEventListener('scroll', function () {
     if (!mediaQuery.matches) return;


### PR DESCRIPTION
## Summary
- add a left-facing navigation scroll button to the FH header for mid-size viewports
- adjust styles to accommodate dual nav scroll buttons with directional gradients
- update desktop nav scroll helper logic to support forward and backward scrolling with proper button states

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c98b9c7ec8331857dec162a0db52e)