### PR TITLE
Add Paqato track and trace styling

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3590,3 +3590,19 @@ button[data-testing="quantity-btn-decrease"] {
       min-height: 0;
 }
 /* End Section: Account Page Edits */
+
+/* Section: Paqato Track & Trace Styling */
+.pqt-parcial-service.pqt-block > :first-child {
+  display: none;
+}
+
+.pqt-wrapper .pqt-select .pqt-form-select {
+    padding: 0 10px;
+    border-radius: 6px;
+    margin-right: -10px;
+}
+
+#pqt-tracking {
+    margin-top: 30px
+}
+/* End Section: Paqato Track & Trace Styling */

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3602,6 +3602,10 @@ button[data-testing="quantity-btn-decrease"] {
     margin-right: -10px;
 }
 
+.pqt-sidebar-footer-widget {
+  width: auto !important;
+}
+
 #pqt-tracking {
     margin-top: 30px
 }

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3597,7 +3597,7 @@ button[data-testing="quantity-btn-decrease"] {
 }
 
 .pqt-wrapper .pqt-select .pqt-form-select {
-    padding: 0 10px;
+    padding: 0 10px !important;
     border-radius: 6px;
     margin-right: -10px;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3606,7 +3606,7 @@ button[data-testing="quantity-btn-decrease"] {
 }
 
 .pqt-wrapper .pqt-select .pqt-form-select {
-    padding: 0 10px;
+    padding: 0 10px !important;
     border-radius: 6px;
     margin-right: -10px;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3599,3 +3599,19 @@ button[data-testing="quantity-btn-decrease"] {
       min-height: 0;
 }
 /* End Section: Account Page Edits */
+
+/* Section: Paqato Track & Trace Styling */
+.pqt-parcial-service.pqt-block > :first-child {
+  display: none;
+}
+
+.pqt-wrapper .pqt-select .pqt-form-select {
+    padding: 0 10px;
+    border-radius: 6px;
+    margin-right: -10px;
+}
+
+#pqt-tracking {
+    margin-top: 30px
+}
+/* End Section: Paqato Track & Trace Styling */

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3611,6 +3611,10 @@ button[data-testing="quantity-btn-decrease"] {
     margin-right: -10px;
 }
 
+.pqt-sidebar-footer-widget {
+  width: auto !important;
+}
+
 #pqt-tracking {
     margin-top: 30px
 }


### PR DESCRIPTION
## Summary
- add Paqato track & trace styling for FH to hide the default block heading, restyle the select, and space the tracking container
- mirror the Paqato track & trace styling updates in the SH stylesheet

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936a63f76c88331af6c5895e4ce0bba)