### PR TITLE
Hide Brevo chat iframe during overlay states in FH and SH stylesheets

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3186,12 +3186,14 @@ body.fh-mobile-menu-open {
 .basket-open .widget-cookie-bar,
 .basket-open div[id^="trustbadge-container-"],
 .basket-open #web-chat-loader-root,
+.basket-open .brevo-conversations__iframe-wrapper,
   #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active .widget_container_overlay,
   #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active #trustami-mobile-view,
   #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active .back-to-top,
   #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active .widget-cookie-bar,
   #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active div[id^="trustbadge-container-"],
-  #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active #web-chat-loader-root {
+  #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active #web-chat-loader-root,
+  #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active .brevo-conversations__iframe-wrapper {
     display: none !important;
 }
 
@@ -3200,11 +3202,13 @@ body.fh-mobile-menu-open #trustami-mobile-view,
 body.fh-mobile-menu-open .back-to-top,
 body.fh-mobile-menu-open .widget-cookie-bar,
 body.fh-mobile-menu-open div[id^="trustbadge-container-"],
-body.fh-mobile-menu-open #web-chat-loader-root {
+body.fh-mobile-menu-open #web-chat-loader-root,
+body.fh-mobile-menu-open .brevo-conversations__iframe-wrapper {
   display: none !important;
 }
 
-body.fh-search-overlay-open div[id^="trustbadge-container-"] {
+body.fh-search-overlay-open div[id^="trustbadge-container-"],
+body.fh-search-overlay-open .brevo-conversations__iframe-wrapper {
   display: none !important;
 }
 /* End Section: Trustbadge ausblenden */

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3167,12 +3167,14 @@ body.sh-mobile-menu-open {
 .basket-open .widget-cookie-bar,
 .basket-open div[id^="trustbadge-container-"],
 .basket-open #web-chat-loader-root,
+.basket-open .brevo-conversations__iframe-wrapper,
   #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active .widget_container_overlay,
   #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active #trustami-mobile-view,
   #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active .back-to-top,
   #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active .widget-cookie-bar,
   #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active div[id^="trustbadge-container-"],
-  #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active #web-chat-loader-root {
+  #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active #web-chat-loader-root,
+  #kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active .brevo-conversations__iframe-wrapper {
     display: none !important;
 }
 
@@ -3181,11 +3183,13 @@ body.sh-mobile-menu-open #trustami-mobile-view,
 body.sh-mobile-menu-open .back-to-top,
 body.sh-mobile-menu-open .widget-cookie-bar,
 body.sh-mobile-menu-open div[id^="trustbadge-container-"],
-body.sh-mobile-menu-open #web-chat-loader-root {
+body.sh-mobile-menu-open #web-chat-loader-root,
+body.sh-mobile-menu-open .brevo-conversations__iframe-wrapper {
   display: none !important;
 }
 
-body.sh-search-overlay-open div[id^="trustbadge-container-"] {
+body.sh-search-overlay-open div[id^="trustbadge-container-"],
+body.sh-search-overlay-open .brevo-conversations__iframe-wrapper {
   display: none !important;
 }
 /* End Section: Trustbadge ausblenden */


### PR DESCRIPTION
### Motivation
- Ensure the Brevo conversations iframe is hidden in the same overlay/overlay-like states where the Trustbadge and related widgets are hidden (basket preview, mega-menu dropdown active, mobile menu open, search overlay). 
- Keep both shop stylesheets (FH and SH) consistent so the chat iframe does not overlap or interfere with overlay UI states.

### Description
- Added the selector `.brevo-conversations__iframe-wrapper` to the existing Trustbadge-hiding rules in `FH - Stylesheets.css` for `.basket-open`, `#kyjMegaMenuNavContainer.kyj-mega-menu-dropdown-is-active`, `body.fh-mobile-menu-open` and `body.fh-search-overlay-open` contexts. 
- Added the same `.brevo-conversations__iframe-wrapper` entries to `SH - Stylesheets.css` for the matching `.basket-open`, mega-menu, mobile-menu and search-overlay contexts. 
- The rule uses `display: none !important;` to match the existing Trustbadge hiding behavior and avoid z-index/visibility conflicts.

### Testing
- No automated tests were executed for this change because it is a static CSS adjustment. 
- A visual check in the running storefront is recommended to verify the Brevo iframe is hidden in the described overlay states.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696767c5007883318ef54c5168199ac5)