### PR TITLE
Add Nylon Dübel submenu entry for SH header

### DIFF
--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -286,6 +286,7 @@
                         <a href="/anwendungsgebiet/beton-metallbau/gewindestangen/" class="sh-header__dropdown-sublink">Gewindestangen</a>
                         <a href="/anwendungsgebiet/beton-metallbau/metrische-schrauben/" class="sh-header__dropdown-sublink">Metrische Schrauben</a>
                         <a href="/anwendungsgebiet/beton-metallbau/muttern/" class="sh-header__dropdown-sublink">Muttern</a>
+                        <a href="/duebel/nylon-duebel" class="sh-header__dropdown-sublink">Nylon Dübel</a>
                         <a href="/anwendungsgebiet/beton-metallbau/scheiben-ringe/" class="sh-header__dropdown-sublink">Scheiben &amp; Ringe</a>
                       </div>
                     </div>
@@ -705,6 +706,7 @@
             <li><a href="/anwendungsgebiet/beton-metallbau/gewindestangen/" class="sh-header__mobile-submenu-link">Gewindestangen</a></li>
             <li><a href="/anwendungsgebiet/beton-metallbau/metrische-schrauben/" class="sh-header__mobile-submenu-link">Metrische Schrauben</a></li>
             <li><a href="/anwendungsgebiet/beton-metallbau/muttern/" class="sh-header__mobile-submenu-link">Muttern</a></li>
+            <li><a href="/duebel/nylon-duebel" class="sh-header__mobile-submenu-link">Nylon Dübel</a></li>
             <li><a href="/anwendungsgebiet/beton-metallbau/scheiben-ringe/" class="sh-header__mobile-submenu-link">Scheiben &amp; Ringe</a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- add Nylon Dübel link under Beton- & Metallbau in the SH header dropdown and mobile menu

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da8cd2a248331994abc4c9dd59bc3)