### PR TITLE
FH: add 'Cookie Einstellungen' footer link and JS trigger

### DIFF
--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -49,6 +49,7 @@
           <li><a href="/impressum">Impressum</a></li>
           <li><a href="/agb">Allgemeine Geschäftsbedingungen</a></li>
           <li><a href="/privacy-policy">Datenschutzerklärung</a></li>
+          <li><a href="#" data-fh-cookie-settings>Cookie Einstellungen</a></li>
           <li><a href="/barrierefreiheitserklaerung">Barrierefreiheitserklärung</a></li>
           <li><a href="/cancellation-rights">Widerrufsbelehrung</a></li>
         </ul>

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -8,6 +8,23 @@ function fhOnReady(callback) {
   callback();
 }
 
+// Section: FH cookie settings link
+fhOnReady(function () {
+  function handleCookieSettingsClick(event) {
+    const trigger = event.target.closest('[data-fh-cookie-settings]');
+
+    if (!trigger) return;
+
+    event.preventDefault();
+
+    if (window.__ucCmp && typeof window.__ucCmp.showSecondLayer === 'function') {
+      window.__ucCmp.showSecondLayer();
+    }
+  }
+
+  document.addEventListener('click', handleCookieSettingsClick);
+});
+
 // Section: FH account menu toggle behaviour
 fhOnReady(function () {
   function resolveGreeting(defaultGreeting) {


### PR DESCRIPTION
### Motivation
- Provide a localized "Cookie Einstellungen" link in the FH footer directly below the Datenschutzerklärung so users can open the CMP privacy panel.  
- The CMP exposes `__ucCmp.showSecondLayer()` on the page and the footer link should trigger that without inline JavaScript.  
- PlentyLTS shopbuilder blocks inline JS, so the behavior must be implemented via the theme's custom JS.  
- Keep the change isolated to FH so SH is not affected.

### Description
- Added a new footer entry in `Footer/FH-Footer.html`: `<li><a href="#" data-fh-cookie-settings>Cookie Einstellungen</a></li>`.  
- Implemented a delegated click handler in `JavaScript im Head/FH - JS im Head.js` that runs inside `fhOnReady`, listens for clicks on `[data-fh-cookie-settings]`, calls `event.preventDefault()` and invokes `window.__ucCmp.showSecondLayer()` if available.  
- The solution avoids inline JS and uses an attribute selector to preserve the existing footer styling and semantics.  
- Only FH files were modified; SH files remain unchanged.

### Testing
- No automated tests were executed for this change.  
- JavaScript changes are wrapped with `fhOnReady` to ensure they run after DOM readiness.  
- Code was lint/checked visually in the repository environment (no formal test run).  
- Manual verification is recommended in a staging environment to confirm the CMP opens its second layer when the link is clicked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960cdbb89b083318ef6c8212e6e8dca)