### PR TITLE
Round top corners on second payment method item (FH & SH styles)

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3687,6 +3687,13 @@ button[data-testing="quantity-btn-decrease"] {
 }
 /* End Section: Method list item label padding */
 
+/* Section: Payment method list item rounded corners */
+.page-checkout .widget-rounded-corners .payment-method-select .cmp-method-list .method-list-item:nth-child(2) {
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+}
+/* End Section: Payment method list item rounded corners */
+
 /* Section: Basket preview totals visibility */
 :root .cmp-totals dt,
 :root .cmp-totals dd {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3669,6 +3669,13 @@ button[data-testing="quantity-btn-decrease"] {
 }
 /* End Section: Method list item label padding */
 
+/* Section: Payment method list item rounded corners */
+.page-checkout .widget-rounded-corners .payment-method-select .cmp-method-list .method-list-item:nth-child(2) {
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+}
+/* End Section: Payment method list item rounded corners */
+
 /* Section: Basket preview totals visibility */
 :root .cmp-totals dt,
 :root .cmp-totals dd {


### PR DESCRIPTION
### Motivation
- Ensure the visible top payment method shows rounded top corners when the original first method is hidden (e.g. data attribute `6001`) by targeting the effective first visible item (the original second child).

### Description
- Add a CSS rule to `FH - Stylesheets.css` and `SH - Stylesheets.css` using the selector `.page-checkout .widget-rounded-corners .payment-method-select .cmp-method-list .method-list-item:nth-child(2)` that sets `border-top-left-radius: 12px` and `border-top-right-radius: 12px`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970be41a4c48331b5f0ecf851be78a1)