### PR TITLE
Add lazy loading and size attributes to footer images (FH & SH)

### DIFF
--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -10,7 +10,7 @@
       <section class="fh-footer__column fh-footer__column--info">
         <h5 class="fh-footer__heading">
           <span class="fh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/info_14574710.svg" alt="Infos">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/info_14574710.svg" alt="Infos" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Infos
         </h5>
@@ -26,7 +26,7 @@
       <section class="fh-footer__column fh-footer__column--community">
         <h5 class="fh-footer__heading">
           <span class="fh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/workgroup_12886873.svg" alt="Community">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/workgroup_12886873.svg" alt="Community" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Community
         </h5>
@@ -41,7 +41,7 @@
       <section class="fh-footer__column fh-footer__column--legal">
         <h5 class="fh-footer__heading">
           <span class="fh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/balance_2970715.svg" alt="Rechtliches">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/balance_2970715.svg" alt="Rechtliches" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Rechtliches
         </h5>
@@ -57,7 +57,7 @@
       <section class="fh-footer__column fh-footer__column--benefits">
         <h5 class="fh-footer__heading">
           <span class="fh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/raise_1054356.svg" alt="Vorteile">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/raise_1054356.svg" alt="Vorteile" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Vorteile
         </h5>
@@ -75,17 +75,17 @@
       <div class="fh-footer__brand-section">
         <div class="fh-footer__brands">
         <a href="https://schrauben-hammer.de" target="_blank" rel="noopener noreferrer">
-       <img class="fh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="Schraubenhammer">
+       <img class="fh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="Schraubenhammer" loading="lazy" decoding="async" width="335" height="150">
       </a>
        <a href="https://fenster-hammer.de" target="_blank" rel="noopener noreferrer">
-        <img class="fh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer">
+        <img class="fh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer" loading="lazy" decoding="async" width="300" height="300">
        </a>
       </div>
         <div class="fh-footer__legal">
           <p>
             Onlineshops der INTRA-TEC GmbH
             <a class="fh-footer__social-link" href="https://www.linkedin.com/company/intra-tec-gmbh/" aria-label="LinkedIn">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/LinkedIn.png" alt="LinkedIn">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/LinkedIn.png" alt="LinkedIn" loading="lazy" decoding="async" width="16" height="16">
             </a>
           </p>
           <p>
@@ -106,29 +106,29 @@
         <div class="fh-footer__logistics-section">
           <h6 class="fh-footer__sub-heading">Unsere Zahlungsarten</h6>
           <div class="fh-footer__badge-grid fh-footer__badge-grid--payments" aria-label="Akzeptierte Zahlungsarten">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Apple_Pay.png" alt="Apple Pay">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/PayPal.png" alt="PayPal">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Klarna.png" alt="Klarna">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/American_Express.png" alt="American Express">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Mastercard.png" alt="Mastercard">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Visa.png" alt="Visa">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Billie_Rechnungskauf_fuer_Fimrnen.png" alt="Billie Rechnungskauf für Firmen">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Vorkasse.png" alt="Vorkasse">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Apple_Pay.png" alt="Apple Pay" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/PayPal.png" alt="PayPal" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Klarna.png" alt="Klarna" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/American_Express.png" alt="American Express" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Mastercard.png" alt="Mastercard" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Visa.png" alt="Visa" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Billie_Rechnungskauf_fuer_Fimrnen.png" alt="Billie Rechnungskauf für Firmen" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Vorkasse.png" alt="Vorkasse" loading="lazy" decoding="async">
           </div>
         </div>
         <div class="fh-footer__logistics-section">
           <h6 class="fh-footer__sub-heading">Unsere Versandarten</h6>
           <div class="fh-footer__badge-grid fh-footer__badge-grid--shipping" aria-label="Versanddienstleister">
             <div class="fh-footer__shipping-item">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand" loading="lazy" decoding="async">
               <span class="fh-footer__shipping-label">Standardversand</span>
             </div>
             <div class="fh-footer__shipping-item">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express" loading="lazy" decoding="async">
               <span class="fh-footer__shipping-label">Expressversand</span>
             </div>
             <div class="fh-footer__shipping-item">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer" loading="lazy" decoding="async">
               <span class="fh-footer__shipping-label">Selbstabholung</span>
             </div>
           </div>

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -11,7 +11,7 @@
       <section class="sh-footer__column sh-footer__column--info">
         <h5 class="sh-footer__heading">
           <span class="sh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/info_14574710.svg" alt="Infos">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/info_14574710.svg" alt="Infos" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Infos
         </h5>
