### PR TITLE
Adjust FH header midsize button styling and add white background utility

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -34,6 +34,10 @@
   border-radius: 3px !important;
 }
 
+.bg-w100 {
+  background-color: #ffffff !important;
+}
+
 /* End Section: Border radius utility classes */
 
 body,
@@ -2929,6 +2933,7 @@ body,
 
   .fh-header__nav-burger {
     display: inline-flex;
+    box-shadow: none;
   }
 
   .fh-header__nav-scroll-button {
@@ -2941,7 +2946,6 @@ body,
     border: 1px solid #d9d9d9;
     background-color: #ffffff;
     color: #0f172a;
-    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
     flex-shrink: 0;
     flex: 0 0 auto;
   }


### PR DESCRIPTION
## Summary
- add a bg-w100 utility class that enforces a white background color
- remove box shadows from FH header navigation buttons in the midsize viewport

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb0a0fe74833199e8981e8ad2a528)