### PR TITLE
Switch customer-facing copy to Du form

### DIFF
--- a/Custom Components/FH - Mein-Konto-Nav.html
+++ b/Custom Components/FH - Mein-Konto-Nav.html
@@ -15,7 +15,7 @@
           </span>
           <span v-else v-cloak>Hallo</span>
         </div>
-        <div class="fh-header__panel-text">Schön, dass Sie wieder da sind!</div>
+        <div class="fh-header__panel-text">Schön, dass Du wieder da bist!</div>
       </div>
       <div
         class="fh-header__customer-segment"
@@ -34,7 +34,7 @@
           v-else-if="Number($store.state.user.userData.classId) === 12"
           v-cloak
         >
-          <div class="fh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+          <div class="fh-header__customer-contact-heading">Dein Ansprechpartner:</div>
           <div class="fh-header__customer-contact-name">Ulrich Vorländer</div>
           <div class="fh-header__customer-contact-role">Produktexperte &amp; Kundenbetreuer</div>
           <a href="/kundenbetreuer-ulrich-vorlaender" class="fh-header__contact-button">Direkt kontaktieren</a>
@@ -44,7 +44,7 @@
           v-else-if="Number($store.state.user.userData.classId) === 16"
           v-cloak
         >
-          <div class="fh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+          <div class="fh-header__customer-contact-heading">Dein Ansprechpartner:</div>
           <div class="fh-header__customer-contact-name">Andreas Fischermann</div>
           <div class="fh-header__customer-contact-role">Produktexperte &amp; Kundenbetreuer</div>
           <a href="/kundenbetreuer-andreas-fischermann" class="fh-header__contact-button">Direkt kontaktieren</a>
@@ -54,7 +54,7 @@
           v-else-if="Number($store.state.user.userData.classId) === 21"
           v-cloak
         >
-          <div class="fh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+          <div class="fh-header__customer-contact-heading">Dein Ansprechpartner:</div>
           <div class="fh-header__customer-contact-name">Gabriele Sprenger</div>
           <div class="fh-header__customer-contact-role">Produktexperte &amp; Kundenbetreuer</div>
           <a href="/kundenbetreuer-gabriele-sprenger" class="fh-header__contact-button">Direkt kontaktieren</a>
@@ -66,7 +66,7 @@
       class="fh-header__panel-contact fh-account-nav__contact"
       v-if="!($store.state.user && $store.state.user.userData && [12, 16, 21].includes(Number($store.state.user.userData.classId)))"
     >
-      <div class="fh-header__panel-contact-label">Fragen? Sie erreichen uns hier:</div>
+      <div class="fh-header__panel-contact-label">Fragen? Du erreichst uns hier:</div>
       <div class="fh-header__panel-contact-line">
         <a href="tel:02204910980" class="fh-header__panel-contact-chip">
           <span class="fh-header__panel-contact-icon" aria-hidden="true">

--- a/Custom Components/SH - Mein-Konto-Nav.html
+++ b/Custom Components/SH - Mein-Konto-Nav.html
@@ -15,7 +15,7 @@
           </span>
           <span v-else v-cloak>Hallo</span>
         </div>
-        <div class="sh-header__panel-text">Schön, dass Sie wieder da sind!</div>
+        <div class="sh-header__panel-text">Schön, dass Du wieder da bist!</div>
       </div>
       <div
         class="sh-header__customer-segment"
@@ -34,7 +34,7 @@
           v-else-if="Number($store.state.user.userData.classId) === 12"
           v-cloak
         >
-          <div class="sh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+          <div class="sh-header__customer-contact-heading">Dein Ansprechpartner:</div>
           <div class="sh-header__customer-contact-name">Ulrich Vorländer</div>
           <div class="sh-header__customer-contact-role">Produktexperte &amp; Kundenbetreuer</div>
           <a href="/kundenbetreuer-ulrich-vorlaender" class="sh-header__contact-button">Direkt kontaktieren</a>
@@ -44,7 +44,7 @@
           v-else-if="Number($store.state.user.userData.classId) === 16"
           v-cloak
         >
-          <div class="sh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+          <div class="sh-header__customer-contact-heading">Dein Ansprechpartner:</div>
           <div class="sh-header__customer-contact-name">Andreas Fischermann</div>
           <div class="sh-header__customer-contact-role">Produktexperte &amp; Kundenbetreuer</div>
           <a href="/kundenbetreuer-andreas-fischermann" class="sh-header__contact-button">Direkt kontaktieren</a>
@@ -54,7 +54,7 @@
           v-else-if="Number($store.state.user.userData.classId) === 21"
           v-cloak
         >
