### PR TITLE
Position Trusted Shops badge on left for FH

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3245,6 +3245,14 @@ body.fh-search-overlay-open .brevo-conversations__iframe-wrapper {
 }
 /* End Section: Trustbadge ausblenden */
 
+/* Section: Trusted Shops Badge Position */
+div._1ggtbm9,
+div._1dqk8hp {
+  left: 20px !important;
+  right: auto !important;
+}
+/* End Section: Trusted Shops Badge Position */
+
 /* Section: Allgemeines Button-Styling für .btn-primary */
 .btn.btn-primary {
   background-color: #000000 !important; /* Tiefschwarz – kräftig */


### PR DESCRIPTION
### Motivation
- Move the Trusted Shops badge from the bottom-right to the bottom-left on the FH storefront to implement the requested visual repositioning (SH will be updated later). 

### Description
- Added a dedicated CSS section in `FH - Stylesheets.css` that targets `div._1ggtbm9` and `div._1dqk8hp` and sets `left: 20px !important;` and `right: auto !important;` to position the badge on the left. 

### Testing
- No automated tests were run because this is a CSS-only change and requires a running frontend to visually verify.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969f041b7a88331aa4a849d6531165b)