### PR TITLE
Fix wishlist badge visibility in FH and SH headers

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1032,11 +1032,9 @@ a.logo {
   line-height: 1;
 }
 
-.fh-header__badge wish-list-count,
-.fh-header__badge wish-list-count > * {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.fh-header__icon-button .fh-header__badge wish-list-count .badge-right,
+.fh-header__icon-button .fh-header__badge wish-list-count .count {
+  display: inline-flex !important;
   opacity: 1 !important;
   visibility: visible !important;
 }
@@ -2660,14 +2658,6 @@ div.grecaptcha-badge {
     font-size: 10px;
   }
 
-  .fh-header__badge wish-list-count,
-  .fh-header__badge wish-list-count > * {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    opacity: 1 !important;
-    visibility: visible !important;
-  }
 
   .fh-header__basket {
     justify-self: auto;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1040,11 +1040,9 @@ a.logo {
   line-height: 1;
 }
 
-.sh-header__badge wish-list-count,
-.sh-header__badge wish-list-count > * {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.sh-header__icon-button .sh-header__badge wish-list-count .badge-right,
+.sh-header__icon-button .sh-header__badge wish-list-count .count {
+  display: inline-flex !important;
   opacity: 1 !important;
   visibility: visible !important;
 }
@@ -2641,14 +2639,6 @@ div.grecaptcha-badge {
     font-size: 10px;
   }
 
-  .sh-header__badge wish-list-count,
-  .sh-header__badge wish-list-count > * {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    opacity: 1 !important;
-    visibility: visible !important;
-  }
 
   .sh-header__basket {
     justify-self: auto;


### PR DESCRIPTION
### Motivation
- The previous selectors targeted the `wish-list-count` custom element directly (e.g. `.fh-header__badge wish-list-count`) which did not match the actual rendered DOM inside the component and therefore the counter text stayed hidden. 
- The Vue component renders a `span.badge-right` for the counter, so CSS must target that rendered element to make the Merkliste counter visible on desktop and mobile.

### Description
- Removed the ineffective selectors ` .fh-header__badge wish-list-count` and ` .sh-header__badge wish-list-count` and their mobile duplicates from `FH - Stylesheets.css` and `SH - Stylesheets.css`. 
- Added high-specificity overrides that target the rendered element inside the Ceres component with selectors ` .fh-header__icon-button .fh-header__badge wish-list-count .badge-right, .fh-header__icon-button .fh-header__badge wish-list-count .count` and the equivalent `sh-` selectors. 
- The new rules force `display: inline-flex; opacity: 1; visibility: visible;` (using `!important` for `display` and visibility flags) so the wishlist counter text is visible without hover across breakpoints.

### Testing
- No automated tests were run for this change because it is a CSS-only visual fix; visual verification in a browser at desktop and mobile breakpoints is recommended to confirm the Merkliste counter is visible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696de91e95148331b2df585ee37ba1a5)