### PR TITLE
Update Trockenbau main links in SH header

### DIFF
--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -417,7 +417,7 @@
                       </div>
                     </div>
                     <div class="sh-header__dropdown-group">
-                        <a href="/schrauben/schnellbauschrauben/" class="sh-header__dropdown-link sh-header__dropdown-link--parent">Trockenbau</a>
+                        <a href="/anwendungsgebiet/trockenbau/" class="sh-header__dropdown-link sh-header__dropdown-link--parent">Trockenbau</a>
                       <div class="sh-header__dropdown-sublist">
                         <a href="/anwendungsgebiet/trockenbau/expressnaegel-deckenbefestigungen/" class="sh-header__dropdown-sublink">Expressnägel &amp; Deckenbefestigungen</a>
                         <a href="/anwendungsgebiet/trockenbau/kleben-dichten/" class="sh-header__dropdown-sublink">Kleben &amp; Dichten</a>
@@ -436,7 +436,7 @@
             <li class="nav-item dropdown sh-header__nav-item">
                 <a
                   class="nav-link sh-header__nav-link"
-                  href="/schrauben/schnellbauschrauben/"
+                  href="/anwendungsgebiet/trockenbau/"
                   data-sh-mobile-submenu-target="anwendungsgebiet-trockenbau-innenausbau"
                   aria-controls="sh-mobile-submenu-anwendungsgebiet-trockenbau-innenausbau"
                   aria-expanded="false"


### PR DESCRIPTION
### Motivation
- Ensure the Trockenbau navigation entries point to the dedicated landing page instead of the Schrauben category so users land on `/anwendungsgebiet/trockenbau/`.

### Description
- Update `Header/SH-Header.html` to change the Trockenbau parent dropdown link from `/schrauben/schnellbauschrauben/` to `/anwendungsgebiet/trockenbau/` and to change the main navigation link `href` to `/anwendungsgebiet/trockenbau/`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970bbe0e88c8331b56b442e3e136423)