### PR TITLE
Fix wishlist count badge visibility in FH and SH headers

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1041,6 +1041,25 @@ a.logo {
   visibility: visible !important;
 }
 
+.fh-header__icon-button wish-list-count .nav-link .badge-right {
+  display: inline-flex !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  color: #fff !important;
+}
+
+.fh-header__icon-button wish-list-count .nav-link:hover .badge-right {
+  display: inline-flex !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  color: #fff !important;
+}
+
+.fh-header__icon-button wish-list-count .nav-link .fa-heart,
+.fh-header__icon-button wish-list-count .nav-link .fa-heart-o {
+  display: none !important;
+}
+
 .fh-header__panel {
   position: absolute;
   top: calc(100% + 16px);
@@ -2667,6 +2686,25 @@ div.grecaptcha-badge {
     justify-content: center;
     opacity: 1 !important;
     visibility: visible !important;
+  }
+
+  .fh-header__icon-button wish-list-count .nav-link .badge-right {
+    display: inline-flex !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+    color: #fff !important;
+  }
+
+  .fh-header__icon-button wish-list-count .nav-link:hover .badge-right {
+    display: inline-flex !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+    color: #fff !important;
+  }
+
+  .fh-header__icon-button wish-list-count .nav-link .fa-heart,
+  .fh-header__icon-button wish-list-count .nav-link .fa-heart-o {
+    display: none !important;
   }
 
   .fh-header__basket {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1049,6 +1049,25 @@ a.logo {
   visibility: visible !important;
 }
 
+.sh-header__icon-button wish-list-count .nav-link .badge-right {
+  display: inline-flex !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  color: #fff !important;
+}
+
+.sh-header__icon-button wish-list-count .nav-link:hover .badge-right {
+  display: inline-flex !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  color: #fff !important;
+}
+
+.sh-header__icon-button wish-list-count .nav-link .fa-heart,
+.sh-header__icon-button wish-list-count .nav-link .fa-heart-o {
+  display: none !important;
+}
+
 .sh-header__panel {
   position: absolute;
   top: calc(100% + 16px);
@@ -2648,6 +2667,25 @@ div.grecaptcha-badge {
     justify-content: center;
     opacity: 1 !important;
     visibility: visible !important;
+  }
+
+  .sh-header__icon-button wish-list-count .nav-link .badge-right {
+    display: inline-flex !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+    color: #fff !important;
+  }
+
+  .sh-header__icon-button wish-list-count .nav-link:hover .badge-right {
+    display: inline-flex !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+    color: #fff !important;
+  }
+
+  .sh-header__icon-button wish-list-count .nav-link .fa-heart,
+  .sh-header__icon-button wish-list-count .nav-link .fa-heart-o {
+    display: none !important;
   }
 
   .sh-header__basket {


### PR DESCRIPTION
### Motivation
- Ceres’ wishlist counter can be hidden by hover-only rules which makes the wishlist count inconsistent with the always-visible basket counter. 
- The header badges for both FH and SH must show the numeric count at all times and the number must remain readable inside the colored badge. 
- Changes must target both shop variants (FH and SH) so the behaviour remains synchronized across stores.

### Description
- Added stronger CSS overrides in `FH - Stylesheets.css` and `SH - Stylesheets.css` that target the Ceres markup for the wishlist widget (e.g. `... wish-list-count .nav-link .badge-right`).
- The overrides force `display: inline-flex !important`, `opacity: 1 !important`, `visibility: visible !important` and `color: #fff !important` so the counter is always visible and readable. 
- Neutralized hover-only visibility rules by adding matching `:hover` selectors with the same strong declarations. 
- Hid the heart icon inside the wishlist badge by forcing `.fa-heart` and `.fa-heart-o` to `display: none !important` so only the numeric counter is shown.

### Testing
- No automated tests were executed for this change because it is a CSS-only visual fix. 
- Changes were committed to `FH - Stylesheets.css` and `SH - Stylesheets.css` and are ready for visual verification in a running storefront (manual browser/devtools check recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e140cdfec8331a5d0dd6f362f718a)