### PR TITLE
Add FH header nav category preview images

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1983,6 +1983,8 @@ body,
   display: block;
   width: 100%;
   height: auto;
+  border-radius: 6px;
+  transform-origin: center;
   transition: transform 0.25s ease;
 }
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1985,12 +1985,14 @@ body,
   height: auto;
   border-radius: 6px;
   transform-origin: center;
-  transition: transform 0.25s ease;
+  filter: brightness(0.96);
+  transition: transform 0.25s ease, filter 0.25s ease;
 }
 
 .fh-header__dropdown-preview-link:hover .fh-header__dropdown-preview-image,
 .fh-header__dropdown-preview-link:focus .fh-header__dropdown-preview-image {
   transform: scale(1.05);
+  filter: brightness(1.05);
 }
 
 .fh-header__dropdown-column > .fh-header__dropdown-group:first-child {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1967,6 +1967,30 @@ body,
   flex-direction: column;
 }
 
+.fh-header__dropdown-column--preview {
+  align-items: flex-start;
+}
+
+.fh-header__dropdown-preview-link {
+  display: block;
+  width: 100%;
+  max-width: 360px;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.fh-header__dropdown-preview-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  transition: transform 0.25s ease;
+}
+
+.fh-header__dropdown-preview-link:hover .fh-header__dropdown-preview-image,
+.fh-header__dropdown-preview-link:focus .fh-header__dropdown-preview-image {
+  transform: scale(1.05);
+}
+
 .fh-header__dropdown-column > .fh-header__dropdown-group:first-child {
   margin-top: 0;
 }

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -298,9 +298,9 @@
                     </div>
                     <a href="/schloesser/haustuerschloesser" class="fh-header__dropdown-link">Haustürschlösser</a>
                     <a href="/schloesser/kastenschloesser" class="fh-header__dropdown-link">Kastenschlösser</a>
-                    <a href="/schloesser/kaesten" class="fh-header__dropdown-link">Kästen</a>
                   </div>
                   <div class="fh-header__dropdown-column">
+                    <a href="/schloesser/kaesten" class="fh-header__dropdown-link">Kästen</a>
                     <a href="/schloesser/korridortuerschloesser" class="fh-header__dropdown-link">Korridortürschlösser</a>
                     <a href="/profilzylinder" class="fh-header__dropdown-link">Profilzylinder</a>
                     <a href="/schloesser/riegelschloesser/" class="fh-header__dropdown-link">Riegelschlösser</a>
@@ -496,9 +496,9 @@
                         <a href="https://www.fenster-hammer.de/zubehoer/bohrer/sds-plus-hammerbohrer/" class="fh-header__dropdown-sublink">SDS-Plus Hammerbohrer</a>
                       </div>
                     </div>
-                    <a href="/zubehoer/dampfbremsen" class="fh-header__dropdown-link">Dampfbremsen</a>
                   </div>
                   <div class="fh-header__dropdown-column">
+                    <a href="/zubehoer/dampfbremsen" class="fh-header__dropdown-link">Dampfbremsen</a>
                     <a href="/zubehoer/malerzubehoer/" class="fh-header__dropdown-link">Malerzubehör</a>
                     <a href="/zubehoer/schleifen-trennen/" class="fh-header__dropdown-link">Schleifen-Trennen</a>
                     <a href="/zubehoer/werkzeug" class="fh-header__dropdown-link">Werkzeug</a>

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -280,6 +280,10 @@
                     <a href="/schloesser/einsteckschloesser-fuer-metalltore" class="fh-header__dropdown-link">Einsteckschlösser</a>
                     <a href="/schloesser/elektrische-tueroeffner" class="fh-header__dropdown-link">Elektrische Türöffner</a>
                     <a href="/schloesser/fh-schloesser" class="fh-header__dropdown-link">FH-Schlösser</a>
