### PR TITLE
Add brand-logo sizing and hide default Ceres logo, breadcrumb start, and reCAPTCHA badge in FH/SH CSS

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -159,6 +159,16 @@ body,
 }
 /* End Section: Produktseite Variantenauswahl Box */
 
+/* Section: Produktseite Markenlogo */
+div.external-brand-logo img {
+  max-height: 30px;
+  height: auto;
+  max-width: 120px;
+  width: auto;
+  margin-top: 10px;
+}
+/* End Section: Produktseite Markenlogo */
+
 /* Section: Verfügbarkeitshinweis Produktseite */
 #kjvItemAvailabilityText,
 .availability .availability-text,
@@ -878,6 +888,12 @@ body,
   width: auto;
   height: 64px;
 }
+
+/* Section: Ceres Standard-Logo ausblenden */
+a.logo {
+  display: none !important;
+}
+/* End Section: Ceres Standard-Logo ausblenden */
 
 .fh-header__search-area {
   display: flex;
@@ -2352,6 +2368,16 @@ body,
   color: #475569;
 }
 
+/* Section: Breadcrumb-Startpunkt ausblenden */
+.breadcrumb > li:first-child {
+  display: none;
+}
+
+.breadcrumb > li:nth-child(2)::before {
+  display: none;
+}
+/* End Section: Breadcrumb-Startpunkt ausblenden */
+
 .fh-header__mobile-breadcrumb:empty {
   display: none;
 }
@@ -2387,6 +2413,12 @@ body,
   font-size: 14px;
   line-height: 1;
 }
+
+/* Section: reCAPTCHA Badge ausblenden */
+div.grecaptcha-badge {
+  display: none !important;
+}
+/* End Section: reCAPTCHA Badge ausblenden */
 
 .fh-header__mobile-submenu-title {
   margin: 0;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -159,6 +159,16 @@ body,
 }
 /* End Section: Produktseite Variantenauswahl Box */
 
+/* Section: Produktseite Markenlogo */
+div.external-brand-logo img {
+  max-height: 30px;
+  height: auto;
+  max-width: 120px;
+  width: auto;
+  margin-top: 10px;
+}
+/* End Section: Produktseite Markenlogo */
+
 /* Section: Verfügbarkeitshinweis Produktseite */
 #kjvItemAvailabilityText,
 .availability .availability-text,
@@ -886,6 +896,12 @@ body,
   width: auto;
   height: 64px;
 }
+
+/* Section: Ceres Standard-Logo ausblenden */
+a.logo {
+  display: none !important;
+}
+/* End Section: Ceres Standard-Logo ausblenden */
 
 .sh-header__search-area {
   display: flex;
@@ -2333,6 +2349,16 @@ body,
   color: #475569;
 }
 
+/* Section: Breadcrumb-Startpunkt ausblenden */
+.breadcrumb > li:first-child {
+  display: none;
+}
+
+.breadcrumb > li:nth-child(2)::before {
+  display: none;
+}
+/* End Section: Breadcrumb-Startpunkt ausblenden */
+
 .sh-header__mobile-breadcrumb:empty {
   display: none;
 }
@@ -2368,6 +2394,12 @@ body,
   font-size: 14px;
   line-height: 1;
 }
+
+/* Section: reCAPTCHA Badge ausblenden */
+div.grecaptcha-badge {
+  display: none !important;
+}
+/* End Section: reCAPTCHA Badge ausblenden */
 
 .sh-header__mobile-submenu-title {
   margin: 0;


### PR DESCRIPTION
### Motivation
- Ensure external brand logos on product/article pages display consistently and remove redundant UI elements from the default Ceres markup across both FH and SH styles.
- Keep header/breadcrumb markup visually cleaner by hiding the default Ceres logo anchor and removing the first breadcrumb item and its separator where appropriate.
- Remove the visible reCAPTCHA badge from the storefront display via stylesheet override.

### Description
- Added `div.external-brand-logo img` rules to both `FH - Stylesheets.css` and `SH - Stylesheets.css` to constrain brand logo sizing (`max-height: 30px`, `max-width: 120px`, maintain aspect ratio and top margin). 
- Added `a.logo { display: none !important; }` to both stylesheets to hide the default Ceres logo anchor in the header. 
- Added breadcrumb cleanup rules `.breadcrumb > li:first-child { display: none; }` and `.breadcrumb > li:nth-child(2)::before { display: none; }` in both stylesheets to remove the starting breadcrumb item and its separator. 
- Added `div.grecaptcha-badge { display: none !important; }` to both stylesheets to suppress the reCAPTCHA badge display. 

### Testing
- No automated tests were executed for this change because it is CSS-only and does not affect application logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969ed3740cc8331a996c4121b38f7d9)