### PR TITLE
Remove header wishlist hover color and style product wishlist button (FH & SH)

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1000,6 +1000,12 @@ a.logo {
   transition: all 0.2s ease;
 }
 
+.fh-header__actions > .fh-header__icon-button:hover,
+.fh-header__actions > .fh-header__icon-button:focus-visible {
+  color: #1a1a1a;
+  text-decoration: none;
+}
+
 .fh-header__status-indicator {
   position: absolute;
   top: -6px;
@@ -3670,6 +3676,57 @@ button[data-testing="quantity-btn-decrease"] {
   display: none !important;
 }
 /* End Section: Icon Visibility Adjustments */
+
+/* Section: Wishlist button styling */
+.widget-add-to-wish-list .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border: 1px solid #d9d9d9;
+  border-radius: 10px;
+  background-color: #ffffff;
+  color: #1a1a1a;
+  font-weight: 600;
+  text-decoration: none;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.widget-add-to-wish-list .btn::before {
+  content: "";
+  width: 18px;
+  height: 18px;
+  display: inline-block;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='black'%20stroke-width='1.6'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
+  mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='black'%20stroke-width='1.6'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
+}
+
+.widget-add-to-wish-list .btn:hover,
+.widget-add-to-wish-list .btn:focus-visible {
+  border-color: #cbd5e1;
+  background-color: #f8fafc;
+  color: #111827;
+  text-decoration: none;
+}
+
+.widget-add-to-wish-list .btn.is-active,
+.widget-add-to-wish-list .btn.active,
+.widget-add-to-wish-list .btn[aria-pressed="true"],
+.widget-add-to-wish-list .btn[data-original-title*="entfernen"] {
+  border-color: #9ca3af;
+  background-color: #f1f5f9;
+  color: #111827;
+}
+
+.widget-add-to-wish-list .btn.is-active::before,
+.widget-add-to-wish-list .btn.active::before,
+.widget-add-to-wish-list .btn[aria-pressed="true"]::before,
+.widget-add-to-wish-list .btn[data-original-title*="entfernen"]::before {
+  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
+  mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
+}
+/* End Section: Wishlist button styling */
 
 /* Section: Temporary hidden blocks until external functions added */
 .fh-header__price-toggle,

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1008,6 +1008,12 @@ a.logo {
   transition: all 0.2s ease;
 }
 
+.sh-header__actions > .sh-header__icon-button:hover,
+.sh-header__actions > .sh-header__icon-button:focus-visible {
+  color: #1a1a1a;
+  text-decoration: none;
+}
+
 .sh-header__status-indicator {
   position: absolute;
   top: -6px;
@@ -3643,6 +3649,57 @@ button[data-testing="quantity-btn-decrease"] {
   display: none !important;
 }
 /* End Section: Icon Visibility Adjustments */
+
+/* Section: Wishlist button styling */
+.widget-add-to-wish-list .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border: 1px solid #d9d9d9;
+  border-radius: 10px;
+  background-color: #ffffff;
+  color: #1a1a1a;
+  font-weight: 600;
+  text-decoration: none;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.widget-add-to-wish-list .btn::before {
+  content: "";
+  width: 18px;
+  height: 18px;
+  display: inline-block;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='black'%20stroke-width='1.6'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
+  mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%20fill='none'%20stroke='black'%20stroke-width='1.6'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
+}
+
+.widget-add-to-wish-list .btn:hover,
+.widget-add-to-wish-list .btn:focus-visible {
+  border-color: #cbd5e1;
+  background-color: #f8fafc;
+  color: #111827;
+  text-decoration: none;
+}
+
+.widget-add-to-wish-list .btn.is-active,
+.widget-add-to-wish-list .btn.active,
+.widget-add-to-wish-list .btn[aria-pressed="true"],
+.widget-add-to-wish-list .btn[data-original-title*="entfernen"] {
+  border-color: #9ca3af;
+  background-color: #f1f5f9;
+  color: #111827;
+}
+
+.widget-add-to-wish-list .btn.is-active::before,
+.widget-add-to-wish-list .btn.active::before,
+.widget-add-to-wish-list .btn[aria-pressed="true"]::before,
+.widget-add-to-wish-list .btn[data-original-title*="entfernen"]::before {
+  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
+  mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
+}
+/* End Section: Wishlist button styling */
 
 /* Section: Temporary hidden blocks until external functions added */
 .sh-header__price-toggle,


### PR DESCRIPTION
### Motivation
- The header wishlist icon currently changes to a blue hover color which conflicts with the header visual design and must remain neutral. 
- The product-page wishlist control should visually match the header bookmark icon and clearly show outline (not saved) vs filled (saved) states with a border that fits the site style.

### Description
- Updated `FH - Stylesheets.css` and `SH - Stylesheets.css` to suppress hover/focus color changes on header icon buttons by adding `.fh-header__actions > .fh-header__icon-button:hover` and the equivalent `.sh-...` rule to keep icon color stable.  
- Added a `.widget-add-to-wish-list .btn` block in both FH and SH stylesheets to restyle the product wishlist button with inline-flex layout, padding, border, rounded corners, and transitions.  
- Implemented a bookmark glyph via `::before` using SVG data-URIs and `mask`/`-webkit-mask` so the button shows an outline glyph normally and a filled glyph when active (`.is-active`, `.active`, `[aria-pressed=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f227d994c8331bfa5416867b70777)