### PR TITLE
Align SH header layout with FH mid-range updates

### DIFF
--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -1147,9 +1147,15 @@
           <ul class="sh-header__mobile-submenu-list">
             <li><a href="/aktion/" class="sh-header__mobile-submenu-link sh-header__mobile-submenu-link--all">Alle Aktionen</a></li>
             <li><a href="/aktion/" class="sh-header__mobile-submenu-link">Aktuelle Aktionen</a></li>
-          </ul>
+              </ul>
+            </div>
+            <button type="button" class="sh-header__nav-scroll-button sh-header__nav-scroll-button--prev" data-sh-nav-scroll-prev aria-label="Vorherige Kategorien anzeigen">
+              <span aria-hidden="true" class="sh-header__nav-scroll-icon">➜</span>
+            </button>
+            <button type="button" class="sh-header__nav-scroll-button sh-header__nav-scroll-button--next" data-sh-nav-scroll-next aria-label="Weitere Kategorien anzeigen">
+              <span aria-hidden="true" class="sh-header__nav-scroll-icon">➜</span>
+            </button>
+          </div>
         </div>
-      </div>
-    </div>
   </nav>
 </div>

--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -1149,12 +1149,6 @@
             <li><a href="/aktion/" class="sh-header__mobile-submenu-link">Aktuelle Aktionen</a></li>
               </ul>
             </div>
-            <button type="button" class="sh-header__nav-scroll-button sh-header__nav-scroll-button--prev" data-sh-nav-scroll-prev aria-label="Vorherige Kategorien anzeigen">
-              <span aria-hidden="true" class="sh-header__nav-scroll-icon">➜</span>
-            </button>
-            <button type="button" class="sh-header__nav-scroll-button sh-header__nav-scroll-button--next" data-sh-nav-scroll-next aria-label="Weitere Kategorien anzeigen">
-              <span aria-hidden="true" class="sh-header__nav-scroll-icon">➜</span>
-            </button>
           </div>
         </div>
   </nav>

--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -250,7 +250,23 @@
           </div>
           <div class="sh-header__nav-surface" data-sh-desktop-nav-surface>
             <span class="sh-header__nav-highlight" aria-hidden="true"></span>
-            <ul class="nav sh-header__nav-list">
+            <button
+              type="button"
+              class="sh-header__nav-burger"
+              data-sh-mobile-menu-toggle
+              aria-controls="sh-mobile-menu"
+              aria-expanded="false"
+              aria-label="Menü"
+            >
+              <span class="sh-header__sr-only">Navigation öffnen</span>
+              <svg aria-hidden="true" class="sh-header__burger-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="3" y1="6" x2="21" y2="6"></line>
+                <line x1="3" y1="12" x2="21" y2="12"></line>
+                <line x1="3" y1="18" x2="21" y2="18"></line>
+              </svg>
+            </button>
+            <div class="sh-header__nav-scroll" data-sh-nav-scroll>
+              <ul class="nav sh-header__nav-list">
             <li class="nav-item dropdown sh-header__nav-item">
               <a class="nav-link sh-header__nav-link" href="/anwendungsgebiet/" data-sh-mobile-submenu-target="anwendungsgebiet" aria-controls="sh-mobile-submenu-anwendungsgebiet" aria-expanded="false">
                 <span class="sh-header__nav-icon" aria-hidden="true">
@@ -589,7 +605,14 @@
                 </div>
               </div>
             </li>
-            </ul>
+              </ul>
+            </div>
+            <button type="button" class="sh-header__nav-scroll-button sh-header__nav-scroll-button--prev" data-sh-nav-scroll-prev aria-label="Vorherige Kategorien anzeigen">
+              <span aria-hidden="true" class="sh-header__nav-scroll-icon">➜</span>
+            </button>
+            <button type="button" class="sh-header__nav-scroll-button sh-header__nav-scroll-button--next" data-sh-nav-scroll-next aria-label="Weitere Kategorien anzeigen">
+              <span aria-hidden="true" class="sh-header__nav-scroll-icon">➜</span>
+            </button>
           </div>
           </div>
           <div class="sh-header__mobile-view sh-header__mobile-submenu-panel" id="sh-mobile-submenu-anwendungsgebiet" data-sh-mobile-panel="anwendungsgebiet" aria-hidden="true">

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -1078,6 +1078,131 @@ shOnReady(function () {
 });
 // End Section: sh desktop header scroll behaviour
 
