### PR TITLE
Fix FH header padding on mid viewports

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2782,9 +2782,10 @@ body,
 @media (max-width: 1599.98px) and (min-width: 768px) {
   .fh-header {
     position: relative;
-    width: 100vw;
-    max-width: 100vw;
-    padding: 0 20px;
+    width: 100%;
+    max-width: 100%;
+    padding-left: 20px;
+    padding-right: 20px;
     box-sizing: border-box;
   }
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2861,11 +2861,10 @@ body,
   }
 
   .fh-header__nav-inner {
-    width: 100vw;
-    margin-left: calc(50% - 50vw);
-    margin-right: calc(50% - 50vw);
+    width: 100%;
+    margin: 0;
     padding: 0 20px;
-    max-width: none;
+    max-width: 100%;
   }
 
   .fh-header__nav-surface {


### PR DESCRIPTION
## Summary
- adjust FH header layout for 768-1600px viewports to use 100% width with equal padding
- ensure mid-size header spacing stays consistent instead of shifting right

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d419935fc8331b99d4d695a070d69)