### PR TITLE
Add border radius to Paqato buttons

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3602,6 +3602,10 @@ button[data-testing="quantity-btn-decrease"] {
     margin-right: -10px;
 }
 
+.pqt-wrapper .pqt-select .pqt-btn {
+    border-radius: 6px;
+}
+
 .pqt-sidebar-footer-widget {
   width: auto !important;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3611,6 +3611,10 @@ button[data-testing="quantity-btn-decrease"] {
     margin-right: -10px;
 }
 
+.pqt-wrapper .pqt-select .pqt-btn {
+    border-radius: 6px;
+}
+
 .pqt-sidebar-footer-widget {
   width: auto !important;
 }


### PR DESCRIPTION
## Summary
- add border radius styling to Paqato select buttons in both FH and SH themes
- align Paqato button appearance with existing form select rounding

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693986b6d7a4833189a71d950f9ff643)