### PR TITLE
Fix full viewport container utility to override body constraints

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -376,17 +376,19 @@ body,
 
 /* Section: Layout Utilities */
 
-/* Utility class so body widgets (e.g. Doofinder recommendations) can span the full viewport width. */
+/* Utility class so body widgets (e.g. Doofinder recommendations) can span the full viewport width.
+   Add !important to break out of the body container and override Ceres' container widths. */
 .fh-full-viewport-container,
 .doofinder-product-recommendation-fw {
   position: relative;
   box-sizing: border-box;
-  width: 100vw;
-  max-width: none;
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
-  padding-left: 0;
-  padding-right: 0;
+  display: block;
+  width: 100vw !important;
+  max-width: 100vw !important;
+  margin-left: calc(50% - 50vw) !important;
+  margin-right: calc(50% - 50vw) !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
 }
 
 #vue-app > div.footer.container-max.d-print-none {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -383,17 +383,19 @@ body,
 
 /* Section: Layout Utilities */
 
-/* Utility class so body widgets (e.g. Doofinder recommendations) can span the full viewport width. */
+/* Utility class so body widgets (e.g. Doofinder recommendations) can span the full viewport width.
+   Add !important to break out of the body container and override Ceres' container widths. */
 .sh-full-viewport-container,
 .doofinder-product-recommendation-fw {
   position: relative;
   box-sizing: border-box;
-  width: 100vw;
-  max-width: none;
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
-  padding-left: 0;
-  padding-right: 0;
+  display: block;
+  width: 100vw !important;
+  max-width: 100vw !important;
+  margin-left: calc(50% - 50vw) !important;
+  margin-right: calc(50% - 50vw) !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
 }
 
 #vue-app > div.footer.container-max.d-print-none {


### PR DESCRIPTION
## Summary
- strengthen the full viewport utility classes for FH and SH so they break out of the body container constraints
- keep full-width recommendations and other widgets by forcing viewport-based widths and spacing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694286e9d0d8833184a706fd33eacfde)