+// Section: sh desktop navigation scroll helper (768px–1599.98px)
+shOnReady(function () {
+  const navScroll = document.querySelector('[data-sh-nav-scroll]');
+  const navScrollNextButton = document.querySelector('[data-sh-nav-scroll-next]');
+  const navScrollPrevButton = document.querySelector('[data-sh-nav-scroll-prev]');
+
+  if (!navScroll || !navScrollNextButton || !navScrollPrevButton) return;
+
+  const mediaQuery = window.matchMedia('(max-width: 1599.98px) and (min-width: 768px)');
+
+  function setScrollableState() {
+    const hasOverflow = mediaQuery.matches && navScroll.scrollWidth - navScroll.clientWidth > 2;
+    const atStart = navScroll.scrollLeft <= 1;
+    const atEnd = navScroll.scrollLeft >= navScroll.scrollWidth - navScroll.clientWidth - 1;
+
+    navScroll.classList.toggle('is-scrollable', hasOverflow);
+    navScroll.classList.toggle('is-scrollable-left', hasOverflow && !atStart);
+    navScroll.classList.toggle('is-scrollable-right', hasOverflow && !atEnd);
+
+    if (hasOverflow && !atEnd) {
+      navScrollNextButton.removeAttribute('disabled');
+    } else {
+      navScrollNextButton.setAttribute('disabled', 'disabled');
+    }
+
+    if (hasOverflow && !atStart) {
+      navScrollPrevButton.removeAttribute('disabled');
+    } else {
+      navScrollPrevButton.setAttribute('disabled', 'disabled');
+    }
+
+    if (!mediaQuery.matches) {
+      navScroll.scrollLeft = 0;
+    }
+  }
+
+  function getNavItems() {
+    return Array.prototype.slice.call(navScroll.querySelectorAll('.sh-header__nav-item'));
+  }
+
+  function scrollToNextItem() {
+    if (!mediaQuery.matches) return;
+
+    const items = getNavItems();
+
+    if (items.length === 0) return;
+
+    const viewportLeft = navScroll.scrollLeft;
+    let nextItem = null;
+
+    for (let index = 0; index < items.length; index += 1) {
+      const item = items[index];
+
+      if (item.offsetLeft > viewportLeft + 2) {
+        nextItem = item;
+        break;
+      }
+    }
+
+    const targetLeft = nextItem ? nextItem.offsetLeft : navScroll.scrollWidth - navScroll.clientWidth;
+
+    if (typeof navScroll.scrollTo === 'function') {
+      navScroll.scrollTo({ left: targetLeft, behavior: 'smooth' });
+    } else {
+      navScroll.scrollLeft = targetLeft;
+    }
+  }
+
+  function scrollToPreviousItem() {
+    if (!mediaQuery.matches) return;
+
+    const items = getNavItems();
+
+    if (items.length === 0) return;
+
+    const viewportLeft = navScroll.scrollLeft;
+    let previousItem = null;
+
+    for (let index = items.length - 1; index >= 0; index -= 1) {
+      const item = items[index];
+
+      if (item.offsetLeft < viewportLeft - 2) {
+        previousItem = item;
+        break;
+      }
+    }
+
+    const targetLeft = previousItem ? previousItem.offsetLeft : 0;
+
+    if (typeof navScroll.scrollTo === 'function') {
+      navScroll.scrollTo({ left: targetLeft, behavior: 'smooth' });
+    } else {
+      navScroll.scrollLeft = targetLeft;
+    }
+  }
+
+  function handleMediaChange() {
+    setScrollableState();
+  }
+
+  navScrollNextButton.addEventListener('click', scrollToNextItem);
+  navScrollPrevButton.addEventListener('click', scrollToPreviousItem);
+
+  navScroll.addEventListener('scroll', function () {
+    if (!mediaQuery.matches) return;
+
+    window.requestAnimationFrame(setScrollableState);
+  });
+
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', handleMediaChange);
+  } else if (typeof mediaQuery.addListener === 'function') {
+    mediaQuery.addListener(handleMediaChange);
+  }
+
+  window.addEventListener('resize', setScrollableState);
+
+  if (typeof ResizeObserver === 'function') {
+    const scrollObserver = new ResizeObserver(setScrollableState);
+    scrollObserver.observe(navScroll);
+  }
+
+  setScrollableState();
+});
+
 // Section: sh mobile navigation toggle
 shOnReady(function () {
   const header = document.querySelector('[data-sh-header-root]');

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -2477,9 +2477,8 @@ body,
 
 @media (max-width: 1599.98px) {
   .sh-header {
-    width: min(1600px, 100vw);
+    width: min(1600px, 100%);
     max-width: none;
-    padding-right: 12px;
     box-sizing: border-box;
   }
 
@@ -2749,6 +2748,283 @@ body,
   }
 }
 
+@media (max-width: 1599.98px) and (min-width: 768px) {
+  .sh-header {
+    position: relative;
+    width: 100vw;
+    max-width: 100vw;
+    padding: 0 30px;
+    box-sizing: border-box;
+  }
+
+  .sh-header .container,
+  .sh-header__nav .container,
+  .sh-header__nav-inner,
+  #page-header,
+  #page-header > div {
+    width: 100%;
+    max-width: 100%;
+    padding: 0;
+    margin: 0;
+    box-sizing: border-box;
+  }
+
+  .sh-header__main {
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas: "logo search actions";
+    column-gap: 16px;
+    row-gap: 0;
+    padding: 18px 0 16px;
+    width: 100%;
+    max-width: none;
+    margin: 0 auto;
+    align-items: center;
+  }
+
+  .sh-header__search-area {
+    grid-area: search;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+  }
+
+  .sh-header__search-form {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .sh-header__actions {
+    column-gap: 16px;
+    align-self: center;
+  }
+
+  .sh-header__burger {
+    display: none;
+  }
+
+  .sh-header__basket-link {
+    width: auto;
+    padding: 10px 18px;
+    gap: 12px;
+    min-width: 0;
+  }
+
+  .sh-header__basket-total {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .sh-header__nav {
+    position: relative;
+    height: auto;
+    transform: none;
+    overflow: visible;
+    padding-top: 0;
+    width: 100%;
+    max-width: none;
+    margin: 0 auto;
+    display: block;
+    z-index: 1;
+  }
+
+  .sh-header__nav-inner {
+    width: 100vw;
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
+    padding: 0 30px;
+    max-width: none;
+  }
+
+  .sh-header__nav-surface {
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    padding: 10px 0;
+    gap: 12px;
+    align-items: center;
+    justify-content: flex-start;
+    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .sh-header__nav-surface::before {
+    display: none;
+  }
+
+  .sh-header__nav-highlight {
+    display: none;
+  }
+
+  .sh-header__nav-scroll {
+    display: flex;
+    align-items: center;
+    flex: 1 1 auto;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-right: 0;
+    scroll-behavior: smooth;
+    scrollbar-width: none;
+    scroll-snap-type: x proximity;
+    position: relative;
+  }
+
+  .sh-header__nav-scroll::-webkit-scrollbar {
+    display: none;
+  }
+
+  .sh-header__nav-scroll::before,
+  .sh-header__nav-scroll::after {
+    content: none;
+  }
+
+  .sh-header__nav-list {
+    flex-direction: row;
+    gap: 12px;
+    justify-content: flex-start;
+    width: auto;
+    min-width: max-content;
+    padding: 0;
+  }
+
+  .sh-header__nav-item {
+    flex: none;
+    text-align: center;
+    scroll-snap-align: start;
+  }
+
+  .sh-header__nav-link {
+    font-size: 15px;
+    border-bottom: none;
+    white-space: nowrap;
+    padding: 14px 12px;
+  }
+
+  .sh-header__nav-burger {
+    display: inline-flex;
+    box-shadow: none;
+  }
+
+  .sh-header__nav-scroll-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    border: 1px solid #d9d9d9;
+    background-color: #ffffff;
+    color: #0f172a;
+    flex-shrink: 0;
+    flex: 0 0 auto;
+  }
+
+  .basket-open .sh-header__nav {
+    z-index: 0;
+  }
+
+  .sh-header__nav-scroll-button:hover,
+  .sh-header__nav-scroll-button:focus-visible {
+    color: var(--sh-color-primary-red);
+    border-color: #cbd5e1;
+    outline: none;
+  }
+
+  .sh-header__nav-scroll-button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  .sh-header__nav-scroll-icon {
+    font-size: 18px;
+    line-height: 1;
+    transform: none;
+  }
+
+  .sh-header__nav-scroll-button--next .sh-header__nav-scroll-icon {
+    transform: translateX(1px);
+  }
+
+  .sh-header__nav-scroll-button--prev .sh-header__nav-scroll-icon {
+    transform: rotate(180deg) translateX(1px);
+  }
+
+  .sh-header__mobile-close {
+    display: none;
+  }
+
+  body.sh-mobile-menu-open .sh-header__mobile-close {
+    display: inline-flex;
+  }
+
+  body.sh-mobile-menu-open .sh-header__nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    transform: translateX(0);
+    z-index: 5000;
+    margin: 0;
+    overflow: hidden;
+    padding-top: 0;
+  }
+
+  body.sh-mobile-menu-open .sh-header__nav-inner {
+    margin: 0;
+    padding: 24px 24px 48px;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  body.sh-mobile-menu-open .sh-header__nav-surface {
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    align-items: stretch;
+  }
+
+  body.sh-mobile-menu-open .sh-header__nav-scroll {
+    padding: 0;
+    flex: 1 1 auto;
+    width: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+    scroll-snap-type: none;
+  }
+
+  body.sh-mobile-menu-open .sh-header__nav-list {
+    flex-direction: column;
+    gap: 0;
+    width: 100%;
+    min-width: 0;
+    padding: 0;
+  }
+
+  body.sh-mobile-menu-open .sh-header__nav-link {
+    width: 100%;
+    justify-content: flex-start;
+    white-space: normal;
+    border-bottom: 1px solid #e5e7eb;
+    padding: 18px 0;
+  }
+
+  body.sh-mobile-menu-open .sh-header__nav-item:last-child .sh-header__nav-link {
+    border-bottom: none;
+  }
+
+  body.sh-mobile-menu-open .sh-header__nav-burger,
+  body.sh-mobile-menu-open .sh-header__nav-scroll-button {
+    display: none;
+  }
+}
+
 body.sh-mobile-menu-open {
   overflow: hidden;
 }
@@ -2815,7 +3091,8 @@ body.sh-mobile-menu-open {
   }
 
   #page-header::before {
-    display: none;
+    display: block;
+    box-shadow: var(--sh-shadow-elevation-soft);
   }
 }
 /* End Section: Page Header Background */

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1818,6 +1818,15 @@ body,
     background-color 0.22s ease;
 }
 
