### PR TITLE
Adjust FH nav scroll padding

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2893,7 +2893,7 @@ body,
     flex: 1 1 auto;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
-    padding-right: 72px;
+    padding-right: 0;
     scroll-behavior: smooth;
     scrollbar-width: none;
     scroll-snap-type: x proximity;


### PR DESCRIPTION
## Summary
- remove extra right padding from the scrollable FH header nav container on tablet/desktop widths so items align flush

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d47c435f48331b11e9be74e072bfb)