+                    <a href="/schloesser/schliessbleche" class="fh-header__dropdown-link">Schließbleche</a>
+                    <a href="/schloesser/schiebetuerschloesser" class="fh-header__dropdown-link">Schiebtürschlösser</a>
+                    <a href="/schloesser/vorhaengeschloesser/" class="fh-header__dropdown-link">Vorhängeschlösser</a>
+                    <a href="/schloesser/wc-tuer-schloesser" class="fh-header__dropdown-link">WC-Tür-Schlösser</a>
                   </div>
                   <div class="fh-header__dropdown-column">
                     <div class="fh-header__dropdown-group">
@@ -293,23 +297,22 @@
                       </div>
                     </div>
                     <a href="/schloesser/haustuerschloesser" class="fh-header__dropdown-link">Haustürschlösser</a>
-                  </div>
-                  <div class="fh-header__dropdown-column">
                     <a href="/schloesser/kastenschloesser" class="fh-header__dropdown-link">Kastenschlösser</a>
                     <a href="/schloesser/kaesten" class="fh-header__dropdown-link">Kästen</a>
+                  </div>
+                  <div class="fh-header__dropdown-column">
                     <a href="/schloesser/korridortuerschloesser" class="fh-header__dropdown-link">Korridortürschlösser</a>
                     <a href="/profilzylinder" class="fh-header__dropdown-link">Profilzylinder</a>
                     <a href="/schloesser/riegelschloesser/" class="fh-header__dropdown-link">Riegelschlösser</a>
                     <a href="/schloesser/rohrrahmenschloesser" class="fh-header__dropdown-link">Rohrrahmenschlösser</a>
-                  </div>
-                  <div class="fh-header__dropdown-column">
-                    <a href="/schloesser/schliessbleche" class="fh-header__dropdown-link">Schließbleche</a>
-                    <a href="/schloesser/schiebetuerschloesser" class="fh-header__dropdown-link">Schiebtürschlösser</a>
-                    <a href="/schloesser/vorhaengeschloesser/" class="fh-header__dropdown-link">Vorhängeschlösser</a>
-                    <a href="/schloesser/wc-tuer-schloesser" class="fh-header__dropdown-link">WC-Tür-Schlösser</a>
                     <a href="/schloesser/wohnungstuerschloesser" class="fh-header__dropdown-link">Wohnungstürschlösser</a>
                     <a href="/schloesser/zimmertuerschloesser" class="fh-header__dropdown-link">Zimmertürschlösser</a>
                     <a href="/schloesser/zubehoer-fuer-schloss-und-tor" class="fh-header__dropdown-link">Zubehör für Schloss und Tor</a>
+                  </div>
+                  <div class="fh-header__dropdown-column fh-header__dropdown-column--preview">
+                    <a href="/schloesser" class="fh-header__dropdown-preview-link">
+                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Schloesser_Kategorie_Nav_Vorschau_360x120.jpg" alt="Schlösser Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
+                    </a>
                   </div>
                   <div class="fh-header__dropdown-footer">
                     <hr class="fh-header__dropdown-divider">
@@ -332,6 +335,7 @@
                 <div class="fh-header__dropdown-grid fh-header__dropdown-grid--four" style="grid-template-columns: repeat(4, minmax(0, 1fr));">
                   <div class="fh-header__dropdown-column">
                     <a href="/klemmen/glasklemmen" class="fh-header__dropdown-link">Glasklemmen</a>
+                    <a href="/rosetten" class="fh-header__dropdown-link">Rosetten</a>
                   </div>
                   <div class="fh-header__dropdown-column">
                     <div class="fh-header__dropdown-group">
@@ -344,10 +348,12 @@
                     </div>
                   </div>
                   <div class="fh-header__dropdown-column">
-                    <a href="/rosetten" class="fh-header__dropdown-link">Rosetten</a>
-                  </div>
-                  <div class="fh-header__dropdown-column">
                     <a href="/schilder" class="fh-header__dropdown-link">Schilder</a>
