### PR TITLE
Add wishlist toggle/panel to FH and SH headers

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -207,6 +207,22 @@
           </div>
         </div>
       </div>
+      <div class="fh-wishlist-menu-container position-relative" data-fh-wishlist-menu-container>
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-wishlist-menu" aria-label="{{ trans('Ceres::Template.wishList') }}" data-fh-wishlist-menu-toggle class="fh-header__icon-button">
+          <span class="fh-header__wishlist-count" aria-hidden="true">
+            <wish-list-count></wish-list-count>
+          </span>
+          <span class="fh-header__sr-only">{{ trans('Ceres::Template.wishList') }}</span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="fh-header__icon">
+            <path d="M20.8 7.6c0 4.6-8.8 11.7-8.8 11.7S3.2 12.2 3.2 7.6a4.2 4.2 0 0 1 7.3-2.8L12 6.3l1.5-1.5a4.2 4.2 0 0 1 7.3 2.8Z"></path>
+          </svg>
+        </button>
+        <div id="fh-wishlist-menu" data-fh-wishlist-menu aria-hidden="true" class="fh-header__panel fh-header__panel--wishlist">
+          <div class="fh-header__panel-arrow"></div>
+          <div class="fh-header__panel-title mb-3">{{ trans('Ceres::Template.wishList') }}</div>
+          <wish-list></wish-list>
+        </div>
+      </div>
       <div class="fh-basket-preview fh-header__basket">
         <a v-toggle-basket-preview href="#" class="toggle-basket-preview fh-header__basket-link" aria-label="Warenkorb">
           <span class="fh-header__basket-count" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>

--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -207,6 +207,22 @@
           </div>
         </div>
       </div>
+      <div class="sh-wishlist-menu-container position-relative" data-sh-wishlist-menu-container>
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="sh-wishlist-menu" aria-label="{{ trans('Ceres::Template.wishList') }}" data-sh-wishlist-menu-toggle class="sh-header__icon-button">
+          <span class="sh-header__wishlist-count" aria-hidden="true">
+            <wish-list-count></wish-list-count>
+          </span>
+          <span class="sh-header__sr-only">{{ trans('Ceres::Template.wishList') }}</span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="sh-header__icon">
+            <path d="M20.8 7.6c0 4.6-8.8 11.7-8.8 11.7S3.2 12.2 3.2 7.6a4.2 4.2 0 0 1 7.3-2.8L12 6.3l1.5-1.5a4.2 4.2 0 0 1 7.3 2.8Z"></path>
+          </svg>
+        </button>
+        <div id="sh-wishlist-menu" data-sh-wishlist-menu aria-hidden="true" class="sh-header__panel sh-header__panel--wishlist">
+          <div class="sh-header__panel-arrow"></div>
+          <div class="sh-header__panel-title mb-3">{{ trans('Ceres::Template.wishList') }}</div>
+          <wish-list></wish-list>
+        </div>
+      </div>
       <div class="sh-basket-preview sh-header__basket">
         <a v-toggle-basket-preview href="#" class="toggle-basket-preview sh-header__basket-link" aria-label="Warenkorb">
           <span class="sh-header__basket-count" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -885,6 +885,105 @@ fhOnReady(function () {
 });
 // End Section: FH account menu toggle behaviour
 
