### PR TITLE
Animate shipping countdown icon on hover

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3590,3 +3590,37 @@ button[data-testing="quantity-btn-decrease"] {
       min-height: 0;
 }
 /* End Section: Account Page Edits */
+
+/* Section: Shipping countdown icon hover animation */
+#cutoff-countdown .cutoff-countdown__icon-wrapper {
+  position: relative;
+  width: 2.6em;
+  height: 2.6em;
+  overflow: hidden;
+}
+
+#cutoff-countdown .cutoff-countdown__icon {
+  display: block;
+  height: 100%;
+  width: auto;
+}
+
+#cutoff-countdown:hover .cutoff-countdown__icon {
+  animation: cutoff-countdown-slide 1.2s ease-in-out infinite;
+}
+
+@keyframes cutoff-countdown-slide {
+  0% {
+    transform: translateX(0);
+  }
+  45% {
+    transform: translateX(-120%);
+  }
+  55% {
+    transform: translateX(120%);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+/* End Section: Shipping countdown icon hover animation */

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -2910,7 +2910,7 @@ fhOnReady(function () {
     return t + '</span>';
   }
   var iconUrl = "https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/shipping_9288277.svg";
-  var iconHtml = '<img src="' + iconUrl + '" alt="" style="height:2.6em;width:auto;vertical-align:middle;display:block;">';
+  var iconHtml = '<img class="cutoff-countdown__icon" src="' + iconUrl + '" alt="" style="height:2.6em;width:auto;vertical-align:middle;display:block;">';
   function waitForCountdownDiv(){
     var elem = document.getElementById('cutoff-countdown');
     if (!elem) return setTimeout(waitForCountdownDiv, 300);
@@ -2986,8 +2986,8 @@ fhOnReady(function () {
     var textHtml = '<div style="display:flex;flex-direction:column;justify-content:center;line-height:1.45;max-width:640px;">' +
      '<span>Bestellen Sie innerhalb ' + zeitHtml + ', damit Ihre Ware ' + dateLabel + ' unser Lager verlässt.   </span>' +
   '</div>';
-    elem.innerHTML = 
-      '<div style="display:flex;align-items:center;">' +
+    elem.innerHTML =
+      '<div class="cutoff-countdown__icon-wrapper" style="display:flex;align-items:center;overflow:hidden;">' +
         iconHtml +
       '</div>' +
       textHtml;

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -2887,7 +2887,7 @@ shOnReady(function () {
     return t + '</span>';
   }
   var iconUrl = "https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/shipping_9288277.svg";
-  var iconHtml = '<img src="' + iconUrl + '" alt="" style="height:2.6em;width:auto;vertical-align:middle;display:block;">';
+  var iconHtml = '<img class="cutoff-countdown__icon" src="' + iconUrl + '" alt="" style="height:2.6em;width:auto;vertical-align:middle;display:block;">';
   function waitForCountdownDiv(){
     var elem = document.getElementById('cutoff-countdown');
     if (!elem) return setTimeout(waitForCountdownDiv, 300);
@@ -2963,8 +2963,8 @@ shOnReady(function () {
     var textHtml = '<div style="display:flex;flex-direction:column;justify-content:center;line-height:1.45;max-width:640px;">' +
      '<span>Bestellen Sie innerhalb ' + zeitHtml + ', damit Ihre Ware ' + dateLabel + ' unser Lager verlässt.   </span>' +
   '</div>';
-    elem.innerHTML = 
-      '<div style="display:flex;align-items:center;">' +
+    elem.innerHTML =
+      '<div class="cutoff-countdown__icon-wrapper" style="display:flex;align-items:center;overflow:hidden;">' +
         iconHtml +
       '</div>' +
       textHtml;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3599,3 +3599,37 @@ button[data-testing="quantity-btn-decrease"] {
       min-height: 0;
 }
 /* End Section: Account Page Edits */
+
+/* Section: Shipping countdown icon hover animation */
+#cutoff-countdown .cutoff-countdown__icon-wrapper {
+  position: relative;
+  width: 2.6em;
+  height: 2.6em;
+  overflow: hidden;
+}
+
+#cutoff-countdown .cutoff-countdown__icon {
+  display: block;
+  height: 100%;
+  width: auto;
+}
+
+#cutoff-countdown:hover .cutoff-countdown__icon {
+  animation: cutoff-countdown-slide 1.2s ease-in-out infinite;
+}
+
+@keyframes cutoff-countdown-slide {
+  0% {
+    transform: translateX(0);
+  }
+  45% {
+    transform: translateX(-120%);
+  }
+  55% {
+    transform: translateX(120%);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+/* End Section: Shipping countdown icon hover animation */


### PR DESCRIPTION
## Summary
- wrap the shipping countdown icon markup with reusable classes for styling
- add hover animation so the countdown package icon slides out left and re-enters from the right on FH and SH

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e97450db083318117b7a5efb68f06)