### PR TITLE
Align Trusted Shops trustbadge position in SH stylesheet

### DIFF
--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3336,6 +3336,14 @@ body.sh-search-overlay-open .brevo-conversations__iframe-wrapper {
 }
 /* End Section: Trustbadge ausblenden */
 
+/* Section: Trusted Shops Badge Position */
+div._1ggtbm9,
+div._1dqk8hp {
+  left: 20px !important;
+  right: auto !important;
+}
+/* End Section: Trusted Shops Badge Position */
+
 /* Section: Allgemeines Button-Styling für .btn-primary */
 .btn.btn-primary {
   background-color: #000000 !important; /* Tiefschwarz – kräftig */


### PR DESCRIPTION
### Motivation
- Ensure the Trusted Shops trustbadge in the SH storefront is positioned the same way as in FH to keep the UI consistent and prevent overlap with other widgets.

### Description
- Add a small CSS block to `SH - Stylesheets.css` that mirrors FH by targeting `div._1ggtbm9, div._1dqk8hp` and applying `left: 20px !important; right: auto !important;`.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697091a8c01c8331aff581cfa1eeb192)