+.sh-header__nav-scroll {
+  position: relative;
+  width: 100%;
+}
+
+.sh-header__nav-scroll-button {
+  display: none;
+}
+
 .sh-header__nav-highlight::after {
   content: none;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -2304,7 +2304,6 @@ body,
   align-items: stretch;
   gap: 12px;
   margin-bottom: 0;
-  padding: 16px 0;
   background: linear-gradient(180deg, #ffffff 85%, rgba(255, 255, 255, 0.92));
   border-bottom: 1px solid #e5e7eb;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1706,6 +1706,33 @@ body,
   box-shadow: none;
 }
 
+.sh-header__nav-burger {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid #d9d9d9;
+  background-color: #ffffff;
+  color: #0f172a;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.sh-header__nav-burger .sh-header__burger-icon {
+  width: 22px;
+  height: 22px;
+}
+
+.sh-header__nav-burger:hover,
+.sh-header__nav-burger:focus-visible {
+  color: var(--sh-color-primary-red);
+  border-color: #cbd5e1;
+  outline: none;
+}
+
 .sh-header__nav-surface::before {
   content: '';
   position: absolute;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -34,6 +34,10 @@
   border-radius: 3px !important;
 }
 
+.bg-w100 {
+  background-color: #ffffff !important;
+}
+
 /* End Section: Border radius utility classes */
 
 body,


### PR DESCRIPTION
## Summary
- adjust SH header mid-range layout sizing to match FH changes
- add 768-1600px navigation layout rules including scroll buttons and search alignment
- ensure page header background overlay remains visible on mid-width viewports

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d5b292e1083318129981e805d1b9c)