### PR TITLE
Hide PayPal smart buttons when product availability id is 0

### DIFF
--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -2677,7 +2677,23 @@ fhOnReady(function () {
     return null;
   }
 
-  function applyAvailabilityUi(isSalable) {
+  function resolveAvailabilityId(state) {
+    const variation = state && state.item ? state.item.variation : null;
+
+    if (!variation || typeof variation.availability !== 'object') return null;
+
+    const availabilityId = variation.availability.id;
+
+    return typeof availabilityId === 'number' ? availabilityId : null;
+  }
+
+  function updatePaypalSmartButtons(shouldHide) {
+    document.querySelectorAll('.paypal-smart-button').forEach(function (button) {
+      button.style.display = shouldHide ? 'none' : '';
+    });
+  }
+
+  function applyAvailabilityUi(isSalable, availabilityId) {
     const availabilityText = document.querySelector(availabilityTextSelector);
     const availabilityIcon = document.querySelector('#kjvItemAvailabilityIcon, .availability .availability-icon, [data-testing="availability-icon"]');
     const availabilityContainer = document.querySelector(availabilityContainerSelector);
@@ -2706,6 +2722,10 @@ fhOnReady(function () {
     const countdown = document.getElementById('cutoff-countdown');
 
     if (countdown) countdown.style.display = isSalable ? '' : 'none';
+
+    if (typeof availabilityId === 'number') {
+      updatePaypalSmartButtons(availabilityId === 0);
+    }
   }
 
   function bootstrapAvailabilityWatcher() {
@@ -2720,10 +2740,11 @@ fhOnReady(function () {
       const isSalable = resolveIsSalable(store.state);
       const domSalable = resolveIsSalableFromText();
       const resolved = typeof isSalable === 'boolean' ? isSalable : domSalable;
+      const availabilityId = resolveAvailabilityId(store.state);
 
       if (resolved === null) return;
 
-      applyAvailabilityUi(resolved);
+      applyAvailabilityUi(resolved, availabilityId);
     }, { immediate: true, deep: true });
   }
 

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -2637,7 +2637,23 @@ shOnReady(function () {
     return null;
   }
 
-  function applyAvailabilityUi(isSalable) {
+  function resolveAvailabilityId(state) {
+    const variation = state && state.item ? state.item.variation : null;
+
+    if (!variation || typeof variation.availability !== 'object') return null;
+
+    const availabilityId = variation.availability.id;
+
+    return typeof availabilityId === 'number' ? availabilityId : null;
+  }
+
+  function updatePaypalSmartButtons(shouldHide) {
+    document.querySelectorAll('.paypal-smart-button').forEach(function (button) {
+      button.style.display = shouldHide ? 'none' : '';
+    });
+  }
+
+  function applyAvailabilityUi(isSalable, availabilityId) {
     const availabilityText = document.querySelector(availabilityTextSelector);
     const availabilityIcon = document.querySelector('#kjvItemAvailabilityIcon, .availability .availability-icon, [data-testing="availability-icon"]');
     const availabilityContainer = document.querySelector(availabilityContainerSelector);
@@ -2666,6 +2682,10 @@ shOnReady(function () {
     const countdown = document.getElementById('cutoff-countdown');
 
     if (countdown) countdown.style.display = isSalable ? '' : 'none';
+
+    if (typeof availabilityId === 'number') {
+      updatePaypalSmartButtons(availabilityId === 0);
+    }
   }
 
   function bootstrapAvailabilityWatcher() {
@@ -2680,10 +2700,11 @@ shOnReady(function () {
       const isSalable = resolveIsSalable(store.state);
       const domSalable = resolveIsSalableFromText();
       const resolved = typeof isSalable === 'boolean' ? isSalable : domSalable;
+      const availabilityId = resolveAvailabilityId(store.state);
 
       if (resolved === null) return;
 
-      applyAvailabilityUi(resolved);
+      applyAvailabilityUi(resolved, availabilityId);
     }, { immediate: true, deep: true });
   }
 


### PR DESCRIPTION
### Motivation
- Prevent the PayPal smart button from being shown on product pages where the backend availability indicates the item is unavailable (`availability.id === 0`) and keep behavior consistent across both FH and SH shop scripts.

### Description
- Added `resolveAvailabilityId(state)` to extract `availability.id` from the Vue store state. 
- Added `updatePaypalSmartButtons(shouldHide)` which toggles `.paypal-smart-button` elements via `style.display`. 
- Modified `applyAvailabilityUi` to accept an `availabilityId` parameter and hide PayPal buttons when `availabilityId === 0`. 
- Applied the changes in both `JavaScript im Head/FH - JS im Head.js` and `JavaScript im Head/SH - JS im Head.js`, and wired the availability id into the existing store watcher.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e35324adc8331b75c6c941768ea80)