### PR TITLE
Align product card quantity info and hide on hover (FH & SH)

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -90,6 +90,11 @@ body,
   order: 3;
   font-size: 0.85rem;
   color: #6b7280;
+  align-self: flex-end;
+}
+
+.widget-item-grid .cmp-product-thumb:hover .prices > .price-info {
+  display: none;
 }
 /* End Section: Artikel Preview Card Preis Layout */
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -90,6 +90,11 @@ body,
   order: 3;
   font-size: 0.85rem;
   color: #6b7280;
+  align-self: flex-end;
+}
+
+.widget-item-grid .cmp-product-thumb:hover .prices > .price-info {
+  display: none;
 }
 /* End Section: Artikel Preview Card Preis Layout */
 


### PR DESCRIPTION
### Motivation
- Prevent the quantity/price-info from being pushed left on product cards and reserve the right edge for the cart icon by aligning the info to the right and hiding it on hover.

### Description
- Added `align-self: flex-end` and a hover rule (`display: none`) for `.widget-item-grid .cmp-product-thumb .prices > .price-info` in `FH - Stylesheets.css` and `SH - Stylesheets.css` so the price/quantity info sits on the right and disappears on hover.

### Testing
- No unit tests; this is a CSS-only change and was committed after a visual check attempt; a Playwright screenshot attempt failed due to no local dev server responding (net::ERR_EMPTY_RESPONSE).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a39cb338c8331a59e29ccb7a44a5d)