+                  </div>
+                  <div class="fh-header__dropdown-column fh-header__dropdown-column--preview">
+                    <a href="/beschlaege" class="fh-header__dropdown-preview-link">
+                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Beschlaege_Kategorie_Nav_Vorschau_360x120.jpg" alt="Beschläge Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
+                    </a>
                   </div>
                   <div class="fh-header__dropdown-footer">
                     <hr class="fh-header__dropdown-divider">
@@ -368,18 +374,21 @@
                   <div class="fh-header__dropdown-column">
                     <a href="/fenster-sicherheit/fensterbankschrauben/" class="fh-header__dropdown-link">Fensterbankschrauben</a>
                     <a href="/fenster-sicherheit/fenstergriffe/" class="fh-header__dropdown-link">Fenstergriffe</a>
-                  </div>
-                  <div class="fh-header__dropdown-column">
                     <a href="/fensterleisten/" class="fh-header__dropdown-link">Fensterleisten</a>
-                    <a href="/fenster-sicherheit/fenstermontageschrauben/" class="fh-header__dropdown-link">Fenstermontageschrauben</a>
                   </div>
                   <div class="fh-header__dropdown-column">
+                    <a href="/fenster-sicherheit/fenstermontageschrauben/" class="fh-header__dropdown-link">Fenstermontageschrauben</a>
                     <a href="/fenster-sicherheit/fenstersicherungen/" class="fh-header__dropdown-link">Fenstersicherungen</a>
                     <a href="/fenster-sicherheit/keile/" class="fh-header__dropdown-link">Keile</a>
                   </div>
                   <div class="fh-header__dropdown-column">
                     <a href="/fenster-sicherheit/kompriband-fugendichtband/" class="fh-header__dropdown-link">Kompriband / Fugendichtband</a>
                     <a href="/schloesser/vorhaengeschloesser/" class="fh-header__dropdown-link">Vorhängeschlösser</a>
+                  </div>
+                  <div class="fh-header__dropdown-column fh-header__dropdown-column--preview">
+                    <a href="/fenster-sicherheit/" class="fh-header__dropdown-preview-link">
+                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Fenster_und_Sicherheit_Kategorie_Nav_Vorschau_360x120.jpg" alt="Fenster &amp; Sicherheit Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
+                    </a>
                   </div>
                   <div class="fh-header__dropdown-footer">
                     <hr class="fh-header__dropdown-divider">
@@ -399,6 +408,7 @@
                 <div class="fh-header__dropdown-grid fh-header__dropdown-grid--four">
                   <div class="fh-header__dropdown-column">
                     <a href="/terrasse/holzschutzband" class="fh-header__dropdown-link">Holzschutzband</a>
+                    <a href="/terrasse/terrassen-unterkonstruktion" class="fh-header__dropdown-link">Terrassen-Unterkonstruktion</a>
                   </div>
                   <div class="fh-header__dropdown-column">
                     <div class="fh-header__dropdown-group">
@@ -420,8 +430,10 @@
                       </div>
                     </div>
                   </div>
-                  <div class="fh-header__dropdown-column">
-                    <a href="/terrasse/terrassen-unterkonstruktion" class="fh-header__dropdown-link">Terrassen-Unterkonstruktion</a>
+                  <div class="fh-header__dropdown-column fh-header__dropdown-column--preview">
+                    <a href="/terrasse" class="fh-header__dropdown-preview-link">
+                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Garten_Kategorie_Nav_Vorschau_360x120.jpg" alt="Gartenbau Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
+                    </a>
                   </div>
                   <div class="fh-header__dropdown-footer">
                     <hr class="fh-header__dropdown-divider">
@@ -448,6 +460,11 @@
                   <div class="fh-header__dropdown-column">
                     <a href="/chemische-befestigung/zubehoer-chemische-befestigung" class="fh-header__dropdown-link">Zubehör Chemische Befestigung</a>
                   </div>
