### PR TITLE
Add wishlist count badges to FH/SH headers

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1023,7 +1023,7 @@ a.logo {
   padding: 0;
   border-radius: 50%;
   background-color: var(--fh-color-bright-blue);
-  color: #ffffff;
+  color: #000000;
   opacity: 1 !important;
   visibility: visible !important;
   font-size: 11px;

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1041,6 +1041,17 @@ a.logo {
   visibility: visible !important;
 }
 
+.fh-header__badge .nav-link,
+.fh-header__badge .badge-right,
+.fh-header__badge .badge-right.d-none {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  color: #000000;
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
 .fh-header__panel {
   position: absolute;
   top: calc(100% + 16px);

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -48,6 +48,9 @@
     </div>
     <div class="fh-header__actions">
       <a href="/wish-list" aria-label="{{ trans('Ceres::Template.wishList') }}" class="fh-header__icon-button">
+        <span class="fh-header__badge" aria-hidden="true">
+          <wish-list-count></wish-list-count>
+        </span>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="fh-header__icon">
           <path d="M7 4h10a1 1 0 0 1 1 1v15l-6-3-6 3V5a1 1 0 0 1 1-1z"></path>
         </svg>

--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -48,6 +48,9 @@
     </div>
     <div class="sh-header__actions">
       <a href="/wish-list" aria-label="{{ trans('Ceres::Template.wishList') }}" class="sh-header__icon-button">
+        <span class="sh-header__badge" aria-hidden="true">
+          <wish-list-count></wish-list-count>
+        </span>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" class="sh-header__icon">
           <path d="M7 4h10a1 1 0 0 1 1 1v15l-6-3-6 3V5a1 1 0 0 1 1-1z"></path>
         </svg>

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1049,6 +1049,17 @@ a.logo {
   visibility: visible !important;
 }
 
+.sh-header__badge .nav-link,
+.sh-header__badge .badge-right,
+.sh-header__badge .badge-right.d-none {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  color: #000000;
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
 .sh-header__panel {
   position: absolute;
   top: calc(100% + 16px);

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1031,7 +1031,7 @@ a.logo {
   padding: 0;
   border-radius: 50%;
   background-color: var(--sh-color-primary-red);
-  color: #ffffff;
+  color: #000000;
   opacity: 1 !important;
   visibility: visible !important;
   font-size: 11px;


### PR DESCRIPTION
### Motivation

- Provide a visible notification bubble for the wishlist (Merkliste) in both FH and SH headers using the same live-update approach used for the basket counter so users immediately see the number of saved items.

### Description

- Inserted a badge wrapper with the existing `<wish-list-count>` hook into the wishlist button in `Header/FH-Header.html` and `Header/SH-Header.html` so the component updates automatically on add/remove actions.
- Kept the brand background colors and forced the badge text color to black by changing `.fh-header__badge` and `.sh-header__badge` to `color: #000000;` in `FH - Stylesheets.css` and `SH - Stylesheets.css` so the number remains readable on hover and non-hover.
- Ensured the badge remains visible by keeping the existing `opacity`/`visibility` overrides used for status badges, so the counter is always shown similarly to the basket counter.

### Testing

- No automated tests were run; changes are static template and CSS updates only.
- Manual verification recommended in a running storefront to confirm the `<wish-list-count>` updates on add/remove and that styling matches the basket counter behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e15a2f2dc8331a63256ad1b1aef9d)