### PR TITLE
Force wishlist counter to remain visible in FH/SH headers

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1034,7 +1034,7 @@ a.logo {
 
 .fh-header__badge wish-list-count,
 .fh-header__badge wish-list-count > * {
-  display: flex;
+  display: flex !important;
   align-items: center;
   justify-content: center;
   opacity: 1 !important;
@@ -2662,7 +2662,7 @@ div.grecaptcha-badge {
 
   .fh-header__badge wish-list-count,
   .fh-header__badge wish-list-count > * {
-    display: flex;
+    display: flex !important;
     align-items: center;
     justify-content: center;
     opacity: 1 !important;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1042,7 +1042,7 @@ a.logo {
 
 .sh-header__badge wish-list-count,
 .sh-header__badge wish-list-count > * {
-  display: flex;
+  display: flex !important;
   align-items: center;
   justify-content: center;
   opacity: 1 !important;
@@ -2643,7 +2643,7 @@ div.grecaptcha-badge {
 
   .sh-header__badge wish-list-count,
   .sh-header__badge wish-list-count > * {
-    display: flex;
+    display: flex !important;
     align-items: center;
     justify-content: center;
     opacity: 1 !important;


### PR DESCRIPTION
### Motivation
- The wishlist item counter badge was only visible on hover due to conflicting/inherited CSS, so it must be forced visible across header styles and breakpoints.

### Description
- Added `display: flex !important;` to `.fh-header__badge wish-list-count` in `FH - Stylesheets.css` for desktop and responsive blocks to ensure the inner counter is always rendered.
- Added `display: flex !important;` to `.sh-header__badge wish-list-count` in `SH - Stylesheets.css` for desktop and responsive blocks to ensure the inner counter is always rendered.
- The change targets only the badge inner element so visual layout and other header behavior remain unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696de369a3ec8331bbc0897905e2e130)