+                  <div class="fh-header__dropdown-column fh-header__dropdown-column--preview">
+                    <a href="/chemische-befestigung" class="fh-header__dropdown-preview-link">
+                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Bauchemie_Kategorie_Nav_Vorschau_360x120.jpg" alt="Bauchemie Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
+                    </a>
+                  </div>
                   <div class="fh-header__dropdown-footer">
                     <hr class="fh-header__dropdown-divider">
                     <a href="/chemische-befestigung" class="fh-header__dropdown-footer-link">Alle Bauchemie sehen</a>
@@ -468,6 +485,7 @@
                     <a href="/zubehoer/arbeitshandschuhe/" class="fh-header__dropdown-link">Arbeitshandschuhe</a>
                     <a href="/zubehoer/betriebsmittel/" class="fh-header__dropdown-link">Betriebsmittel</a>
                     <a href="/zubehoer/bit" class="fh-header__dropdown-link">Bits</a>
+                    <a href="/zubehoer/klebebaender" class="fh-header__dropdown-link">Klebebänder</a>
                   </div>
                   <div class="fh-header__dropdown-column">
                     <div class="fh-header__dropdown-group">
@@ -481,12 +499,14 @@
                     <a href="/zubehoer/dampfbremsen" class="fh-header__dropdown-link">Dampfbremsen</a>
                   </div>
                   <div class="fh-header__dropdown-column">
-                    <a href="/zubehoer/klebebaender" class="fh-header__dropdown-link">Klebebänder</a>
                     <a href="/zubehoer/malerzubehoer/" class="fh-header__dropdown-link">Malerzubehör</a>
-                  </div>
-                  <div class="fh-header__dropdown-column">
                     <a href="/zubehoer/schleifen-trennen/" class="fh-header__dropdown-link">Schleifen-Trennen</a>
                     <a href="/zubehoer/werkzeug" class="fh-header__dropdown-link">Werkzeug</a>
+                  </div>
+                  <div class="fh-header__dropdown-column fh-header__dropdown-column--preview">
+                    <a href="/zubehoer" class="fh-header__dropdown-preview-link">
+                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Zubehoer_Kategorie_Nav_Vorschau_360x120.jpg" alt="Zubehör Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
+                    </a>
                   </div>
                   <div class="fh-header__dropdown-footer">
                     <hr class="fh-header__dropdown-divider">


### PR DESCRIPTION
### Motivation
- Add visual category preview thumbnails to the FH desktop navigation submenus to improve discoverability and reduce uneven whitespace in dropdowns.
- Place previews in the fourth (right-most) column and make each preview link to its top-level category.
- Keep the submenu link distribution even so dropdowns appear balanced across columns.
- Implement a subtle hover zoom and rounded corners for a polished interaction without changing layout bounds.

### Description
- Updated `Header/FH-Header.html` to add a preview column (`.fh-header__dropdown-column--preview`) to the desktop dropdowns for the categories: Schlösser, Beschläge, Fenster & Sicherheit, Gartenbau, Bauchemie and Zubehör, using the provided 360×120 preview image URLs and top-level links.
- Rebalanced submenu items across existing columns so each dropdown remains even and avoids excessive whitespace by moving/duplicating a few links between columns.
- Added CSS rules to `FH - Stylesheets.css` (`.fh-header__dropdown-column--preview`, `.fh-header__dropdown-preview-link`, `.fh-header__dropdown-preview-image`) to apply a 6px border-radius, overflow hidden, and a subtle internal zoom on hover using `transform: scale(1.05)` with a smooth transition.
- Image elements include `width`/`height` attributes and are wrapped in anchor links to the top-level category to preserve accessibility and click behavior.

### Testing
- No automated tests were executed for these changes because they are static HTML/CSS updates.
- Files changed: `Header/FH-Header.html` and `FH - Stylesheets.css`, and the changes were committed locally (`Add FH header nav preview images`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964a31ee3288331b7a43ddbcda302bd)