### PR TITLE
Match shipping icons by label text instead of ShippingProfileID

### DIFF
--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3016,46 +3016,71 @@ fhOnReady(function () {
 
 // Section: Versand Icons ändern & einfügen (läuft auf ALLEN Seiten inkl. Checkout)
 fhOnReady(function () {
-  const shippingIcons = {
-    'ShippingProfileID731': 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/DHLVersand_Icon_D1.png',
-    'ShippingProfileID745': 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/GO_Express_Versand_Icon_D1.1.png',
-    'ShippingProfileID710': 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Selbstabholung_Lager_Versand_Icon_D1.1.png'
-  };
+  const shippingIconRules = [
+    {
+      match: function (labelText) {
+        return labelText.includes('dhl');
+      },
+      src: 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/DHLVersand_Icon_D1.png'
+    },
+    {
+      match: function (labelText) {
+        return labelText.includes('general overnight express') || labelText.includes('go express');
+      },
+      src: 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/GO_Express_Versand_Icon_D1.1.png'
+    },
+    {
+      match: function (labelText) {
+        return labelText.includes('selbstabholung');
+      },
+      src: 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Selbstabholung_Lager_Versand_Icon_D1.1.png'
+    }
+  ];
 
   function applyShippingIcons(root = document) {
     const scope = root && typeof root.querySelectorAll === 'function' ? root : document;
+    const labels = scope.querySelectorAll ? scope.querySelectorAll('.shipping-method-select label.provider-select-label') : [];
 
-    Object.keys(shippingIcons).forEach(function (profileId) {
-      const selector = `label[for="${profileId}"]`;
-      const labels = scope.querySelectorAll ? scope.querySelectorAll(selector) : [];
+    Array.prototype.forEach.call(labels, function (label) {
+      const content = label.querySelector('.content');
+      const labelText = ((content && content.textContent) || label.textContent || '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .toLowerCase();
 
-      Array.prototype.forEach.call(labels, function (label) {
-        const iconContainers = label.querySelectorAll('.icon');
+      if (!labelText) return;
 
-        Array.prototype.forEach.call(iconContainers, function (iconContainer) {
-          const existingIcons = iconContainer.querySelectorAll('.shipping-icon');
+      const matchedRule = shippingIconRules.find(function (rule) {
+        return rule.match(labelText);
+      });
 
-          Array.prototype.forEach.call(existingIcons, function (existingIcon) {
-            if (existingIcon && existingIcon.parentNode) existingIcon.parentNode.removeChild(existingIcon);
-          });
+      if (!matchedRule) return;
 
-          const defaultIcons = iconContainer.querySelectorAll('img:not(.shipping-icon)');
+      const iconContainers = label.querySelectorAll('.icon');
 
-          Array.prototype.forEach.call(defaultIcons, function (defaultIcon) {
-            if (!defaultIcon) return;
+      Array.prototype.forEach.call(iconContainers, function (iconContainer) {
+        const existingIcons = iconContainer.querySelectorAll('.shipping-icon');
 
-            defaultIcon.classList.add('shipping-icon-hidden');
-            defaultIcon.setAttribute('aria-hidden', 'true');
-            defaultIcon.style.display = 'none';
-          });
-
-          const img = document.createElement('img');
-          img.src = shippingIcons[profileId];
-          img.alt = 'Versandart Icon';
-          img.className = 'shipping-icon';
-
-          iconContainer.appendChild(img);
+        Array.prototype.forEach.call(existingIcons, function (existingIcon) {
+          if (existingIcon && existingIcon.parentNode) existingIcon.parentNode.removeChild(existingIcon);
         });
+
+        const defaultIcons = iconContainer.querySelectorAll('img:not(.shipping-icon)');
+
+        Array.prototype.forEach.call(defaultIcons, function (defaultIcon) {
+          if (!defaultIcon) return;
+
+          defaultIcon.classList.add('shipping-icon-hidden');
+          defaultIcon.setAttribute('aria-hidden', 'true');
+          defaultIcon.style.display = 'none';
+        });
+
+        const img = document.createElement('img');
+        img.src = matchedRule.src;
+        img.alt = 'Versandart Icon';
+        img.className = 'shipping-icon';
+
+        iconContainer.appendChild(img);
       });
     });
   }

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3037,16 +3037,21 @@ fhOnReady(function () {
     }
   ];
 
+  function normalizeShippingLabel(text) {
+    return (text || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
   function applyShippingIcons(root = document) {
     const scope = root && typeof root.querySelectorAll === 'function' ? root : document;
     const labels = scope.querySelectorAll ? scope.querySelectorAll('.shipping-method-select label.provider-select-label') : [];
 
     Array.prototype.forEach.call(labels, function (label) {
       const content = label.querySelector('.content');
-      const labelText = ((content && content.textContent) || label.textContent || '')
-        .replace(/\s+/g, ' ')
-        .trim()
-        .toLowerCase();
+      const labelText = normalizeShippingLabel((content && content.textContent) || label.textContent);
 
       if (!labelText) return;
 

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -2997,16 +2997,21 @@ shOnReady(function () {
     }
   ];
 
+  function normalizeShippingLabel(text) {
+    return (text || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
   function applyShippingIcons(root = document) {
     const scope = root && typeof root.querySelectorAll === 'function' ? root : document;
     const labels = scope.querySelectorAll ? scope.querySelectorAll('.shipping-method-select label.provider-select-label') : [];
 
     Array.prototype.forEach.call(labels, function (label) {
       const content = label.querySelector('.content');
-      const labelText = ((content && content.textContent) || label.textContent || '')
-        .replace(/\s+/g, ' ')
-        .trim()
-        .toLowerCase();
+      const labelText = normalizeShippingLabel((content && content.textContent) || label.textContent);
 
       if (!labelText) return;
 

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -2976,46 +2976,71 @@ shOnReady(function () {
 
 // Section: Versand Icons ändern & einfügen (läuft auf ALLEN Seiten inkl. Checkout)
 shOnReady(function () {
-  const shippingIcons = {
-    'ShippingProfileID731': 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/DHLVersand_Icon_D1.png',
-    'ShippingProfileID745': 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/GO_Express_Versand_Icon_D1.1.png',
-    'ShippingProfileID710': 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Selbstabholung_Lager_Versand_Icon_D1.1.png'
-  };
+  const shippingIconRules = [
+    {
+      match: function (labelText) {
+        return labelText.includes('dhl');
+      },
+      src: 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/DHLVersand_Icon_D1.png'
+    },
+    {
+      match: function (labelText) {
+        return labelText.includes('general overnight express') || labelText.includes('go express');
+      },
+      src: 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/GO_Express_Versand_Icon_D1.1.png'
+    },
+    {
+      match: function (labelText) {
+        return labelText.includes('selbstabholung');
+      },
+      src: 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Selbstabholung_Lager_Versand_Icon_D1.1.png'
+    }
+  ];
 
   function applyShippingIcons(root = document) {
     const scope = root && typeof root.querySelectorAll === 'function' ? root : document;
+    const labels = scope.querySelectorAll ? scope.querySelectorAll('.shipping-method-select label.provider-select-label') : [];
 
-    Object.keys(shippingIcons).forEach(function (profileId) {
-      const selector = `label[for="${profileId}"]`;
-      const labels = scope.querySelectorAll ? scope.querySelectorAll(selector) : [];
+    Array.prototype.forEach.call(labels, function (label) {
+      const content = label.querySelector('.content');
+      const labelText = ((content && content.textContent) || label.textContent || '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .toLowerCase();
 
-      Array.prototype.forEach.call(labels, function (label) {
-        const iconContainers = label.querySelectorAll('.icon');
+      if (!labelText) return;
 
-        Array.prototype.forEach.call(iconContainers, function (iconContainer) {
-          const existingIcons = iconContainer.querySelectorAll('.shipping-icon');
+      const matchedRule = shippingIconRules.find(function (rule) {
+        return rule.match(labelText);
+      });
 
-          Array.prototype.forEach.call(existingIcons, function (existingIcon) {
-            if (existingIcon && existingIcon.parentNode) existingIcon.parentNode.removeChild(existingIcon);
-          });
+      if (!matchedRule) return;
 
-          const defaultIcons = iconContainer.querySelectorAll('img:not(.shipping-icon)');
+      const iconContainers = label.querySelectorAll('.icon');
 
-          Array.prototype.forEach.call(defaultIcons, function (defaultIcon) {
-            if (!defaultIcon) return;
+      Array.prototype.forEach.call(iconContainers, function (iconContainer) {
+        const existingIcons = iconContainer.querySelectorAll('.shipping-icon');
 
-            defaultIcon.classList.add('shipping-icon-hidden');
-            defaultIcon.setAttribute('aria-hidden', 'true');
-            defaultIcon.style.display = 'none';
-          });
-
-          const img = document.createElement('img');
-          img.src = shippingIcons[profileId];
-          img.alt = 'Versandart Icon';
-          img.className = 'shipping-icon';
-
-          iconContainer.appendChild(img);
+        Array.prototype.forEach.call(existingIcons, function (existingIcon) {
+          if (existingIcon && existingIcon.parentNode) existingIcon.parentNode.removeChild(existingIcon);
         });
+
+        const defaultIcons = iconContainer.querySelectorAll('img:not(.shipping-icon)');
+
+        Array.prototype.forEach.call(defaultIcons, function (defaultIcon) {
+          if (!defaultIcon) return;
+
+          defaultIcon.classList.add('shipping-icon-hidden');
+          defaultIcon.setAttribute('aria-hidden', 'true');
+          defaultIcon.style.display = 'none';
+        });
+
+        const img = document.createElement('img');
+        img.src = matchedRule.src;
+        img.alt = 'Versandart Icon';
+        img.className = 'shipping-icon';
+
+        iconContainer.appendChild(img);
       });
     });
   }


### PR DESCRIPTION
### Motivation
- Shipping method `id` values are volatile and change over time, so matching by those static `ShippingProfileID*` attributes is brittle.  
- The label text for each method is stable, so use it as the selector to reliably apply shipping icons in checkout.  
- Changes must apply to both FH and SH head scripts to keep behavior consistent across shops.

### Description
- Replaced the static `shippingIcons` map keyed by `ShippingProfileID...` with a `shippingIconRules` array of `{ match: function, src }` rules that match normalized label text.  
- Updated `applyShippingIcons` to query labels via `'.shipping-method-select label.provider-select-label'`, extract and normalize the text from the label (prefer `.content`), find a matching rule, hide existing/default icons, and append the rule's icon.  
- Mirrored the same logic in both `JavaScript im Head/FH - JS im Head.js` and `JavaScript im Head/SH - JS im Head.js`, keeping the existing MutationObserver/bootstrap logic intact.  
- Continued to expose `window.applyShippingIcons` so the behavior can be invoked externally.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f386207288331a113eabf98da36c6)