### PR TITLE
Always show wishlist counter badge in headers

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1032,6 +1032,20 @@ a.logo {
   line-height: 1;
 }
 
+.fh-header__icon-button .fh-header__badge {
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: none !important;
+}
+
+.fh-header__icon-button .fh-header__badge wish-list-count,
+.fh-header__icon-button .fh-header__badge wish-list-count > * {
+  display: flex !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: none !important;
+}
+
 .fh-header__badge wish-list-count,
 .fh-header__badge wish-list-count > * {
   display: flex;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1040,6 +1040,20 @@ a.logo {
   line-height: 1;
 }
 
+.sh-header__icon-button .sh-header__badge {
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: none !important;
+}
+
+.sh-header__icon-button .sh-header__badge wish-list-count,
+.sh-header__icon-button .sh-header__badge wish-list-count > * {
+  display: flex !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: none !important;
+}
+
 .sh-header__badge wish-list-count,
 .sh-header__badge wish-list-count > * {
   display: flex;


### PR DESCRIPTION
### Motivation
- The wishlist counter badge was only visible on hover due to existing stylesheet rules, so the counter must be forced visible at all times in both FH and SH headers.

### Description
- Add stronger CSS rules in `FH - Stylesheets.css` and `SH - Stylesheets.css` (selectors like `.fh-header__icon-button .fh-header__badge` / `.sh-header__icon-button .sh-header__badge` and their `wish-list-count` children) to force `opacity`, `visibility`, `display` and remove transform so the badge and its contents are always shown.

### Testing
- No automated tests were run for this change because it is a CSS-only visual fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696de369a3ec8331bbc0897905e2e130)