### PR TITLE
Expose BasketPreview LayoutContainer slots in FH/SH headers for plugin injections

### DIFF
--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -273,7 +273,50 @@
             'totalSumNet',
             'totalSumGross'
           ]"
-        ></basket-preview>
+        >
+          <template #before-basket-item>
+            {{ LayoutContainer.show("Ceres::BasketList.BeforeItem") }}
+          </template>
+          <template #after-basket-item>
+            {{ LayoutContainer.show("Ceres::BasketList.AfterItem") }}
+          </template>
+          <template #before-basket-totals>
+            {{ LayoutContainer.show("Ceres::BasketPreview.BeforeBasketTotals") }}
+          </template>
+          <template #before-item-sum>
+            {{ LayoutContainer.show("Ceres::BasketTotals.BeforeItemSum") }}
+          </template>
+          <template #after-item-sum>
+            {{ LayoutContainer.show("Ceres::BasketTotals.AfterItemSum") }}
+          </template>
+          <template #before-shipping-costs>
+            {{ LayoutContainer.show("Ceres::BasketTotals.BeforeShippingCosts") }}
+          </template>
+          <template #after-shipping-costs>
+            {{ LayoutContainer.show("Ceres::BasketTotals.AfterShippingCosts") }}
+          </template>
+          <template #before-total-sum>
+            {{ LayoutContainer.show("Ceres::BasketTotals.BeforeTotalSum") }}
+          </template>
+          <template #before-vat>
+            {{ LayoutContainer.show("Ceres::BasketTotals.BeforeVat") }}
+          </template>
+          <template #after-vat>
+            {{ LayoutContainer.show("Ceres::BasketTotals.AfterVat") }}
+          </template>
+          <template #after-total-sum>
+            {{ LayoutContainer.show("Ceres::BasketTotals.AfterTotalSum") }}
+          </template>
+          <template #after-basket-totals>
+            {{ LayoutContainer.show("Ceres::BasketPreview.AfterBasketTotals") }}
+          </template>
+          <template #before-checkout-button>
+            {{ LayoutContainer.show("Ceres::BasketPreview.BeforeCheckoutButton") }}
+          </template>
+          <template #after-checkout-button>
+            {{ LayoutContainer.show("Ceres::BasketPreview.AfterCheckoutButton") }}
+          </template>
+        </basket-preview>
       </div>
     </div>
   </div>

--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -273,7 +273,50 @@
             'totalSumNet',
             'totalSumGross'
           ]"
-        ></basket-preview>
+        >
+          <template #before-basket-item>
+            {{ LayoutContainer.show("Ceres::BasketList.BeforeItem") }}
+          </template>
+          <template #after-basket-item>
+            {{ LayoutContainer.show("Ceres::BasketList.AfterItem") }}
+          </template>
+          <template #before-basket-totals>
+            {{ LayoutContainer.show("Ceres::BasketPreview.BeforeBasketTotals") }}
+          </template>
+          <template #before-item-sum>
+            {{ LayoutContainer.show("Ceres::BasketTotals.BeforeItemSum") }}
+          </template>
+          <template #after-item-sum>
+            {{ LayoutContainer.show("Ceres::BasketTotals.AfterItemSum") }}
+          </template>
+          <template #before-shipping-costs>
+            {{ LayoutContainer.show("Ceres::BasketTotals.BeforeShippingCosts") }}
+          </template>
+          <template #after-shipping-costs>
+            {{ LayoutContainer.show("Ceres::BasketTotals.AfterShippingCosts") }}
+          </template>
+          <template #before-total-sum>
+            {{ LayoutContainer.show("Ceres::BasketTotals.BeforeTotalSum") }}
+          </template>
+          <template #before-vat>
+            {{ LayoutContainer.show("Ceres::BasketTotals.BeforeVat") }}
+          </template>
+          <template #after-vat>
+            {{ LayoutContainer.show("Ceres::BasketTotals.AfterVat") }}
+          </template>
+          <template #after-total-sum>
+            {{ LayoutContainer.show("Ceres::BasketTotals.AfterTotalSum") }}
+          </template>
+          <template #after-basket-totals>
+            {{ LayoutContainer.show("Ceres::BasketPreview.AfterBasketTotals") }}
+          </template>
+          <template #before-checkout-button>
+            {{ LayoutContainer.show("Ceres::BasketPreview.BeforeCheckoutButton") }}
+          </template>
+          <template #after-checkout-button>
+            {{ LayoutContainer.show("Ceres::BasketPreview.AfterCheckoutButton") }}
+          </template>
+        </basket-preview>
       </div>
     </div>
   </div>

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Die Version **5.0.78** der offiziellen plentyShop-LTS-Plugins (Ceres & IO) bilde
 * Der Header und Footer werden in PlentyLTS vollständig neu aufgebaut. Verwende dieses Repository, um die benötigten HTML-Gerüste (innerhalb der zulässigen Content-Boxen), CSS-Overrides und unterstützenden JavaScript-Hooks vorzubereiten.
 * Inline-CSS darf keine eigenen Skripte einbinden; dynamisches Verhalten wird über bestehende oder hier gepflegte JavaScript-Dateien gelöst.
 * Achte darauf, dass Anpassungen für **SH** und **FH** Shops parallel gepflegt werden und konsistent mit den Ceres-Vorlagen sind.
+* Im Basket-Preview müssen die Ceres-LayoutContainer-Slots (z. B. `Ceres::BasketPreview.BeforeCheckoutButton`) erhalten bleiben, damit Plugins wie PayPal Express ihre Buttons korrekt injizieren können.
 
 ## Ergänzende Features über Custom JS/CSS
 


### PR DESCRIPTION
### Motivation

* Ensure third‑party plugins (e.g. PayPal Express) can inject buttons into the Basket Preview by providing the same Ceres LayoutContainer slots the plugin expects. 
* Keep FH and SH header implementations in sync so both shops support the same injection points and preserve relative links and Ceres integration points.

### Description

* Inserted Ceres `LayoutContainer.show(...)` templates as named Vue slots inside the existing `<basket-preview>` in `Header/FH-Header.html` and `Header/SH-Header.html` to mirror the Ceres BasketPreview slot structure (slots include `BeforeItem`, `AfterItem`, `BeforeBasketTotals`, `BeforeItemSum`, `AfterItemSum`, `BeforeShippingCosts`, `AfterShippingCosts`, `BeforeTotalSum`, `BeforeVat`, `AfterVat`, `AfterTotalSum`, `AfterBasketTotals`, `BeforeCheckoutButton`, `AfterCheckoutButton`).
* Updated `README.md` to document that the Basket Preview must retain the Ceres LayoutContainer slots (e.g. `Ceres::BasketPreview.BeforeCheckoutButton`) so plugins like PayPal Express can inject their buttons.

### Testing

* No automated tests were run for these content-only template changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970cc32f8408331a4cd8ea20dfb82ab)