### PR TITLE
Adjust footer trust badge sizes, alignment and icon order

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -707,12 +707,13 @@ div.external-brand-logo img {
   flex-wrap: wrap;
   gap: 32px;
   justify-content: flex-end;
+  align-items: flex-end;
 }
 
 .fh-footer__trust-badges img {
   width: auto;
-  height: 72px;
-  max-width: 170px;
+  height: auto;
+  max-width: 220px;
   object-fit: contain;
   display: block;
   filter: drop-shadow(0 4px 6px rgba(15, 23, 42, 0.2));
@@ -738,7 +739,15 @@ div.external-brand-logo img {
 }
 
 .fh-footer__trust-badge--anniversary {
-  height: 82px;
+  height: 110px;
+}
+
+.fh-footer__trust-badge--company {
+  height: 60px;
+}
+
+.fh-footer__trust-badge--ssl {
+  height: 85px;
 }
 
 .fh-footer__brand-logo {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -724,7 +724,6 @@ div.external-brand-logo img {
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 24px;
   align-items: end;
-  margin-top: 28px;
   grid-column: 1 / -1;
 }
 
@@ -739,15 +738,15 @@ div.external-brand-logo img {
 }
 
 .fh-footer__trust-badge--anniversary {
-  height: 110px;
+  height: 110px !important;
 }
 
 .fh-footer__trust-badge--company {
-  height: 60px;
+  height: 60px !important;
 }
 
 .fh-footer__trust-badge--ssl {
-  height: 85px;
+  height: 85px !important;
 }
 
 .fh-footer__brand-logo {

--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -140,8 +140,8 @@
         </div>
         <div class="fh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
           <img class="fh-footer__trust-badge fh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
+          <img class="fh-footer__trust-badge fh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
+          <img class="fh-footer__trust-badge fh-footer__trust-badge--company" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
         </div>
       </div>
     </div>

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -140,8 +140,8 @@
         </div>
         <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
           <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
+          <img class="sh-footer__trust-badge sh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
+          <img class="sh-footer__trust-badge sh-footer__trust-badge--company" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
         </div>
       </div>
     </div>

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -746,15 +746,15 @@ div.external-brand-logo img {
 }
 
 .sh-footer__trust-badge--anniversary {
-  height: 110px;
+  height: 110px !important;
 }
 
 .sh-footer__trust-badge--company {
-  height: 60px;
+  height: 60px !important;
 }
 
 .sh-footer__trust-badge--ssl {
-  height: 85px;
+  height: 85px !important;
 }
 
 .sh-footer__brand-logo,

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -714,12 +714,13 @@ div.external-brand-logo img {
   flex-wrap: wrap;
   gap: 32px;
   justify-content: flex-end;
+  align-items: flex-end;
 }
 
 .sh-footer__trust-badges img {
   width: auto;
-  height: 72px;
-  max-width: 170px;
+  height: auto;
+  max-width: 220px;
   object-fit: contain;
   display: block;
   filter: drop-shadow(0 4px 6px rgba(15, 23, 42, 0.2));
@@ -745,7 +746,15 @@ div.external-brand-logo img {
 }
 
 .sh-footer__trust-badge--anniversary {
-  height: 82px;
+  height: 110px;
+}
+
+.sh-footer__trust-badge--company {
+  height: 60px;
+}
+
+.sh-footer__trust-badge--ssl {
+  height: 85px;
 }
 
 .sh-footer__brand-logo,


### PR DESCRIPTION
### Motivation
- Make the footer trust badges appear more unique and individual by assigning distinct heights, a larger max width and aligning the badge container to the end, plus swap the second and third icons for visual ordering.

### Description
- Reordered the trust badge markup in `Footer/FH-Footer.html` and `Footer/SH-Footer.html` and added per-badge classes `--ssl` and `--company` next to the existing `--anniversary` class.
- Updated `FH - Stylesheets.css` to set `.fh-footer__trust-badges` to `align-items: flex-end`, set images to `height: auto` and `max-width: 220px`, and added per-badge height rules: `.fh-footer__trust-badge--anniversary { height: 110px; }`, `.fh-footer__trust-badge--company { height: 60px; }`, `.fh-footer__trust-badge--ssl { height: 85px; }`.
- Applied the same CSS changes to `SH - Stylesheets.css` with `sh-` prefixed classes for parity between both shops.
- Files changed: `Footer/FH-Footer.html`, `Footer/SH-Footer.html`, `FH - Stylesheets.css`, and `SH - Stylesheets.css`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f815e18888331b7dd25e640201c2b)