### PR TITLE
Always show wishlist counter in FH and SH headers

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1032,16 +1032,21 @@ a.logo {
 
 .fh-header__badge wish-list-count,
 .fh-header__badge wish-list-count > * {
-  display: flex;
+  display: inline-flex !important;
   align-items: center;
   justify-content: center;
 }
 
 .fh-wishlist-menu-container wish-list-count,
 .fh-wishlist-menu-container wish-list-count * {
-  display: inline-flex !important;
-  align-items: center;
-  justify-content: center;
+  opacity: 1 !important;
+  visibility: visible !important;
+  color: inherit !important;
+  font-size: inherit !important;
+}
+
+.fh-header__badge,
+.fh-header__badge * {
   opacity: 1 !important;
   visibility: visible !important;
 }

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1024,8 +1024,6 @@ a.logo {
   border-radius: 50%;
   background-color: var(--fh-color-bright-blue);
   color: #ffffff;
-  opacity: 1 !important;
-  visibility: visible !important;
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.3px;
@@ -1035,6 +1033,13 @@ a.logo {
 .fh-header__badge wish-list-count,
 .fh-header__badge wish-list-count > * {
   display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.fh-wishlist-menu-container wish-list-count,
+.fh-wishlist-menu-container wish-list-count * {
+  display: inline-flex !important;
   align-items: center;
   justify-content: center;
   opacity: 1 !important;
@@ -2655,8 +2660,6 @@ div.grecaptcha-badge {
     height: 18px;
     padding: 0;
     border-radius: 50%;
-    opacity: 1 !important;
-    visibility: visible !important;
     font-size: 10px;
   }
 
@@ -2665,8 +2668,6 @@ div.grecaptcha-badge {
     display: flex;
     align-items: center;
     justify-content: center;
-    opacity: 1 !important;
-    visibility: visible !important;
   }
 
   .fh-header__basket {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1032,8 +1032,6 @@ a.logo {
   border-radius: 50%;
   background-color: var(--sh-color-primary-red);
   color: #ffffff;
-  opacity: 1 !important;
-  visibility: visible !important;
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.3px;
@@ -1043,6 +1041,13 @@ a.logo {
 .sh-header__badge wish-list-count,
 .sh-header__badge wish-list-count > * {
   display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sh-wishlist-menu-container wish-list-count,
+.sh-wishlist-menu-container wish-list-count * {
+  display: inline-flex !important;
   align-items: center;
   justify-content: center;
   opacity: 1 !important;
@@ -2636,8 +2641,6 @@ div.grecaptcha-badge {
     height: 18px;
     padding: 0;
     border-radius: 50%;
-    opacity: 1 !important;
-    visibility: visible !important;
     font-size: 10px;
   }
 
@@ -2646,8 +2649,6 @@ div.grecaptcha-badge {
     display: flex;
     align-items: center;
     justify-content: center;
-    opacity: 1 !important;
-    visibility: visible !important;
   }
 
   .sh-header__basket {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1040,16 +1040,21 @@ a.logo {
 
 .sh-header__badge wish-list-count,
 .sh-header__badge wish-list-count > * {
-  display: flex;
+  display: inline-flex !important;
   align-items: center;
   justify-content: center;
 }
 
 .sh-wishlist-menu-container wish-list-count,
 .sh-wishlist-menu-container wish-list-count * {
-  display: inline-flex !important;
-  align-items: center;
-  justify-content: center;
+  opacity: 1 !important;
+  visibility: visible !important;
+  color: inherit !important;
+  font-size: inherit !important;
+}
+
+.sh-header__badge,
+.sh-header__badge * {
   opacity: 1 !important;
   visibility: visible !important;
 }


### PR DESCRIPTION
### Motivation
- The wishlist item counter was only visible on hover because existing CSS visibility rules were ineffective and conflicted with the rendered `wish-list-count` element. 
- The goal is to ensure the "Merkliste item counter" text is always visible in both FH and SH headers without relying on hover state. 

### Description
- Removed the redundant `opacity`/`visibility` overrides from the `.fh-header__badge` and `.sh-header__badge` rules to avoid conflicting declarations. 
- Added explicit selectors ` .fh-wishlist-menu-container wish-list-count, .fh-wishlist-menu-container wish-list-count *` and ` .sh-wishlist-menu-container wish-list-count, .sh-wishlist-menu-container wish-list-count *` that force `display: inline-flex !important;` and `opacity: 1 !important; visibility: visible !important;` so the counter is always shown. 
- Applied the same changes to both `FH - Stylesheets.css` and `SH - Stylesheets.css` to keep both shops synchronized. 

### Testing
- No automated tests were run because this is a CSS-only change and there is no frontend test harness in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696de58b44ac83319ee85246f1371902)