### PR TITLE
Add trust badge row to FH & SH footers with styling

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -705,7 +705,7 @@ div.external-brand-logo img {
 .fh-footer__trust-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 20px;
+  gap: 26px;
   justify-content: flex-end;
   margin-top: 8px;
 }
@@ -716,6 +716,11 @@ div.external-brand-logo img {
   max-width: 170px;
   object-fit: contain;
   display: block;
+  filter: drop-shadow(0 12px 16px rgba(15, 23, 42, 0.22));
+}
+
+.fh-footer__trust-badge--anniversary {
+  height: 82px;
 }
 
 .fh-footer__brand-logo {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -711,6 +711,7 @@ div.external-brand-logo img {
   margin-top: auto;
   padding-top: 28px;
   align-self: end;
+  transform: translateY(8px);
 }
 
 .fh-footer__trust-badges img {
@@ -719,7 +720,7 @@ div.external-brand-logo img {
   max-width: 170px;
   object-fit: contain;
   display: block;
-  filter: drop-shadow(0 6px 6px rgba(15, 23, 42, 0.24));
+  filter: drop-shadow(0 4px 6px rgba(15, 23, 42, 0.2));
 }
 
 .fh-footer__trust-badge--anniversary {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -712,11 +712,9 @@ div.external-brand-logo img {
 
 .fh-footer__trust-badges img {
   width: auto;
-  max-width: 180px;
   height: auto;
-  max-height: 96px;
-  border-radius: 14px;
-  box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.45);
+  max-width: 180px;
+  display: block;
 }
 
 .fh-footer__brand-logo {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -705,15 +705,16 @@ div.external-brand-logo img {
 .fh-footer__trust-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 18px;
+  gap: 20px;
   justify-content: flex-end;
   margin-top: 8px;
 }
 
 .fh-footer__trust-badges img {
   width: auto;
-  height: auto;
-  max-width: 180px;
+  height: 72px;
+  max-width: 170px;
+  object-fit: contain;
   display: block;
 }
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -702,6 +702,22 @@ div.external-brand-logo img {
   text-align: right;
 }
 
+.fh-footer__trust-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.fh-footer__trust-badges img {
+  width: 150px;
+  max-width: 100%;
+  height: auto;
+  border-radius: 14px;
+  box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.45);
+}
+
 .fh-footer__brand-logo {
   max-height: 72px;
   width: auto;
@@ -787,6 +803,10 @@ div.external-brand-logo img {
     width: min(100%, 420px);
     justify-items: center;
     text-align: center;
+  }
+
+  .fh-footer__trust-badges {
+    justify-content: center;
   }
 
   .fh-footer__shipping-item {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -690,8 +690,7 @@ div.external-brand-logo img {
 }
 
 .fh-footer__logistics {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: 24px;
   align-content: start;
 }
@@ -708,10 +707,9 @@ div.external-brand-logo img {
   flex-wrap: wrap;
   gap: 26px;
   justify-content: flex-end;
-  margin-top: auto;
-  padding-top: 28px;
-  align-self: end;
-  transform: translateY(8px);
+  grid-column: 2 / 3;
+  justify-self: end;
+  margin-top: 28px;
 }
 
 .fh-footer__trust-badges img {
@@ -721,6 +719,10 @@ div.external-brand-logo img {
   object-fit: contain;
   display: block;
   filter: drop-shadow(0 4px 6px rgba(15, 23, 42, 0.2));
+}
+
+.fh-footer__copyright {
+  grid-column: 1 / -1;
 }
 
 .fh-footer__trust-badge--anniversary {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -707,9 +707,6 @@ div.external-brand-logo img {
   flex-wrap: wrap;
   gap: 26px;
   justify-content: flex-end;
-  grid-column: 2 / 3;
-  justify-self: end;
-  margin-top: 28px;
 }
 
 .fh-footer__trust-badges img {
@@ -721,8 +718,16 @@ div.external-brand-logo img {
   filter: drop-shadow(0 4px 6px rgba(15, 23, 42, 0.2));
 }
 
-.fh-footer__copyright {
-  grid-column: 1 / -1;
+.fh-footer__footer-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: end;
+  margin-top: 28px;
+}
+
+.fh-footer__trust-badges {
+  justify-self: end;
 }
 
 .fh-footer__trust-badge--anniversary {
@@ -816,8 +821,15 @@ div.external-brand-logo img {
     text-align: center;
   }
 
+  .fh-footer__footer-row {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+  }
+
   .fh-footer__trust-badges {
     justify-content: center;
+    justify-self: center;
   }
 
   .fh-footer__shipping-item {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -690,7 +690,8 @@ div.external-brand-logo img {
 }
 
 .fh-footer__logistics {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 24px;
   align-content: start;
 }
@@ -707,7 +708,9 @@ div.external-brand-logo img {
   flex-wrap: wrap;
   gap: 26px;
   justify-content: flex-end;
-  margin-top: 8px;
+  margin-top: auto;
+  padding-top: 28px;
+  align-self: end;
 }
 
 .fh-footer__trust-badges img {
@@ -716,7 +719,7 @@ div.external-brand-logo img {
   max-width: 170px;
   object-fit: contain;
   display: block;
-  filter: drop-shadow(0 12px 16px rgba(15, 23, 42, 0.22));
+  filter: drop-shadow(0 6px 6px rgba(15, 23, 42, 0.24));
 }
 
 .fh-footer__trust-badge--anniversary {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -711,9 +711,10 @@ div.external-brand-logo img {
 }
 
 .fh-footer__trust-badges img {
-  width: 150px;
-  max-width: 100%;
+  width: auto;
+  max-width: 180px;
   height: auto;
+  max-height: 96px;
   border-radius: 14px;
   box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.45);
 }

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -726,7 +726,13 @@ div.external-brand-logo img {
   margin-top: 28px;
 }
 
+.fh-footer__copyright {
+  justify-self: start;
+  align-self: end;
+}
+
 .fh-footer__trust-badges {
+  align-self: end;
   justify-self: end;
 }
 

--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -134,13 +134,15 @@
           </div>
         </div>
       </div>
-      <div class="fh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
-        <img class="fh-footer__trust-badge fh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
-      </div>
-      <div class="fh-footer__copyright">
-        © 2014–2026 FENSTER-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
+      <div class="fh-footer__footer-row">
+        <div class="fh-footer__copyright">
+          © 2014–2026 FENSTER-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
+        </div>
+        <div class="fh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
+          <img class="fh-footer__trust-badge fh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
+        </div>
       </div>
     </div>
   </div>

--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -135,7 +135,7 @@
         </div>
         <div class="fh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
+          <img class="fh-footer__trust-badge fh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
         </div>
       </div>

--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -135,8 +135,8 @@
         </div>
         <div class="fh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
         </div>
       </div>
       <div class="fh-footer__copyright">

--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -133,6 +133,11 @@
             </div>
           </div>
         </div>
+        <div class="fh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
+        </div>
       </div>
       <div class="fh-footer__copyright">
         © 2014–2026 FENSTER-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.

--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -135,13 +135,13 @@
         </div>
       </div>
       <div class="fh-footer__footer-row">
-        <div class="fh-footer__copyright">
-          © 2014–2026 FENSTER-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
-        </div>
         <div class="fh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
           <img class="fh-footer__trust-badge fh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
+        </div>
+        <div class="fh-footer__copyright">
+          © 2014–2026 FENSTER-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
         </div>
       </div>
     </div>

--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -133,11 +133,11 @@
             </div>
           </div>
         </div>
-        <div class="fh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
-          <img class="fh-footer__trust-badge fh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
-        </div>
+      </div>
+      <div class="fh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
+        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
+        <img class="fh-footer__trust-badge fh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
+        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
       </div>
       <div class="fh-footer__copyright">
         © 2014–2026 FENSTER-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -135,8 +135,8 @@
         </div>
         <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
         </div>
       </div>
       <div class="sh-footer__copyright">

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -134,13 +134,15 @@
           </div>
         </div>
       </div>
-      <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
-        <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
-        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
-      </div>
-      <div class="sh-footer__copyright">
-        © 2014–2026 SCHRAUBEN-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
+      <div class="sh-footer__footer-row">
+        <div class="sh-footer__copyright">
+          © 2014–2026 SCHRAUBEN-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
+        </div>
+        <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
+          <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
+        </div>
       </div>
     </div>
   </div>

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -135,13 +135,13 @@
         </div>
       </div>
       <div class="sh-footer__footer-row">
-        <div class="sh-footer__copyright">
-          © 2014–2026 SCHRAUBEN-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
-        </div>
         <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
           <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
+        </div>
+        <div class="sh-footer__copyright">
+          © 2014–2026 SCHRAUBEN-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
         </div>
       </div>
     </div>

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -133,6 +133,11 @@
             </div>
           </div>
         </div>
+        <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
+        </div>
       </div>
       <div class="sh-footer__copyright">
         © 2014–2026 SCHRAUBEN-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -133,11 +133,11 @@
             </div>
           </div>
         </div>
-        <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
-          <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
-        </div>
+      </div>
+      <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
+        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
+        <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
+        <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
       </div>
       <div class="sh-footer__copyright">
         © 2014–2026 SCHRAUBEN-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -135,7 +135,7 @@
         </div>
         <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
+          <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
           <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
         </div>
       </div>

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -718,6 +718,7 @@ div.external-brand-logo img {
   margin-top: auto;
   padding-top: 28px;
   align-self: end;
+  transform: translateY(8px);
 }
 
 .sh-footer__trust-badges img {
@@ -726,7 +727,7 @@ div.external-brand-logo img {
   max-width: 170px;
   object-fit: contain;
   display: block;
-  filter: drop-shadow(0 6px 6px rgba(15, 23, 42, 0.24));
+  filter: drop-shadow(0 4px 6px rgba(15, 23, 42, 0.2));
 }
 
 .sh-footer__trust-badge--anniversary {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -719,11 +719,9 @@ div.external-brand-logo img {
 
 .sh-footer__trust-badges img {
   width: auto;
-  max-width: 180px;
   height: auto;
-  max-height: 96px;
-  border-radius: 14px;
-  box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.45);
+  max-width: 180px;
+  display: block;
 }
 
 .sh-footer__brand-logo,

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -697,8 +697,7 @@ div.external-brand-logo img {
 }
 
 .sh-footer__logistics {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: 24px;
   align-content: start;
 }
@@ -715,10 +714,9 @@ div.external-brand-logo img {
   flex-wrap: wrap;
   gap: 26px;
   justify-content: flex-end;
-  margin-top: auto;
-  padding-top: 28px;
-  align-self: end;
-  transform: translateY(8px);
+  grid-column: 2 / 3;
+  justify-self: end;
+  margin-top: 28px;
 }
 
 .sh-footer__trust-badges img {
@@ -728,6 +726,10 @@ div.external-brand-logo img {
   object-fit: contain;
   display: block;
   filter: drop-shadow(0 4px 6px rgba(15, 23, 42, 0.2));
+}
+
+.sh-footer__copyright {
+  grid-column: 1 / -1;
 }
 
 .sh-footer__trust-badge--anniversary {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -712,15 +712,16 @@ div.external-brand-logo img {
 .sh-footer__trust-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 18px;
+  gap: 20px;
   justify-content: flex-end;
   margin-top: 8px;
 }
 
 .sh-footer__trust-badges img {
   width: auto;
-  height: auto;
-  max-width: 180px;
+  height: 72px;
+  max-width: 170px;
+  object-fit: contain;
   display: block;
 }
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -718,9 +718,10 @@ div.external-brand-logo img {
 }
 
 .sh-footer__trust-badges img {
-  width: 150px;
-  max-width: 100%;
+  width: auto;
+  max-width: 180px;
   height: auto;
+  max-height: 96px;
   border-radius: 14px;
   box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.45);
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -714,9 +714,6 @@ div.external-brand-logo img {
   flex-wrap: wrap;
   gap: 26px;
   justify-content: flex-end;
-  grid-column: 2 / 3;
-  justify-self: end;
-  margin-top: 28px;
 }
 
 .sh-footer__trust-badges img {
@@ -728,8 +725,16 @@ div.external-brand-logo img {
   filter: drop-shadow(0 4px 6px rgba(15, 23, 42, 0.2));
 }
 
-.sh-footer__copyright {
-  grid-column: 1 / -1;
+.sh-footer__footer-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: end;
+  margin-top: 28px;
+}
+
+.sh-footer__trust-badges {
+  justify-self: end;
 }
 
 .sh-footer__trust-badge--anniversary {
@@ -824,8 +829,15 @@ div.external-brand-logo img {
     text-align: center;
   }
 
+  .sh-footer__footer-row {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+  }
+
   .sh-footer__trust-badges {
     justify-content: center;
+    justify-self: center;
   }
 
   .sh-footer__shipping-item {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -709,6 +709,22 @@ div.external-brand-logo img {
   text-align: right;
 }
 
+.sh-footer__trust-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.sh-footer__trust-badges img {
+  width: 150px;
+  max-width: 100%;
+  height: auto;
+  border-radius: 14px;
+  box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.45);
+}
+
 .sh-footer__brand-logo,
 .fh-footer__brand-logo {
   max-height: 72px;
@@ -795,6 +811,10 @@ div.external-brand-logo img {
     width: min(100%, 420px);
     justify-items: center;
     text-align: center;
+  }
+
+  .sh-footer__trust-badges {
+    justify-content: center;
   }
 
   .sh-footer__shipping-item {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -712,7 +712,7 @@ div.external-brand-logo img {
 .sh-footer__trust-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 20px;
+  gap: 26px;
   justify-content: flex-end;
   margin-top: 8px;
 }
@@ -723,6 +723,11 @@ div.external-brand-logo img {
   max-width: 170px;
   object-fit: contain;
   display: block;
+  filter: drop-shadow(0 12px 16px rgba(15, 23, 42, 0.22));
+}
+
+.sh-footer__trust-badge--anniversary {
+  height: 82px;
 }
 
 .sh-footer__brand-logo,

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -733,7 +733,13 @@ div.external-brand-logo img {
   margin-top: 28px;
 }
 
+.sh-footer__copyright {
+  justify-self: start;
+  align-self: end;
+}
+
 .sh-footer__trust-badges {
+  align-self: end;
   justify-self: end;
 }
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -697,7 +697,8 @@ div.external-brand-logo img {
 }
 
 .sh-footer__logistics {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 24px;
   align-content: start;
 }
@@ -714,7 +715,9 @@ div.external-brand-logo img {
   flex-wrap: wrap;
   gap: 26px;
   justify-content: flex-end;
-  margin-top: 8px;
+  margin-top: auto;
+  padding-top: 28px;
+  align-self: end;
 }
 
 .sh-footer__trust-badges img {
@@ -723,7 +726,7 @@ div.external-brand-logo img {
   max-width: 170px;
   object-fit: contain;
   display: block;
-  filter: drop-shadow(0 12px 16px rgba(15, 23, 42, 0.22));
+  filter: drop-shadow(0 6px 6px rgba(15, 23, 42, 0.24));
 }
 
 .sh-footer__trust-badge--anniversary {


### PR DESCRIPTION
### Motivation
- Add three trust/brand badges to the bottom of the FH and SH footers to increase customer trust and match the requested placement and appearance. 
- Present the badges at an even size with subtle elevation so they remain visible but do not overpower existing footer content.

### Description
- Inserted a new badge row under the logistics section in `Footer/FH-Footer.html` and `Footer/SH-Footer.html` containing the three provided badge images (loaded `lazy` with descriptive `alt` text and an `aria-label` on the container). 
- Added CSS rules to `FH - Stylesheets.css` and `SH - Stylesheets.css` defining `.fh-footer__trust-badges` / `.sh-footer__trust-badges` to layout badges in a horizontal row with `gap: 18px`, each image sized at `width: 150px` (responsive `max-width: 100%`), rounded corners and a subtle drop shadow (`box-shadow: 0 12px 24px -18px rgba(15, 23, 42, 0.45)`). 
- Ensured responsive behavior by centering the badge row on smaller breakpoints so the badges align gracefully on mobile.

### Testing
- No automated tests were run since the change is static HTML/CSS only.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f44ae95108331b036ab940dd73360)