### PR TITLE
Apply rounded top corners to first two checkout methods for FH and SH

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3687,6 +3687,14 @@ button[data-testing="quantity-btn-decrease"] {
 }
 /* End Section: Method list item label padding */
 
+/* Section: Method list item border radius */
+.page-checkout .widget-rounded-corners .cmp-method-list .method-list-item:first-child,
+.page-checkout .widget-rounded-corners .cmp-method-list .method-list-item:nth-child(2) {
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+}
+/* End Section: Method list item border radius */
+
 /* Section: Basket preview totals visibility */
 :root .cmp-totals dt,
 :root .cmp-totals dd {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3669,6 +3669,14 @@ button[data-testing="quantity-btn-decrease"] {
 }
 /* End Section: Method list item label padding */
 
+/* Section: Method list item border radius */
+.page-checkout .widget-rounded-corners .cmp-method-list .method-list-item:first-child,
+.page-checkout .widget-rounded-corners .cmp-method-list .method-list-item:nth-child(2) {
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+}
+/* End Section: Method list item border radius */
+
 /* Section: Basket preview totals visibility */
 :root .cmp-totals dt,
 :root .cmp-totals dd {


### PR DESCRIPTION
### Motivation
- Ensure both the first and second payment/shipping method items on the checkout page receive the same rounded top corners for visual consistency across the FH and SH shops.

### Description
- Added a CSS rule to `FH - Stylesheets.css` and `SH - Stylesheets.css` targeting `.page-checkout .widget-rounded-corners .cmp-method-list .method-list-item:first-child, .page-checkout .widget-rounded-corners .cmp-method-list .method-list-item:nth-child(2)` and applying `border-top-left-radius: 12px;` and `border-top-right-radius: 12px;`.
- The change is limited to a small CSS block inserted near the existing method-list styling and affects only the checkout method list visuals.

### Testing
- No automated tests were run because this is a CSS-only visual change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970bb1e38e88331acfdaea0d0894fda)