@@ -27,7 +27,7 @@
       <section class="sh-footer__column sh-footer__column--community">
         <h5 class="sh-footer__heading">
           <span class="sh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/workgroup_12886873.svg" alt="Community">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/workgroup_12886873.svg" alt="Community" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Community
         </h5>
@@ -42,7 +42,7 @@
       <section class="sh-footer__column sh-footer__column--legal">
         <h5 class="sh-footer__heading">
           <span class="sh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/balance_2970715.svg" alt="Rechtliches">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/balance_2970715.svg" alt="Rechtliches" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Rechtliches
         </h5>
@@ -57,7 +57,7 @@
       <section class="sh-footer__column sh-footer__column--benefits">
         <h5 class="sh-footer__heading">
           <span class="sh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/raise_1054356.svg" alt="Vorteile">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/raise_1054356.svg" alt="Vorteile" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Vorteile
         </h5>
@@ -75,17 +75,17 @@
       <div class="sh-footer__brand-section">
         <div class="sh-footer__brands">
         <a href="https://schrauben-hammer.de" target="_blank" rel="noopener noreferrer">
-       <img class="sh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="Schraubenhammer">
+       <img class="sh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="Schraubenhammer" loading="lazy" decoding="async" width="335" height="150">
       </a>
        <a href="https://fenster-hammer.de" target="_blank" rel="noopener noreferrer">
-        <img class="fh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer">
+        <img class="fh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer" loading="lazy" decoding="async" width="300" height="300">
        </a>
       </div>
         <div class="sh-footer__legal">
           <p>
             Onlineshops der INTRA-TEC GmbH
             <a class="sh-footer__social-link" href="https://www.linkedin.com/company/intra-tec-gmbh/" aria-label="LinkedIn">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/LinkedIn.png" alt="LinkedIn">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/LinkedIn.png" alt="LinkedIn" loading="lazy" decoding="async" width="16" height="16">
             </a>
           </p>
           <p>
@@ -106,29 +106,29 @@
         <div class="sh-footer__logistics-section">
           <h6 class="sh-footer__sub-heading">Unsere Zahlungsarten</h6>
           <div class="sh-footer__badge-grid sh-footer__badge-grid--payments" aria-label="Akzeptierte Zahlungsarten">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Apple_Pay.png" alt="Apple Pay">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/PayPal.png" alt="PayPal">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Klarna.png" alt="Klarna">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/American_Express.png" alt="American Express">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Mastercard.png" alt="Mastercard">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Visa.png" alt="Visa">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Billie_Rechnungskauf_fuer_Fimrnen.png" alt="Billie Rechnungskauf für Firmen">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Vorkasse.png" alt="Vorkasse">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Apple_Pay.png" alt="Apple Pay" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/PayPal.png" alt="PayPal" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Klarna.png" alt="Klarna" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/American_Express.png" alt="American Express" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Mastercard.png" alt="Mastercard" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Visa.png" alt="Visa" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Billie_Rechnungskauf_fuer_Fimrnen.png" alt="Billie Rechnungskauf für Firmen" loading="lazy" decoding="async">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Vorkasse.png" alt="Vorkasse" loading="lazy" decoding="async">
           </div>
         </div>
         <div class="sh-footer__logistics-section">
           <h6 class="sh-footer__sub-heading">Unsere Versandarten</h6>
           <div class="sh-footer__badge-grid sh-footer__badge-grid--shipping" aria-label="Versanddienstleister">
             <div class="sh-footer__shipping-item">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand" loading="lazy" decoding="async">
               <span class="sh-footer__shipping-label">Standardversand</span>
             </div>
             <div class="sh-footer__shipping-item">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express" loading="lazy" decoding="async">
               <span class="sh-footer__shipping-label">Expressversand</span>
             </div>
             <div class="sh-footer__shipping-item">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer" loading="lazy" decoding="async">
               <span class="sh-footer__shipping-label">Selbstabholung</span>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Reduce initial load and improve performance by enabling native lazy loading and async decoding for footer images.
- Prevent layout shifts (CLS) by providing stable image dimensions where available and relying on existing CSS otherwise.
- Keep both shop footers (`FH` and `SH`) consistent and avoid introducing any new JavaScript listeners.

### Description
- Updated `Footer/FH-Footer.html` and `Footer/SH-Footer.html` to add `loading="lazy"` and `decoding="async"` to all `<img>` tags.
- Added explicit `width`/`height` attributes for key icons and logos (e.g. heading icons `18x18`, LinkedIn `16x16`, brand logos `335x150` and `300x300`) where appropriate.
- Left images that are sized via CSS (badges/grids) to the stylesheet and did not change JS or behavior.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69649a3e5d80833190537f4bc42cf662)