-          <div class="sh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+          <div class="sh-header__customer-contact-heading">Dein Ansprechpartner:</div>
           <div class="sh-header__customer-contact-name">Gabriele Sprenger</div>
           <div class="sh-header__customer-contact-role">Produktexpertin &amp; Kundenbetreuerin</div>
           <a href="/kundenbetreuerin-gabriele-sprenger" class="sh-header__contact-button">Direkt kontaktieren</a>
@@ -66,7 +66,7 @@
       class="sh-header__panel-contact sh-account-nav__contact"
       v-if="!($store.state.user && $store.state.user.userData && [12, 16, 21].includes(Number($store.state.user.userData.classId)))"
     >
-      <div class="sh-header__panel-contact-label">Fragen? Sie erreichen uns hier:</div>
+      <div class="sh-header__panel-contact-label">Fragen? Du erreichst uns hier:</div>
       <div class="sh-header__panel-contact-line">
         <a href="tel:02204910980" class="sh-header__panel-contact-chip">
           <span class="sh-header__panel-contact-icon" aria-hidden="true">

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -48,7 +48,7 @@
     </div>
     <div class="fh-header__actions">
       <div class="fh-account-menu-container position-relative" data-fh-account-menu-container>
-        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-account-menu" aria-label="Ihr Konto" data-fh-account-menu-toggle class="fh-header__icon-button">
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-account-menu" aria-label="Dein Konto" data-fh-account-menu-toggle class="fh-header__icon-button">
           <span class="fh-header__status-indicator" :class="{ 'is-logged-in': $store.getters.isLoggedIn }" aria-hidden="true"></span>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="fh-header__icon">
             <path d="M12 12c2.8 0 5-2.2 5-5s-2.2-5-5-5-5 2.2-5 5 2.2 5 5 5z"></path>
@@ -58,7 +58,7 @@
         <div id="fh-account-menu" data-fh-account-menu aria-hidden="true" class="fh-header__panel fh-header__panel--account">
           <div class="fh-header__panel-arrow"></div>
           <div v-if="!$store.getters.isLoggedIn">
-            <div class="fh-header__panel-title mb-3">Ihr Konto</div>
+            <div class="fh-header__panel-title mb-3">Dein Konto</div>
             <a href="#login" data-toggle="modal" data-target="#login" data-fh-login-trigger class="fh-header__account-login">Anmelden</a>
             <div class="fh-header__panel-inline my-3 fh-header__panel-text">
               <span>oder</span>
@@ -81,7 +81,7 @@
                 <span v-if="$store.state.user && $store.state.user.userData && $store.state.user.userData.lastName && (({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title)" v-cloak><span class="fh-account-greeting" data-default-greeting="Hallo,">Hallo,</span> <span v-text="((({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title) + ' ' + $store.state.user.userData.lastName)" v-cloak></span></span>
                 <span v-else v-cloak>Hallo</span>
               </div>
-              <div class="fh-header__panel-text">Schön, dass Sie wieder da sind!</div>
+              <div class="fh-header__panel-text">Schön, dass Du wieder da bist!</div>
               <div class="fh-header__price-toggle" data-fh-price-toggle-root v-if="$store.getters.isLoggedIn">
                 <div class="fh-header__price-toggle-row">
                   <button
@@ -119,7 +119,7 @@
                 v-else-if="Number($store.state.user.userData.classId) === 12"
                 v-cloak
               >
-                <div class="fh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+                <div class="fh-header__customer-contact-heading">Dein Ansprechpartner:</div>
                 <div class="fh-header__customer-contact-name">Ulrich Vorländer</div>
                 <div class="fh-header__customer-contact-role">Produktexperte &amp; Kundenbetreuer</div>
                 <a href="/kundenbetreuer-ulrich-vorlaender" class="fh-header__contact-button">Direkt kontaktieren</a>
@@ -129,7 +129,7 @@
                 v-else-if="Number($store.state.user.userData.classId) === 16"
                 v-cloak
               >
-                <div class="fh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+                <div class="fh-header__customer-contact-heading">Dein Ansprechpartner:</div>
                 <div class="fh-header__customer-contact-name">Andreas Fischermann</div>
                 <div class="fh-header__customer-contact-role">Produktexperte &amp; Kundenbetreuer</div>
                 <a href="/kundenbetreuer-andreas-fischermann" class="fh-header__contact-button">Direkt kontaktieren</a>
@@ -139,7 +139,7 @@
                 v-else-if="Number($store.state.user.userData.classId) === 21"
                 v-cloak
               >
