### PR TITLE
Update footer year to 2026 and fix FH "Alle Beschläge" links

### DIFF
--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -134,7 +134,7 @@
         </div>
       </div>
       <div class="fh-footer__copyright">
-        © 2014–2025 FENSTER-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
+        © 2014–2026 FENSTER-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
       </div>
     </div>
   </div>

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -135,7 +135,7 @@
         </div>
       </div>
       <div class="sh-footer__copyright">
-        © 2014–2025 SCHRAUBEN-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
+        © 2014–2026 SCHRAUBEN-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
       </div>
     </div>
   </div>

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -351,7 +351,7 @@
                   </div>
                   <div class="fh-header__dropdown-footer">
                     <hr class="fh-header__dropdown-divider">
-                    <a href="/griffe-und-tuerdruecker" class="fh-header__dropdown-footer-link">Alle Beschläge sehen</a>
+                    <a href="/beschlaege" class="fh-header__dropdown-footer-link">Alle Beschläge sehen</a>
                   </div>
                 </div>
               </div>
@@ -669,7 +669,7 @@
             <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
           </div>
           <ul class="fh-header__mobile-submenu-list">
-            <li><a href="/griffe-und-tuerdruecker" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Beschläge</a></li>
+            <li><a href="/beschlaege" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--all">Alle Beschläge</a></li>
             <li><a href="/klemmen/glasklemmen" class="fh-header__mobile-submenu-link">Glasklemmen</a></li>
             <li><button type="button" class="fh-header__mobile-submenu-link fh-header__mobile-submenu-link--has-children" data-fh-mobile-submenu-target="griffe-und-tuerdruecker" aria-controls="fh-mobile-submenu-griffe-und-tuerdruecker" aria-expanded="false">Griffe &amp; Türdrücker</button></li>
             <li><a href="/rosetten" class="fh-header__mobile-submenu-link">Rosetten</a></li>


### PR DESCRIPTION
### Motivation
- Bring the displayed copyright year in both shop footers up to date (2026).
- Fix an incorrect FH header link so the “Alle Beschläge” entry points to the intended category path `/beschlaege`.
- Keep header/footer behavior consistent between desktop and mobile menus for the FH shop.

### Description
- Updated the copyright line in `Footer/FH-Footer.html` to `© 2014–2026 FENSTER-HAMMER | INTRA-TEC GmbH.`.
- Updated the copyright line in `Footer/SH-Footer.html` to `© 2014–2026 SCHRAUBEN-HAMMER | INTRA-TEC GmbH.`.
- Fixed the FH header links in `Header/FH-Header.html` so both the desktop dropdown footer link and the mobile “Alle Beschläge” link now point to `/beschlaege`.
- Changes are static HTML edits only and do not introduce new JS or CSS.

### Testing
- No automated tests were run because these are static HTML content updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f51a6f92c83318ee494af7892b525)