### PR TITLE
Ensure FH header shadow persists on mobile

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3119,7 +3119,8 @@ body.fh-mobile-menu-open {
   }
 
   #page-header::before {
-    display: none;
+    display: block;
+    box-shadow: var(--fh-shadow-elevation-soft);
   }
 }
 /* End Section: Page Header Background */


### PR DESCRIPTION
## Summary
- keep the page header pseudo-element visible on smaller viewports
- retain the header drop shadow across midsize and mobile layouts

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cadb0842883319a712aeacb7c4e69)