### PR TITLE
Add tooltip titles to footer trust badges

### DIFF
--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -139,9 +139,9 @@
           © 2014–2026 FENSTER-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
         </div>
         <div class="fh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
-          <img class="fh-footer__trust-badge fh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
-          <img class="fh-footer__trust-badge fh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
-          <img class="fh-footer__trust-badge fh-footer__trust-badge--company" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
+          <img class="fh-footer__trust-badge fh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" title="FENSTER-HAMMER (fenster-hammer.de) gibt es seit 2014" loading="lazy" decoding="async">
+          <img class="fh-footer__trust-badge fh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" title="Standardmäßige Verschlüsselung Ihrer Daten" loading="lazy" decoding="async">
+          <img class="fh-footer__trust-badge fh-footer__trust-badge--company" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" title="Unternehmen unter deutscher Führung und Besitz sowie Sitz in Nordrhein-Westfalen" loading="lazy" decoding="async">
         </div>
       </div>
     </div>

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -139,7 +139,7 @@
           © 2014–2026 SCHRAUBEN-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
         </div>
         <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
-          <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" title="FENSTER-HAMMER (fenster-hammer.de) gibt es seit 2014" loading="lazy" decoding="async">
+          <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" title="SCHRAUBEN-HAMMER (schraubenhammer.de) gibt es seit 2014" loading="lazy" decoding="async">
           <img class="sh-footer__trust-badge sh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" title="Standardmäßige Verschlüsselung Ihrer Daten" loading="lazy" decoding="async">
           <img class="sh-footer__trust-badge sh-footer__trust-badge--company" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" title="Unternehmen unter deutscher Führung und Besitz sowie Sitz in Nordrhein-Westfalen" loading="lazy" decoding="async">
         </div>

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -75,7 +75,7 @@
       <div class="sh-footer__brand-section">
         <div class="sh-footer__brands">
         <a href="https://schrauben-hammer.de" target="_blank" rel="noopener noreferrer">
-       <img class="sh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="Schraubenhammer" loading="lazy" decoding="async" width="335" height="150">
+       <img class="sh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="SCHRAUBEN-HAMMER" loading="lazy" decoding="async" width="335" height="150">
       </a>
        <a href="https://fenster-hammer.de" target="_blank" rel="noopener noreferrer">
         <img class="fh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer" loading="lazy" decoding="async" width="300" height="300">
@@ -139,7 +139,7 @@
           © 2014–2026 SCHRAUBEN-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
         </div>
         <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
-          <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" title="SCHRAUBEN-HAMMER (schraubenhammer.de) gibt es seit 2014" loading="lazy" decoding="async">
+          <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" title="SCHRAUBEN-HAMMER (schrauben-hammer.de) gibt es seit 2014" loading="lazy" decoding="async">
           <img class="sh-footer__trust-badge sh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" title="Standardmäßige Verschlüsselung Ihrer Daten" loading="lazy" decoding="async">
           <img class="sh-footer__trust-badge sh-footer__trust-badge--company" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" title="Unternehmen unter deutscher Führung und Besitz sowie Sitz in Nordrhein-Westfalen" loading="lazy" decoding="async">
         </div>

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -139,9 +139,9 @@
           © 2014–2026 SCHRAUBEN-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
         </div>
         <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
-          <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" loading="lazy" decoding="async">
-          <img class="sh-footer__trust-badge sh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" loading="lazy" decoding="async">
-          <img class="sh-footer__trust-badge sh-footer__trust-badge--company" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" loading="lazy" decoding="async">
+          <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" title="FENSTER-HAMMER (fenster-hammer.de) gibt es seit 2014" loading="lazy" decoding="async">
+          <img class="sh-footer__trust-badge sh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" title="Standardmäßige Verschlüsselung Ihrer Daten" loading="lazy" decoding="async">
+          <img class="sh-footer__trust-badge sh-footer__trust-badge--company" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" title="Unternehmen unter deutscher Führung und Besitz sowie Sitz in Nordrhein-Westfalen" loading="lazy" decoding="async">
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Provide simple, browser-native hover tooltips for the footer trust badge icons so visitors see the requested contextual messages on mouse hover in both FH and SH shops.

### Description
- Add `title` attributes to the three trust badge `<img>` elements in `Footer/FH-Footer.html` and `Footer/SH-Footer.html` with the texts: `FENSTER-HAMMER (fenster-hammer.de) gibt es seit 2014`, `Standardmäßige Verschlüsselung Ihrer Daten`, and `Unternehmen unter deutscher Führung und Besitz sowie Sitz in Nordrhein-Westfalen`.

### Testing
- No automated tests were run because this is a static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f87d2dfac8331a25c7897cfb66de8)