### PR TITLE
Remove FH nav scroll gradient and align scroll arrows

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2903,31 +2903,7 @@ body,
 
   .fh-header__nav-scroll::before,
   .fh-header__nav-scroll::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    width: 50px;
-    height: 100%;
-    pointer-events: none;
-    display: none;
-  }
-
-  .fh-header__nav-scroll::before {
-    left: 0;
-    background: linear-gradient(90deg, rgba(49, 165, 240, 0.85) 0%, rgba(49, 165, 240, 0) 100%);
-  }
-
-  .fh-header__nav-scroll::after {
-    right: 0;
-    background: linear-gradient(90deg, rgba(49, 165, 240, 0) 0%, rgba(49, 165, 240, 0.85) 100%);
-  }
-
-  .fh-header__nav-scroll.is-scrollable-left::before {
-    display: block;
-  }
-
-  .fh-header__nav-scroll.is-scrollable-right::after {
-    display: block;
+    content: none;
   }
 
   .fh-header__nav-list {

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -265,9 +265,6 @@
                 <line x1="3" y1="18" x2="21" y2="18"></line>
               </svg>
             </button>
-            <button type="button" class="fh-header__nav-scroll-button fh-header__nav-scroll-button--prev" data-fh-nav-scroll-prev aria-label="Vorherige Kategorien anzeigen">
-              <span aria-hidden="true" class="fh-header__nav-scroll-icon">➜</span>
-            </button>
             <div class="fh-header__nav-scroll" data-fh-nav-scroll>
               <ul class="nav fh-header__nav-list">
             <li class="nav-item dropdown fh-header__nav-item">
@@ -565,6 +562,9 @@
             </li>
               </ul>
             </div>
+            <button type="button" class="fh-header__nav-scroll-button fh-header__nav-scroll-button--prev" data-fh-nav-scroll-prev aria-label="Vorherige Kategorien anzeigen">
+              <span aria-hidden="true" class="fh-header__nav-scroll-icon">➜</span>
+            </button>
             <button type="button" class="fh-header__nav-scroll-button fh-header__nav-scroll-button--next" data-fh-nav-scroll-next aria-label="Weitere Kategorien anzeigen">
               <span aria-hidden="true" class="fh-header__nav-scroll-icon">➜</span>
             </button>


### PR DESCRIPTION
## Summary
- remove the fading gradient overlays from the FH navigation scroll container
- position the previous navigation scroll arrow next to the next arrow on the right side

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9f01bf7c83319359e0d8ece0fc0e)