-                <div class="fh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+                <div class="fh-header__customer-contact-heading">Dein Ansprechpartner:</div>
                 <div class="fh-header__customer-contact-name">Gabriele Sprenger</div>
                 <div class="fh-header__customer-contact-role">Produktexpertin &amp; Kundenbetreuerin</div>
                 <a href="/kundenbetreuerin-gabriele-sprenger" class="fh-header__contact-button">Direkt kontaktieren</a>
@@ -150,7 +150,7 @@
               class="fh-header__panel-contact"
               v-if="!($store.state.user && $store.state.user.userData && [12, 16, 21].includes(Number($store.state.user.userData.classId)))"
             >
-              <div class="fh-header__panel-contact-label">Fragen? Sie erreichen uns hier:</div>
+              <div class="fh-header__panel-contact-label">Fragen? Du erreichst uns hier:</div>
               <div class="fh-header__panel-contact-line">
                 <a href="tel:02204910980" class="fh-header__panel-contact-chip">
                   <span class="fh-header__panel-contact-icon" aria-hidden="true">
@@ -609,7 +609,7 @@
             </div>
             <div class="fh-header__mobile-submenu-title">Schlösser</div>
             <nav class="fh-header__mobile-breadcrumb" aria-label="Breadcrumb" data-fh-mobile-breadcrumb></nav>
-            <p class="fh-header__mobile-submenu-description">Passende Lösungen für Haustüren, Wohnungstüren, Zimmer und Tore: Entdecken Sie robuste Schlösser, elektrische Türöffner sowie Profilzylinder inklusive Zubehör für maximale Sicherheit.</p>
+            <p class="fh-header__mobile-submenu-description">Passende Lösungen für Haustüren, Wohnungstüren, Zimmer und Tore: Entdecke robuste Schlösser, elektrische Türöffner sowie Profilzylinder inklusive Zubehör für maximale Sicherheit.</p>
             <div class="fh-header__mobile-submenu-cta">
               <a href="/schlossfinder" class="schlossfinder schlossfinder--mobile">Schlossfinder</a>
             </div>

--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -48,7 +48,7 @@
     </div>
     <div class="sh-header__actions">
       <div class="sh-account-menu-container position-relative" data-sh-account-menu-container>
-        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="sh-account-menu" aria-label="Ihr Konto" data-sh-account-menu-toggle class="sh-header__icon-button">
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="sh-account-menu" aria-label="Dein Konto" data-sh-account-menu-toggle class="sh-header__icon-button">
           <span class="sh-header__status-indicator" :class="{ 'is-logged-in': $store.getters.isLoggedIn }" aria-hidden="true"></span>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="sh-header__icon">
             <path d="M12 12c2.8 0 5-2.2 5-5s-2.2-5-5-5-5 2.2-5 5 2.2 5 5 5z"></path>
@@ -58,7 +58,7 @@
         <div id="sh-account-menu" data-sh-account-menu aria-hidden="true" class="sh-header__panel sh-header__panel--account">
           <div class="sh-header__panel-arrow"></div>
           <div v-if="!$store.getters.isLoggedIn">
-            <div class="sh-header__panel-title mb-3">Ihr Konto</div>
+            <div class="sh-header__panel-title mb-3">Dein Konto</div>
             <a href="#login" data-toggle="modal" data-target="#login" data-sh-login-trigger class="sh-header__account-login">Anmelden</a>
             <div class="sh-header__panel-inline my-3 sh-header__panel-text">
               <span>oder</span>
@@ -81,7 +81,7 @@
                 <span v-if="$store.state.user && $store.state.user.userData && $store.state.user.userData.lastName && (({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title)" v-cloak><span class="sh-account-greeting" data-default-greeting="Hallo,">Hallo,</span> <span v-text="((({ male: 'Herr', female: 'Frau', diverse: 'Divers' }[$store.state.user.userData.gender]) || $store.state.user.userData.formOfAddress || $store.state.user.userData.title) + ' ' + $store.state.user.userData.lastName)" v-cloak></span></span>
                 <span v-else v-cloak>Hallo</span>
               </div>
-              <div class="sh-header__panel-text">Schön, dass Sie wieder da sind!</div>
+              <div class="sh-header__panel-text">Schön, dass Du wieder da bist!</div>
               <div class="sh-header__price-toggle" data-sh-price-toggle-root v-if="$store.getters.isLoggedIn">
                 <div class="sh-header__price-toggle-row">
                   <button
@@ -119,7 +119,7 @@
                 v-else-if="Number($store.state.user.userData.classId) === 12"
                 v-cloak
               >
-                <div class="sh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+                <div class="sh-header__customer-contact-heading">Dein Ansprechpartner:</div>
                 <div class="sh-header__customer-contact-name">Ulrich Vorländer</div>
                 <div class="sh-header__customer-contact-role">Produktexperte &amp; Kundenbetreuer</div>
                 <a href="/kundenbetreuer-ulrich-vorlaender" class="sh-header__contact-button">Direkt kontaktieren</a>
