### PR TITLE
Add Fensterbau navigation category to SH header

### DIFF
--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -291,6 +291,16 @@
                       </div>
                     </div>
                     <div class="sh-header__dropdown-group">
+                      <a href="/anwendungsgebiet/fensterbau/" class="sh-header__dropdown-link sh-header__dropdown-link--parent">Fensterbau</a>
+                      <div class="sh-header__dropdown-sublist">
+                        <a href="/anwendungsgebiet/fensterbau/fensterbankschrauben/" class="sh-header__dropdown-sublink">Fensterbankschrauben</a>
+                        <a href="/anwendungsgebiet/fensterbau/fensterrahmenschrauben/" class="sh-header__dropdown-sublink">Fensterrahmenschrauben</a>
+                        <a href="/anwendungsgebiet/fensterbau/montagekeile/" class="sh-header__dropdown-sublink">Montagekeile</a>
+                        <a href="/anwendungsgebiet/fensterbau/verglasungsklotz/" class="sh-header__dropdown-sublink">Verglasungsklotz</a>
+                        <a href="/anwendungsgebiet/fensterbau/kompriband/" class="sh-header__dropdown-sublink">Kompriband</a>
+                      </div>
+                    </div>
+                    <div class="sh-header__dropdown-group">
                       <a href="/anwendungsgebiet/dach-fassadenbau/" class="sh-header__dropdown-link sh-header__dropdown-link--parent">Dach- &amp; Fassadenbau</a>
                       <div class="sh-header__dropdown-sublist">
                         <a href="/anwendungsgebiet/dach-fassadenbau/bohrschrauben/" class="sh-header__dropdown-sublink">Bohrschrauben</a>
@@ -640,6 +650,7 @@
             <li><a href="/anwendungsgebiet/" class="sh-header__mobile-submenu-link sh-header__mobile-submenu-link--all">Alle Anwendungsgebiete</a></li>
             <li><button type="button" class="sh-header__mobile-submenu-link sh-header__mobile-submenu-link--has-children" data-sh-mobile-submenu-target="anwendungsgebiet-beton-metallbau" aria-controls="sh-mobile-submenu-anwendungsgebiet-beton-metallbau" aria-expanded="false">Beton- &amp; Metallbau</button></li>
             <li><button type="button" class="sh-header__mobile-submenu-link sh-header__mobile-submenu-link--has-children" data-sh-mobile-submenu-target="anwendungsgebiet-dach-fassadenbau" aria-controls="sh-mobile-submenu-anwendungsgebiet-dach-fassadenbau" aria-expanded="false">Dach- &amp; Fassadenbau</button></li>
+            <li><button type="button" class="sh-header__mobile-submenu-link sh-header__mobile-submenu-link--has-children" data-sh-mobile-submenu-target="anwendungsgebiet-fensterbau" aria-controls="sh-mobile-submenu-anwendungsgebiet-fensterbau" aria-expanded="false">Fensterbau</button></li>
             <li><button type="button" class="sh-header__mobile-submenu-link sh-header__mobile-submenu-link--has-children" data-sh-mobile-submenu-target="anwendungsgebiet-gartenbau" aria-controls="sh-mobile-submenu-anwendungsgebiet-gartenbau" aria-expanded="false">Gartenbau</button></li>
             <li><button type="button" class="sh-header__mobile-submenu-link sh-header__mobile-submenu-link--has-children" data-sh-mobile-submenu-target="anwendungsgebiet-holzbau" aria-controls="sh-mobile-submenu-anwendungsgebiet-holzbau" aria-expanded="false">Holzbau</button></li>
             <li><button type="button" class="sh-header__mobile-submenu-link sh-header__mobile-submenu-link--has-children" data-sh-mobile-submenu-target="anwendungsgebiet-photovoltaik-solar" aria-controls="sh-mobile-submenu-anwendungsgebiet-photovoltaik-solar" aria-expanded="false">Photovoltaik / Solar</button></li>
@@ -738,6 +749,35 @@
             <li><a href="/anwendungsgebiet/dach-fassadenbau/fassadenschrauben/" class="sh-header__mobile-submenu-link">Fassadenschrauben</a></li>
             <li><a href="/anwendungsgebiet/dach-fassadenbau/klebeschaum-wdvs/" class="sh-header__mobile-submenu-link">Klebeschaum / WDVS</a></li>
             <li><a href="/anwendungsgebiet/dach-fassadenbau/zubehoer/" class="sh-header__mobile-submenu-link">Zubehör</a></li>
+          </ul>
+        </div>
+        <div class="sh-header__mobile-view sh-header__mobile-submenu-panel" id="sh-mobile-submenu-anwendungsgebiet-fensterbau" data-sh-mobile-panel="anwendungsgebiet-fensterbau" aria-hidden="true">
+          <div class="sh-header__mobile-submenu-header">
+            <div class="sh-header__mobile-submenu-bar">
+              <button type="button" class="sh-header__mobile-submenu-back" data-sh-mobile-submenu-back aria-label="Zurück zur Kategorie Fensterbau">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="sh-header__mobile-submenu-back-icon">
+                  <polyline points="15 18 9 12 15 6"></polyline>
+                </svg>
+                <span>Zurück</span>
+              </button>
+              <button type="button" class="sh-header__mobile-close" data-sh-mobile-menu-close aria-label="Menü schließen">
+                <span class="sh-header__sr-only">Navigation schließen</span>
+                <svg aria-hidden="true" class="sh-header__mobile-close-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18"></line>
+                  <line x1="6" y1="6" x2="18" y2="18"></line>
+                </svg>
+              </button>
+            </div>
+            <div class="sh-header__mobile-submenu-title">Fensterbau</div>
+            <nav class="sh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-sh-mobile-breadcrumb></nav>
+          </div>
+          <ul class="sh-header__mobile-submenu-list">
+            <li><a href="/anwendungsgebiet/fensterbau/" class="sh-header__mobile-submenu-link sh-header__mobile-submenu-link--all">Alle Fensterbau-Produkte</a></li>
+            <li><a href="/anwendungsgebiet/fensterbau/fensterbankschrauben/" class="sh-header__mobile-submenu-link">Fensterbankschrauben</a></li>
+            <li><a href="/anwendungsgebiet/fensterbau/fensterrahmenschrauben/" class="sh-header__mobile-submenu-link">Fensterrahmenschrauben</a></li>
+            <li><a href="/anwendungsgebiet/fensterbau/montagekeile/" class="sh-header__mobile-submenu-link">Montagekeile</a></li>
+            <li><a href="/anwendungsgebiet/fensterbau/verglasungsklotz/" class="sh-header__mobile-submenu-link">Verglasungsklotz</a></li>
+            <li><a href="/anwendungsgebiet/fensterbau/kompriband/" class="sh-header__mobile-submenu-link">Kompriband</a></li>
           </ul>
         </div>
         <div class="sh-header__mobile-view sh-header__mobile-submenu-panel" id="sh-mobile-submenu-anwendungsgebiet-holzbau" data-sh-mobile-panel="anwendungsgebiet-holzbau" aria-hidden="true">


### PR DESCRIPTION
## Summary
- add a new "Fensterbau" entry to the Anwendungsgebiet dropdown with its subcategories
- extend the mobile navigation with a matching Fensterbau submenu and links

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930217ef8b88331b720dd60040e5ae1)