### PR TITLE
Hide PayPal smart button when variants are sold out

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -194,13 +194,8 @@ div.external-brand-logo img {
   color: rgb(153, 27, 27);
 }
 
-#kjvItemAvailabilityText.is-sold-out:has(+ #smart.paypal-smart-button),
-#kjvItemAvailabilityText.is-sold-out:has(~ #smart.paypal-smart-button) {
-  display: none !important;
-}
-
-#kjvItemAvailabilityText.is-sold-out:has(+ #smart.paypal-smart-button) + #smart.paypal-smart-button,
-#kjvItemAvailabilityText.is-sold-out:has(~ #smart.paypal-smart-button) ~ #smart.paypal-smart-button {
+.widget.widget-add-to-basket:has(#kjvItemAvailabilityText.is-sold-out) #smart.paypal-smart-button,
+.widget.widget-add-to-basket:has(#kjvItemAvailabilityText.is-sold-out) #smart.paypal-smart-button * {
   display: none !important;
 }
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -197,13 +197,8 @@ div.external-brand-logo img {
   color: rgb(153, 27, 27);
 }
 
-#kjvItemAvailabilityText.is-sold-out:has(+ #smart.paypal-smart-button),
-#kjvItemAvailabilityText.is-sold-out:has(~ #smart.paypal-smart-button) {
-  display: none !important;
-}
-
-#kjvItemAvailabilityText.is-sold-out:has(+ #smart.paypal-smart-button) + #smart.paypal-smart-button,
-#kjvItemAvailabilityText.is-sold-out:has(~ #smart.paypal-smart-button) ~ #smart.paypal-smart-button {
+.widget.widget-add-to-basket:has(#kjvItemAvailabilityText.is-sold-out) #smart.paypal-smart-button,
+.widget.widget-add-to-basket:has(#kjvItemAvailabilityText.is-sold-out) #smart.paypal-smart-button * {
   display: none !important;
 }
 


### PR DESCRIPTION
### Motivation
- The existing sibling-based selectors did not match the actual DOM structure and failed to hide the PayPal smart button when variants are sold out, so the rule was updated to target the add-to-basket widget context.

### Description
- Replace sibling `:has` selectors on `#kjvItemAvailabilityText.is-sold-out` with a parent-scoped selector using `.widget.widget-add-to-basket:has(#kjvItemAvailabilityText.is-sold-out)` that hides `#smart.paypal-smart-button` and its children via `#smart.paypal-smart-button *` in both `FH - Stylesheets.css` and `SH - Stylesheets.css`.
- The change ensures the PayPal smart button and any injected child elements are hidden when the availability text indicates sold out.

### Testing
- No automated tests were run because this is a CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f940f259c83318c4219134c9e880c)