@@ -129,7 +129,7 @@
                 v-else-if="Number($store.state.user.userData.classId) === 16"
                 v-cloak
               >
-                <div class="sh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+                <div class="sh-header__customer-contact-heading">Dein Ansprechpartner:</div>
                 <div class="sh-header__customer-contact-name">Andreas Fischermann</div>
                 <div class="sh-header__customer-contact-role">Produktexperte &amp; Kundenbetreuer</div>
                 <a href="/kundenbetreuer-andreas-fischermann" class="sh-header__contact-button">Direkt kontaktieren</a>
@@ -139,7 +139,7 @@
                 v-else-if="Number($store.state.user.userData.classId) === 21"
                 v-cloak
               >
-                <div class="sh-header__customer-contact-heading">Ihr Ansprechpartner:</div>
+                <div class="sh-header__customer-contact-heading">Dein Ansprechpartner:</div>
                 <div class="sh-header__customer-contact-name">Gabriele Sprenger</div>
                 <div class="sh-header__customer-contact-role">Produktexpertin &amp; Kundenbetreuerin</div>
                 <a href="/kundenbetreuerin-gabriele-sprenger" class="sh-header__contact-button">Direkt kontaktieren</a>
@@ -150,7 +150,7 @@
               class="sh-header__panel-contact"
               v-if="!($store.state.user && $store.state.user.userData && [12, 16, 21].includes(Number($store.state.user.userData.classId)))"
             >
-              <div class="sh-header__panel-contact-label">Fragen? Sie erreichen uns hier:</div>
+              <div class="sh-header__panel-contact-label">Fragen? Du erreichst uns hier:</div>
               <div class="sh-header__panel-contact-line">
                 <a href="tel:02204910980" class="sh-header__panel-contact-chip">
                   <span class="sh-header__panel-contact-icon" aria-hidden="true">

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3001,7 +3001,7 @@ fhOnReady(function () {
       }
     }
     var textHtml = '<div style="display:flex;flex-direction:column;justify-content:center;line-height:1.45;max-width:640px;">' +
-     '<span>Bestellen Sie innerhalb ' + zeitHtml + ', damit Ihre Ware ' + dateLabel + ' unser Lager verlässt.   </span>' +
+     '<span>Bestelle innerhalb ' + zeitHtml + ', damit Deine Ware ' + dateLabel + ' unser Lager verlässt.   </span>' +
   '</div>';
     elem.innerHTML = 
       '<div style="display:flex;align-items:center;">' +

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -2961,7 +2961,7 @@ shOnReady(function () {
       }
     }
     var textHtml = '<div style="display:flex;flex-direction:column;justify-content:center;line-height:1.45;max-width:640px;">' +
-     '<span>Bestellen Sie innerhalb ' + zeitHtml + ', damit Ihre Ware ' + dateLabel + ' unser Lager verlässt.   </span>' +
+     '<span>Bestelle innerhalb ' + zeitHtml + ', damit Deine Ware ' + dateLabel + ' unser Lager verlässt.   </span>' +
   '</div>';
     elem.innerHTML = 
       '<div style="display:flex;align-items:center;">' +


### PR DESCRIPTION
### Motivation
- Align customer-facing text with the project's style guide by converting formal German address (`Sie`/`Ihr`) to informal `Du`/`Dein` in header, account panels and related copy.
- Keep messaging consistent across both shops (FH & SH) and in JS-generated UI strings such as the order countdown.

### Description
- Updated account and header copy in FH and SH by changing labels and aria text from `Ihr`/`Sie` to `Dein`/`Du` in `Header/FH-Header.html` and `Header/SH-Header.html` and the corresponding account panel strings shown to logged-in users (greetings, contact headings, contact prompt).
- Updated account navigation components in `Custom Components/FH - Mein-Konto-Nav.html` and `Custom Components/SH - Mein-Konto-Nav.html` to use `Du`/`Dein` phrasing for panel text and contact labels.
- Switched the order countdown message in `JavaScript im Head/FH - JS im Head.js` and `JavaScript im Head/SH - JS im Head.js` from formal to informal (e.g. `Bestelle innerhalb ... damit Deine Ware ...`).
- Minor mobile submenu copy change in `Header/FH-Header.html` to informal tone; no structural or logic changes were made.

### Testing
- Generated a visual preview screenshot of the updated FH header using a local HTTP server and `Playwright`, which completed successfully and produced `artifacts/fh-header-preview.png`.
- No unit or E2E test suites were run; changes are content-only string updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968c5c9961c833180e6eb00d3788906)