### PR TITLE
Remove mid-size header nav shadow

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2874,7 +2874,7 @@ body,
     gap: 12px;
     align-items: center;
     justify-content: flex-start;
-    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
+    box-shadow: none;
     width: 100%;
     box-sizing: border-box;
   }


### PR DESCRIPTION
## Summary
- remove nav surface box shadow on medium viewports to eliminate the visible border in FH header

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cb2d90f108331991b7cfd5ad43f04)