### PR TITLE
Hide #smart when item is sold out

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -194,8 +194,13 @@ div.external-brand-logo img {
   color: rgb(153, 27, 27);
 }
 
-#kjvItemAvailabilityText.is-sold-out + #smart.paypal-smart-button,
-#kjvItemAvailabilityText.is-sold-out ~ #smart.paypal-smart-button {
+#kjvItemAvailabilityText.is-sold-out:has(+ #smart.paypal-smart-button),
+#kjvItemAvailabilityText.is-sold-out:has(~ #smart.paypal-smart-button) {
+  display: none !important;
+}
+
+#kjvItemAvailabilityText.is-sold-out:has(+ #smart.paypal-smart-button) + #smart.paypal-smart-button,
+#kjvItemAvailabilityText.is-sold-out:has(~ #smart.paypal-smart-button) ~ #smart.paypal-smart-button {
   display: none !important;
 }
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -194,8 +194,8 @@ div.external-brand-logo img {
   color: rgb(153, 27, 27);
 }
 
-#kjvItemAvailabilityText.is-sold-out + #smart,
-#kjvItemAvailabilityText.is-sold-out ~ #smart {
+#kjvItemAvailabilityText.is-sold-out + #smart.paypal-smart-button,
+#kjvItemAvailabilityText.is-sold-out ~ #smart.paypal-smart-button {
   display: none !important;
 }
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -194,6 +194,11 @@ div.external-brand-logo img {
   color: rgb(153, 27, 27);
 }
 
+#kjvItemAvailabilityText.is-sold-out + #smart,
+#kjvItemAvailabilityText.is-sold-out ~ #smart {
+  display: none !important;
+}
+
 #kjvItemAvailabilityIcon {
   display: none !important;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -197,6 +197,11 @@ div.external-brand-logo img {
   color: rgb(153, 27, 27);
 }
 
+#kjvItemAvailabilityText.is-sold-out + #smart,
+#kjvItemAvailabilityText.is-sold-out ~ #smart {
+  display: none !important;
+}
+
 #kjvItemAvailabilityIcon {
   display: none !important;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -197,8 +197,8 @@ div.external-brand-logo img {
   color: rgb(153, 27, 27);
 }
 
-#kjvItemAvailabilityText.is-sold-out + #smart,
-#kjvItemAvailabilityText.is-sold-out ~ #smart {
+#kjvItemAvailabilityText.is-sold-out + #smart.paypal-smart-button,
+#kjvItemAvailabilityText.is-sold-out ~ #smart.paypal-smart-button {
   display: none !important;
 }
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -197,8 +197,13 @@ div.external-brand-logo img {
   color: rgb(153, 27, 27);
 }
 
-#kjvItemAvailabilityText.is-sold-out + #smart.paypal-smart-button,
-#kjvItemAvailabilityText.is-sold-out ~ #smart.paypal-smart-button {
+#kjvItemAvailabilityText.is-sold-out:has(+ #smart.paypal-smart-button),
+#kjvItemAvailabilityText.is-sold-out:has(~ #smart.paypal-smart-button) {
+  display: none !important;
+}
+
+#kjvItemAvailabilityText.is-sold-out:has(+ #smart.paypal-smart-button) + #smart.paypal-smart-button,
+#kjvItemAvailabilityText.is-sold-out:has(~ #smart.paypal-smart-button) ~ #smart.paypal-smart-button {
   display: none !important;
 }
 


### PR DESCRIPTION
### Motivation
- Hide `#smart` element when `#kjvItemAvailabilityText` is marked `.is-sold-out` to avoid showing irrelevant UI for sold-out products.

### Description
- Added CSS rules to `FH - Stylesheets.css` and `SH - Stylesheets.css` using `#kjvItemAvailabilityText.is-sold-out + #smart` and `#kjvItemAvailabilityText.is-sold-out ~ #smart` to apply `display: none !important` to `#smart`.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e37375d508331847570232f5b5873)