### PR TITLE
Footer: change SSL badge tooltip to Du-Ansprache

### DIFF
--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -140,7 +140,7 @@
         </div>
         <div class="fh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
           <img class="fh-footer__trust-badge fh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" title="FENSTER-HAMMER (fenster-hammer.de) gibt es seit 2014" loading="lazy" decoding="async">
-          <img class="fh-footer__trust-badge fh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" title="Standardmäßige Verschlüsselung Ihrer Daten" loading="lazy" decoding="async">
+          <img class="fh-footer__trust-badge fh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" title="Standardmäßige Verschlüsselung Deiner Daten" loading="lazy" decoding="async">
           <img class="fh-footer__trust-badge fh-footer__trust-badge--company" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" title="Unternehmen unter deutscher Führung und Besitz sowie Sitz in Nordrhein-Westfalen" loading="lazy" decoding="async">
         </div>
       </div>

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -140,7 +140,7 @@
         </div>
         <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
           <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" title="SCHRAUBEN-HAMMER (schrauben-hammer.de) gibt es seit 2014" loading="lazy" decoding="async">
-          <img class="sh-footer__trust-badge sh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" title="Standardmäßige Verschlüsselung Ihrer Daten" loading="lazy" decoding="async">
+          <img class="sh-footer__trust-badge sh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" title="Standardmäßige Verschlüsselung Deiner Daten" loading="lazy" decoding="async">
           <img class="sh-footer__trust-badge sh-footer__trust-badge--company" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" title="Unternehmen unter deutscher Führung und Besitz sowie Sitz in Nordrhein-Westfalen" loading="lazy" decoding="async">
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Ensure the footer copy uses the Du-form consistently by updating the SSL badge tooltip from formal to personal address.

### Description
- Updated the `title` attribute on the SSL trust-badge image in both `Footer/FH-Footer.html` and `Footer/SH-Footer.html` to change the tooltip text from "Standardmäßige Verschlüsselung Ihrer Daten" to "Standardmäßige Verschlüsselung Deiner Daten".

### Testing
- No automated tests were run for this text-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f8ba3c4dc8331a668e5ba281288f5)