### PR TITLE
Add wishlist dropdown to FH/SH headers

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1032,6 +1032,15 @@ a.logo {
   line-height: 1;
 }
 
+.fh-header__badge wish-list-count,
+.fh-header__badge wish-list-count > * {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
 .fh-header__panel {
   position: absolute;
   top: calc(100% + 16px);
@@ -2649,6 +2658,15 @@ div.grecaptcha-badge {
     opacity: 1 !important;
     visibility: visible !important;
     font-size: 10px;
+  }
+
+  .fh-header__badge wish-list-count,
+  .fh-header__badge wish-list-count > * {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 1 !important;
+    visibility: visible !important;
   }
 
   .fh-header__basket {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1018,10 +1018,10 @@ a.logo {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 20px;
+  width: 20px;
   height: 20px;
-  padding: 0 6px;
-  border-radius: 999px;
+  padding: 0;
+  border-radius: 50%;
   background-color: var(--fh-color-bright-blue);
   color: #ffffff;
   font-size: 11px;
@@ -2640,8 +2640,10 @@ div.grecaptcha-badge {
   }
 
   .fh-header__badge {
-    min-width: 18px;
+    width: 18px;
     height: 18px;
+    padding: 0;
+    border-radius: 50%;
     font-size: 10px;
   }
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1024,6 +1024,8 @@ a.logo {
   border-radius: 50%;
   background-color: var(--fh-color-bright-blue);
   color: #ffffff;
+  opacity: 1 !important;
+  visibility: visible !important;
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.3px;
@@ -2644,6 +2646,8 @@ div.grecaptcha-badge {
     height: 18px;
     padding: 0;
     border-radius: 50%;
+    opacity: 1 !important;
+    visibility: visible !important;
     font-size: 10px;
   }
 

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -47,6 +47,22 @@
       </form>
     </div>
     <div class="fh-header__actions">
+      <div class="fh-wishlist-menu-container position-relative" data-fh-wishlist-menu-container>
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-wishlist-menu" aria-label="{{ trans('Ceres::Template.wishList') }}" data-fh-wishlist-menu-toggle class="fh-header__icon-button">
+          <span class="fh-header__badge" aria-hidden="true">
+            <wish-list-count></wish-list-count>
+          </span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="fh-header__icon">
+            <path d="M7 4h10a1 1 0 0 1 1 1v15l-6-3-6 3V5a1 1 0 0 1 1-1z"></path>
+          </svg>
+          <span class="fh-header__sr-only">{{ trans("Ceres::Template.wishList") }}</span>
+        </button>
+        <div id="fh-wishlist-menu" data-fh-wishlist-menu aria-hidden="true" class="fh-header__panel">
+          <div class="fh-header__panel-arrow"></div>
+          <div class="fh-header__panel-title mb-3">{{ trans("Ceres::Template.wishList") }}</div>
+          <wish-list></wish-list>
+        </div>
+      </div>
       <div class="fh-account-menu-container position-relative" data-fh-account-menu-container>
         <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-account-menu" aria-label="Dein Konto" data-fh-account-menu-toggle class="fh-header__icon-button">
           <span class="fh-header__status-indicator" :class="{ 'is-logged-in': $store.getters.isLoggedIn }" aria-hidden="true"></span>
@@ -205,22 +221,6 @@
               <span class="fh-header__logout-label">Abmelden</span>
             </a>
           </div>
-        </div>
-      </div>
-      <div class="fh-wishlist-menu-container position-relative" data-fh-wishlist-menu-container>
-        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-wishlist-menu" aria-label="{{ trans('Ceres::Template.wishList') }}" data-fh-wishlist-menu-toggle class="fh-header__icon-button">
-          <span class="fh-header__badge" aria-hidden="true">
-            <wish-list-count></wish-list-count>
-          </span>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="fh-header__icon">
-            <path d="M20.8 5.6c-1.4-1.5-3.8-1.5-5.2 0L12 9.2 8.4 5.6c-1.4-1.5-3.8-1.5-5.2 0-1.5 1.6-1.5 4 0 5.6l8.8 9 8.8-9c1.5-1.6 1.5-4 0-5.6z"></path>
-          </svg>
-          <span class="fh-header__sr-only">{{ trans("Ceres::Template.wishList") }}</span>
-        </button>
-        <div id="fh-wishlist-menu" data-fh-wishlist-menu aria-hidden="true" class="fh-header__panel">
-          <div class="fh-header__panel-arrow"></div>
-          <div class="fh-header__panel-title mb-3">{{ trans("Ceres::Template.wishList") }}</div>
-          <wish-list></wish-list>
         </div>
       </div>
       <div class="fh-basket-preview fh-header__basket">

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -207,6 +207,22 @@
           </div>
         </div>
       </div>
+      <div class="fh-wishlist-menu-container position-relative" data-fh-wishlist-menu-container>
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="fh-wishlist-menu" aria-label="{{ trans('Ceres::Template.wishList') }}" data-fh-wishlist-menu-toggle class="fh-header__icon-button">
+          <span class="fh-header__badge" aria-hidden="true">
+            <wish-list-count></wish-list-count>
+          </span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="fh-header__icon">
+            <path d="M20.8 5.6c-1.4-1.5-3.8-1.5-5.2 0L12 9.2 8.4 5.6c-1.4-1.5-3.8-1.5-5.2 0-1.5 1.6-1.5 4 0 5.6l8.8 9 8.8-9c1.5-1.6 1.5-4 0-5.6z"></path>
+          </svg>
+          <span class="fh-header__sr-only">{{ trans("Ceres::Template.wishList") }}</span>
+        </button>
+        <div id="fh-wishlist-menu" data-fh-wishlist-menu aria-hidden="true" class="fh-header__panel">
+          <div class="fh-header__panel-arrow"></div>
+          <div class="fh-header__panel-title mb-3">{{ trans("Ceres::Template.wishList") }}</div>
+          <wish-list></wish-list>
+        </div>
+      </div>
       <div class="fh-basket-preview fh-header__basket">
         <a v-toggle-basket-preview href="#" class="toggle-basket-preview fh-header__basket-link" aria-label="Warenkorb">
           <span class="fh-header__basket-count" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>

--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -207,6 +207,22 @@
           </div>
         </div>
       </div>
+      <div class="sh-wishlist-menu-container position-relative" data-sh-wishlist-menu-container>
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="sh-wishlist-menu" aria-label="{{ trans('Ceres::Template.wishList') }}" data-sh-wishlist-menu-toggle class="sh-header__icon-button">
+          <span class="sh-header__badge" aria-hidden="true">
+            <wish-list-count></wish-list-count>
+          </span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="sh-header__icon">
+            <path d="M20.8 5.6c-1.4-1.5-3.8-1.5-5.2 0L12 9.2 8.4 5.6c-1.4-1.5-3.8-1.5-5.2 0-1.5 1.6-1.5 4 0 5.6l8.8 9 8.8-9c1.5-1.6 1.5-4 0-5.6z"></path>
+          </svg>
+          <span class="sh-header__sr-only">{{ trans("Ceres::Template.wishList") }}</span>
+        </button>
+        <div id="sh-wishlist-menu" data-sh-wishlist-menu aria-hidden="true" class="sh-header__panel">
+          <div class="sh-header__panel-arrow"></div>
+          <div class="sh-header__panel-title mb-3">{{ trans("Ceres::Template.wishList") }}</div>
+          <wish-list></wish-list>
+        </div>
+      </div>
       <div class="sh-basket-preview sh-header__basket">
         <a v-toggle-basket-preview href="#" class="toggle-basket-preview sh-header__basket-link" aria-label="Warenkorb">
           <span class="sh-header__basket-count" v-basket-item-quantity="$store.state.basket.data.itemQuantity">0</span>

--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -47,6 +47,22 @@
       </form>
     </div>
     <div class="sh-header__actions">
+      <div class="sh-wishlist-menu-container position-relative" data-sh-wishlist-menu-container>
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="sh-wishlist-menu" aria-label="{{ trans('Ceres::Template.wishList') }}" data-sh-wishlist-menu-toggle class="sh-header__icon-button">
+          <span class="sh-header__badge" aria-hidden="true">
+            <wish-list-count></wish-list-count>
+          </span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="sh-header__icon">
+            <path d="M7 4h10a1 1 0 0 1 1 1v15l-6-3-6 3V5a1 1 0 0 1 1-1z"></path>
+          </svg>
+          <span class="sh-header__sr-only">{{ trans("Ceres::Template.wishList") }}</span>
+        </button>
+        <div id="sh-wishlist-menu" data-sh-wishlist-menu aria-hidden="true" class="sh-header__panel">
+          <div class="sh-header__panel-arrow"></div>
+          <div class="sh-header__panel-title mb-3">{{ trans("Ceres::Template.wishList") }}</div>
+          <wish-list></wish-list>
+        </div>
+      </div>
       <div class="sh-account-menu-container position-relative" data-sh-account-menu-container>
         <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="sh-account-menu" aria-label="Dein Konto" data-sh-account-menu-toggle class="sh-header__icon-button">
           <span class="sh-header__status-indicator" :class="{ 'is-logged-in': $store.getters.isLoggedIn }" aria-hidden="true"></span>
@@ -205,22 +221,6 @@
               <span class="sh-header__logout-label">Abmelden</span>
             </a>
           </div>
-        </div>
-      </div>
-      <div class="sh-wishlist-menu-container position-relative" data-sh-wishlist-menu-container>
-        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="sh-wishlist-menu" aria-label="{{ trans('Ceres::Template.wishList') }}" data-sh-wishlist-menu-toggle class="sh-header__icon-button">
-          <span class="sh-header__badge" aria-hidden="true">
-            <wish-list-count></wish-list-count>
-          </span>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="sh-header__icon">
-            <path d="M20.8 5.6c-1.4-1.5-3.8-1.5-5.2 0L12 9.2 8.4 5.6c-1.4-1.5-3.8-1.5-5.2 0-1.5 1.6-1.5 4 0 5.6l8.8 9 8.8-9c1.5-1.6 1.5-4 0-5.6z"></path>
-          </svg>
-          <span class="sh-header__sr-only">{{ trans("Ceres::Template.wishList") }}</span>
-        </button>
-        <div id="sh-wishlist-menu" data-sh-wishlist-menu aria-hidden="true" class="sh-header__panel">
-          <div class="sh-header__panel-arrow"></div>
-          <div class="sh-header__panel-title mb-3">{{ trans("Ceres::Template.wishList") }}</div>
-          <wish-list></wish-list>
         </div>
       </div>
       <div class="sh-basket-preview sh-header__basket">

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -949,7 +949,13 @@ fhOnReady(function () {
         after: function (action) {
           if (!action || !action.type) return;
 
-          if (action.type.indexOf('addToWishList') !== -1) refreshWishList();
+          const actionType = String(action.type);
+          const isWishListAction = actionType.indexOf('wishList') !== -1 || actionType.indexOf('WishList') !== -1;
+          const isWishListChange = /add|remove/i.test(actionType);
+
+          if (isWishListAction && isWishListChange) {
+            window.setTimeout(refreshWishList, 50);
+          }
         },
       });
       hasInstalledSubscription = true;

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -885,6 +885,105 @@ fhOnReady(function () {
 });
 // End Section: FH account menu toggle behaviour
 
+// Section: FH wishlist menu toggle behaviour
+fhOnReady(function () {
+  const container = document.querySelector('[data-fh-wishlist-menu-container]');
+
+  if (!container) return;
+
+  const toggleButton = container.querySelector('[data-fh-wishlist-menu-toggle]');
+  const menu = container.querySelector('[data-fh-wishlist-menu]');
+
+  if (!toggleButton || !menu) return;
+
+  let isOpen = false;
+
+  function getVueStore() {
+    if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
+
+    if (window.ceresStore && typeof window.ceresStore.dispatch === 'function') return window.ceresStore;
+
+    return null;
+  }
+
+  function resolveStoreAction(store, actionNames) {
+    if (!store || !store._actions) return null;
+
+    for (let index = 0; index < actionNames.length; index += 1) {
+      const name = actionNames[index];
+
+      if (store._actions[name]) return name;
+    }
+
+    return null;
+  }
+
+  function refreshWishList() {
+    const store = getVueStore();
+
+    if (!store) return;
+
+    const actionName = resolveStoreAction(store, ['wishList/initWishListItems', 'initWishListItems']);
+
+    if (!actionName) return;
+
+    try {
+      const result = store.dispatch(actionName);
+
+      if (result && typeof result.catch === 'function') result.catch(function () {});
+    } catch (error) {
+      /* Ignore dispatch errors in the custom integration to avoid breaking the UI. */
+    }
+  }
+
+  function openMenu() {
+    if (isOpen) return;
+
+    refreshWishList();
+    menu.style.display = 'block';
+    menu.setAttribute('aria-hidden', 'false');
+    toggleButton.setAttribute('aria-expanded', 'true');
+    document.addEventListener('click', handleDocumentClick);
+    document.addEventListener('keydown', handleKeydown);
+    isOpen = true;
+  }
+
+  function closeMenu() {
+    if (!isOpen) return;
+
+    menu.style.display = 'none';
+    menu.setAttribute('aria-hidden', 'true');
+    toggleButton.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('click', handleDocumentClick);
+    document.removeEventListener('keydown', handleKeydown);
+    isOpen = false;
+  }
+
+  function handleDocumentClick(event) {
+    if (!container.contains(event.target)) closeMenu();
+  }
+
+  function handleKeydown(event) {
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      closeMenu();
+      toggleButton.focus();
+    }
+  }
+
+  toggleButton.addEventListener('click', function (event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (isOpen) closeMenu(); else {
+      openMenu();
+    }
+  });
+
+  document.addEventListener('fh:wishlist-refresh', refreshWishList);
+});
+// End Section: FH wishlist menu toggle behaviour
+
+
 // Section: FH account page navigation
 fhOnReady(function () {
   const nav = document.querySelector('[data-fh-account-nav]');

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -952,9 +952,10 @@ fhOnReady(function () {
           const actionType = String(action.type);
           const isWishListAction = actionType.indexOf('wishList') !== -1 || actionType.indexOf('WishList') !== -1;
           const isWishListChange = /add|remove/i.test(actionType);
+          const isDirectWishListAction = /addToWishList|removeWishListItem/i.test(actionType);
 
-          if (isWishListAction && isWishListChange) {
-            window.setTimeout(refreshWishList, 50);
+          if ((isWishListAction && isWishListChange) || isDirectWishListAction) {
+            window.setTimeout(refreshWishList, 120);
           }
         },
       });

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -897,6 +897,7 @@ fhOnReady(function () {
   if (!toggleButton || !menu) return;
 
   let isOpen = false;
+  let hasInstalledSubscription = false;
 
   function getVueStore() {
     if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
@@ -936,9 +937,44 @@ fhOnReady(function () {
     }
   }
 
+  function installWishListSubscription() {
+    if (hasInstalledSubscription) return;
+
+    const store = getVueStore();
+
+    if (!store || typeof store.subscribeAction !== 'function') return;
+
+    try {
+      store.subscribeAction({
+        after: function (action) {
+          if (!action || !action.type) return;
+
+          if (action.type.indexOf('addToWishList') !== -1) refreshWishList();
+        },
+      });
+      hasInstalledSubscription = true;
+    } catch (error) {
+      /* Ignore subscription errors to avoid breaking the UI. */
+    }
+  }
+
+  function scheduleWishListSubscription() {
+    let attempts = 0;
+    const maxAttempts = 20;
+    const intervalId = window.setInterval(function () {
+      attempts += 1;
+      installWishListSubscription();
+
+      if (hasInstalledSubscription || attempts >= maxAttempts) {
+        window.clearInterval(intervalId);
+      }
+    }, 500);
+  }
+
   function openMenu() {
     if (isOpen) return;
 
+    installWishListSubscription();
     refreshWishList();
     menu.style.display = 'block';
     menu.setAttribute('aria-hidden', 'false');
@@ -979,6 +1015,7 @@ fhOnReady(function () {
     }
   });
 
+  scheduleWishListSubscription();
   document.addEventListener('fh:wishlist-refresh', refreshWishList);
 });
 // End Section: FH wishlist menu toggle behaviour

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -932,7 +932,13 @@ shOnReady(function () {
         after: function (action) {
           if (!action || !action.type) return;
 
-          if (action.type.indexOf('addToWishList') !== -1) refreshWishList();
+          const actionType = String(action.type);
+          const isWishListAction = actionType.indexOf('wishList') !== -1 || actionType.indexOf('WishList') !== -1;
+          const isWishListChange = /add|remove/i.test(actionType);
+
+          if (isWishListAction && isWishListChange) {
+            window.setTimeout(refreshWishList, 50);
+          }
         },
       });
       hasInstalledSubscription = true;

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -868,6 +868,105 @@ shOnReady(function () {
 });
 // End Section: sh account menu toggle behaviour
 
+// Section: sh wishlist menu toggle behaviour
+shOnReady(function () {
+  const container = document.querySelector('[data-sh-wishlist-menu-container]');
+
+  if (!container) return;
+
+  const toggleButton = container.querySelector('[data-sh-wishlist-menu-toggle]');
+  const menu = container.querySelector('[data-sh-wishlist-menu]');
+
+  if (!toggleButton || !menu) return;
+
+  let isOpen = false;
+
+  function getVueStore() {
+    if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
+
+    if (window.ceresStore && typeof window.ceresStore.dispatch === 'function') return window.ceresStore;
+
+    return null;
+  }
+
+  function resolveStoreAction(store, actionNames) {
+    if (!store || !store._actions) return null;
+
+    for (let index = 0; index < actionNames.length; index += 1) {
+      const name = actionNames[index];
+
+      if (store._actions[name]) return name;
+    }
+
+    return null;
+  }
+
+  function refreshWishList() {
+    const store = getVueStore();
+
+    if (!store) return;
+
+    const actionName = resolveStoreAction(store, ['wishList/initWishListItems', 'initWishListItems']);
+
+    if (!actionName) return;
+
+    try {
+      const result = store.dispatch(actionName);
+
+      if (result && typeof result.catch === 'function') result.catch(function () {});
+    } catch (error) {
+      /* Ignore dispatch errors in the custom integration to avoid breaking the UI. */
+    }
+  }
+
+  function openMenu() {
+    if (isOpen) return;
+
+    refreshWishList();
+    menu.style.display = 'block';
+    menu.setAttribute('aria-hidden', 'false');
+    toggleButton.setAttribute('aria-expanded', 'true');
+    document.addEventListener('click', handleDocumentClick);
+    document.addEventListener('keydown', handleKeydown);
+    isOpen = true;
+  }
+
+  function closeMenu() {
+    if (!isOpen) return;
+
+    menu.style.display = 'none';
+    menu.setAttribute('aria-hidden', 'true');
+    toggleButton.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('click', handleDocumentClick);
+    document.removeEventListener('keydown', handleKeydown);
+    isOpen = false;
+  }
+
+  function handleDocumentClick(event) {
+    if (!container.contains(event.target)) closeMenu();
+  }
+
+  function handleKeydown(event) {
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      closeMenu();
+      toggleButton.focus();
+    }
+  }
+
+  toggleButton.addEventListener('click', function (event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (isOpen) closeMenu(); else {
+      openMenu();
+    }
+  });
+
+  document.addEventListener('sh:wishlist-refresh', refreshWishList);
+});
+// End Section: sh wishlist menu toggle behaviour
+
+
 // Section: sh account page navigation
 shOnReady(function () {
   const nav = document.querySelector('[data-sh-account-nav]');

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -935,9 +935,10 @@ shOnReady(function () {
           const actionType = String(action.type);
           const isWishListAction = actionType.indexOf('wishList') !== -1 || actionType.indexOf('WishList') !== -1;
           const isWishListChange = /add|remove/i.test(actionType);
+          const isDirectWishListAction = /addToWishList|removeWishListItem/i.test(actionType);
 
-          if (isWishListAction && isWishListChange) {
-            window.setTimeout(refreshWishList, 50);
+          if ((isWishListAction && isWishListChange) || isDirectWishListAction) {
+            window.setTimeout(refreshWishList, 120);
           }
         },
       });

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -880,6 +880,7 @@ shOnReady(function () {
   if (!toggleButton || !menu) return;
 
   let isOpen = false;
+  let hasInstalledSubscription = false;
 
   function getVueStore() {
     if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
@@ -919,9 +920,44 @@ shOnReady(function () {
     }
   }
 
+  function installWishListSubscription() {
+    if (hasInstalledSubscription) return;
+
+    const store = getVueStore();
+
+    if (!store || typeof store.subscribeAction !== 'function') return;
+
+    try {
+      store.subscribeAction({
+        after: function (action) {
+          if (!action || !action.type) return;
+
+          if (action.type.indexOf('addToWishList') !== -1) refreshWishList();
+        },
+      });
+      hasInstalledSubscription = true;
+    } catch (error) {
+      /* Ignore subscription errors to avoid breaking the UI. */
+    }
+  }
+
+  function scheduleWishListSubscription() {
+    let attempts = 0;
+    const maxAttempts = 20;
+    const intervalId = window.setInterval(function () {
+      attempts += 1;
+      installWishListSubscription();
+
+      if (hasInstalledSubscription || attempts >= maxAttempts) {
+        window.clearInterval(intervalId);
+      }
+    }, 500);
+  }
+
   function openMenu() {
     if (isOpen) return;
 
+    installWishListSubscription();
     refreshWishList();
     menu.style.display = 'block';
     menu.setAttribute('aria-hidden', 'false');
@@ -962,6 +998,7 @@ shOnReady(function () {
     }
   });
 
+  scheduleWishListSubscription();
   document.addEventListener('sh:wishlist-refresh', refreshWishList);
 });
 // End Section: sh wishlist menu toggle behaviour

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1032,6 +1032,8 @@ a.logo {
   border-radius: 50%;
   background-color: var(--sh-color-primary-red);
   color: #ffffff;
+  opacity: 1 !important;
+  visibility: visible !important;
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.3px;
@@ -2625,6 +2627,8 @@ div.grecaptcha-badge {
     height: 18px;
     padding: 0;
     border-radius: 50%;
+    opacity: 1 !important;
+    visibility: visible !important;
     font-size: 10px;
   }
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1040,6 +1040,15 @@ a.logo {
   line-height: 1;
 }
 
+.sh-header__badge wish-list-count,
+.sh-header__badge wish-list-count > * {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
 .sh-header__panel {
   position: absolute;
   top: calc(100% + 16px);
@@ -2630,6 +2639,15 @@ div.grecaptcha-badge {
     opacity: 1 !important;
     visibility: visible !important;
     font-size: 10px;
+  }
+
+  .sh-header__badge wish-list-count,
+  .sh-header__badge wish-list-count > * {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 1 !important;
+    visibility: visible !important;
   }
 
   .sh-header__basket {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1026,10 +1026,10 @@ a.logo {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 20px;
+  width: 20px;
   height: 20px;
-  padding: 0 6px;
-  border-radius: 999px;
+  padding: 0;
+  border-radius: 50%;
   background-color: var(--sh-color-primary-red);
   color: #ffffff;
   font-size: 11px;
@@ -2621,8 +2621,10 @@ div.grecaptcha-badge {
   }
 
   .sh-header__badge {
-    min-width: 18px;
+    width: 18px;
     height: 18px;
+    padding: 0;
+    border-radius: 50%;
     font-size: 10px;
   }
 


### PR DESCRIPTION
### Motivation

- Expose the existing Ceres wishlist in the custom FH and SH headers so customers can see and open their wishlist from the header.  
- Reuse Ceres UI and store logic (`wish-list-count`, `wish-list`, `WishListModule` actions) to avoid duplicating wishlist state handling.  
- Ensure wishlist item details are loaded when the header panel opens because `addToWishList` only stores IDs.

### Description

- Added a wishlist button + panel to the FH header in `Header/FH-Header.html` and to the SH header in `Header/SH-Header.html` using the same ARIA/toggle pattern as the account dropdown and the translated label `Ceres::Template.wishList`.  
- The header uses the existing Ceres counter component via `<wish-list-count>` and renders the list with `<wish-list>` inside the panel.  
- Added toggle logic in `JavaScript im Head/FH - JS im Head.js` and `JavaScript im Head/SH - JS im Head.js` that mirrors the account panel behavior, resolves the Vuex action name and dispatches `wishList/initWishListItems` (or `initWishListItems`) when the wishlist panel is opened, and gracefully ignores dispatch errors.  
- Registered custom refresh events (`fh:wishlist-refresh` / `sh:wishlist-refresh`) to allow external triggers to reload wishlist items when needed.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf10a293c8331857393029f8ac9d0)