+// Section: FH wishlist menu toggle behaviour
+fhOnReady(function () {
+  const container = document.querySelector('[data-fh-wishlist-menu-container]');
+
+  if (!container) return;
+
+  const toggleButton = container.querySelector('[data-fh-wishlist-menu-toggle]');
+  const menu = container.querySelector('[data-fh-wishlist-menu]');
+
+  if (!toggleButton || !menu) return;
+
+  let isOpen = false;
+
+  function getVueStore() {
+    if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
+
+    if (window.ceresStore && typeof window.ceresStore.dispatch === 'function') return window.ceresStore;
+
+    return null;
+  }
+
+  function resolveStoreAction(store, actionNames) {
+    if (!store || !store._actions) return null;
+
+    for (let index = 0; index < actionNames.length; index += 1) {
+      const name = actionNames[index];
+
+      if (store._actions[name]) return name;
+    }
+
+    return null;
+  }
+
+  function initWishListItems() {
+    const store = getVueStore();
+    const actionName = resolveStoreAction(store, ['wishList/initWishListItems', 'initWishListItems']);
+
+    if (!actionName) return;
+
+    try {
+      const result = store.dispatch(actionName);
+
+      if (result && typeof result.catch === 'function') result.catch(function () {});
+    } catch (error) {
+      /* Ignore dispatch errors in the custom integration to avoid breaking the UI. */
+    }
+  }
+
+  function openMenu() {
+    if (isOpen) return;
+
+    menu.style.display = 'block';
+    menu.setAttribute('aria-hidden', 'false');
+    toggleButton.setAttribute('aria-expanded', 'true');
+    document.addEventListener('click', handleDocumentClick);
+    document.addEventListener('keydown', handleKeydown);
+    isOpen = true;
+    initWishListItems();
+  }
+
+  function closeMenu() {
+    if (!isOpen) return;
+
+    menu.style.display = 'none';
+    menu.setAttribute('aria-hidden', 'true');
+    toggleButton.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('click', handleDocumentClick);
+    document.removeEventListener('keydown', handleKeydown);
+    isOpen = false;
+  }
+
+  function handleDocumentClick(event) {
+    if (!container.contains(event.target)) closeMenu();
+  }
+
+  function handleKeydown(event) {
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      closeMenu();
+      toggleButton.focus();
+    }
+  }
+
+  toggleButton.addEventListener('click', function (event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (isOpen) closeMenu(); else {
+      openMenu();
+    }
+  });
+
+  menu.addEventListener('click', function (event) {
+    const trigger = event.target.closest('[data-fh-wishlist-close]');
+
+    if (trigger) closeMenu();
+  });
+});
+// End Section: FH wishlist menu toggle behaviour
+
 // Section: FH account page navigation
 fhOnReady(function () {
   const nav = document.querySelector('[data-fh-account-nav]');

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -868,6 +868,105 @@ shOnReady(function () {
 });
 // End Section: sh account menu toggle behaviour
 
+// Section: sh wishlist menu toggle behaviour
+shOnReady(function () {
+  const container = document.querySelector('[data-sh-wishlist-menu-container]');
+
+  if (!container) return;
+
+  const toggleButton = container.querySelector('[data-sh-wishlist-menu-toggle]');
+  const menu = container.querySelector('[data-sh-wishlist-menu]');
+
+  if (!toggleButton || !menu) return;
+
+  let isOpen = false;
+
+  function getVueStore() {
+    if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
+
+    if (window.ceresStore && typeof window.ceresStore.dispatch === 'function') return window.ceresStore;
+
+    return null;
+  }
+
+  function resolveStoreAction(store, actionNames) {
+    if (!store || !store._actions) return null;
+
+    for (let index = 0; index < actionNames.length; index += 1) {
+      const name = actionNames[index];
+
+      if (store._actions[name]) return name;
+    }
+
+    return null;
+  }
+
+  function initWishListItems() {
+    const store = getVueStore();
+    const actionName = resolveStoreAction(store, ['wishList/initWishListItems', 'initWishListItems']);
+
+    if (!actionName) return;
+
+    try {
+      const result = store.dispatch(actionName);
+
+      if (result && typeof result.catch === 'function') result.catch(function () {});
+    } catch (error) {
+      /* Ignore dispatch errors in the custom integration to avoid breaking the UI. */
+    }
+  }
+
+  function openMenu() {
+    if (isOpen) return;
+
+    menu.style.display = 'block';
+    menu.setAttribute('aria-hidden', 'false');
+    toggleButton.setAttribute('aria-expanded', 'true');
+    document.addEventListener('click', handleDocumentClick);
+    document.addEventListener('keydown', handleKeydown);
+    isOpen = true;
+    initWishListItems();
+  }
+
+  function closeMenu() {
+    if (!isOpen) return;
+
+    menu.style.display = 'none';
+    menu.setAttribute('aria-hidden', 'true');
+    toggleButton.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('click', handleDocumentClick);
+    document.removeEventListener('keydown', handleKeydown);
+    isOpen = false;
+  }
+
+  function handleDocumentClick(event) {
+    if (!container.contains(event.target)) closeMenu();
+  }
+
+  function handleKeydown(event) {
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      closeMenu();
+      toggleButton.focus();
+    }
+  }
+
+  toggleButton.addEventListener('click', function (event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (isOpen) closeMenu(); else {
+      openMenu();
+    }
+  });
+
+  menu.addEventListener('click', function (event) {
+    const trigger = event.target.closest('[data-sh-wishlist-close]');
+
+    if (trigger) closeMenu();
+  });
+});
+// End Section: sh wishlist menu toggle behaviour
+
 // Section: sh account page navigation
 shOnReady(function () {
   const nav = document.querySelector('[data-sh-account-nav]');


### PR DESCRIPTION
### Motivation
- Integrate Ceres wishlist into both shop headers so users can open a header preview and see current items using existing store components and translations.
- Ensure the header preview loads full item details by calling the wishlist initialization when the dropdown opens because `addToWishList` only stores IDs.
- Reuse the established account-dropdown ARIA/toggle pattern so behaviour and accessibility remain consistent across FH and SH.

### Description
- Added wishlist button and panel markup to `Header/FH-Header.html` and `Header/SH-Header.html` that includes `<wish-list-count>` and `<wish-list>` and uses `{{ trans('Ceres::Template.wishList') }}` for labels.
- Implemented dropdown toggle logic in `JavaScript im Head/FH - JS im Head.js` and `JavaScript im Head/SH - JS im Head.js` that mirrors the account menu mechanics and calls `initWishListItems()` on open by dispatching the store action (`wishList/initWishListItems` or `initWishListItems`).
- Store resolution helper logic from the existing header scripts is reused so the integration works with either `window.vueApp.$store` or `window.ceresStore` without requiring changes to the core store.

### Testing
- No automated tests were executed for this change.
- Basic repository inspections (`ls`, file previews) and manual verification of the inserted markup and script locations were performed in the dev environment and showed the changes applied to the four files modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf10a293c8331857393029f8ac9d0)