### PR TITLE
Render PayPal Smart Button in basket preview (FH & SH)

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3636,6 +3636,18 @@ button[data-testing="quantity-btn-decrease"] {
 
 /* End Section: Warenkorb->Weiter einkaufen Button Styling */
 
+/* Section: PayPal Smart Button in basket preview */
+.basket-preview-footer .basket-preview-paypal {
+  margin-top: 12px;
+  width: 100%;
+}
+
+.basket-preview-footer .basket-preview-paypal[hidden] {
+  display: none;
+}
+/* End Section: PayPal Smart Button in basket preview */
+
+
 /* Section: Controls List Icon Margin */
 #controlsList .fa {
   margin-right: 0px !important;

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3588,6 +3588,77 @@ fhOnReady(function () {
 });
 // End Section: Trusted Shops Badge toggle during search overlay
 
+// Section: PayPal Smart Button in basket preview
+fhOnReady(function () {
+  var PAYPAL_BUTTON_ID = 'basketPreview';
+  var CONTAINER_ID = 'paypal-button-container_' + PAYPAL_BUTTON_ID;
+  var CONTAINER_CLASS = 'paypalSmartButtons basket-preview-paypal';
+  var PREVIEW_SELECTOR = '.basket-preview';
+  var FOOTER_SELECTOR = '.basket-preview-footer';
+  var payPalListenerAttached = false;
+
+  function hasBasketItems(preview) {
+    return Boolean(preview.querySelector('.basket-preview-item, [data-basket-item]'));
+  }
+
+  function ensureContainer(footer) {
+    var existing = footer.querySelector('#' + CONTAINER_ID);
+
+    if (existing) return existing;
+
+    var container = document.createElement('div');
+    container.id = CONTAINER_ID;
+    container.className = CONTAINER_CLASS;
+    container.setAttribute('data-uuid', PAYPAL_BUTTON_ID);
+    footer.insertBefore(container, footer.firstChild);
+    return container;
+  }
+
+  function renderPayPalButton() {
+    var preview = document.querySelector(PREVIEW_SELECTOR);
+    if (!preview) return;
+
+    var footer = preview.querySelector(FOOTER_SELECTOR);
+    if (!footer) return;
+
+    var container = ensureContainer(footer);
+
+    if (!hasBasketItems(preview)) {
+      container.setAttribute('hidden', '');
+      return;
+    }
+
+    container.removeAttribute('hidden');
+
+    if (container.getAttribute('data-paypal-rendered') === 'true') return;
+
+    if (typeof renderPayPalButtons !== 'function') return;
+
+    renderPayPalButtons(PAYPAL_BUTTON_ID, 'paypal', 'checkout', 'pill', 'gold');
+    container.setAttribute('data-paypal-rendered', 'true');
+  }
+
+  function ensurePayPalListener() {
+    if (payPalListenerAttached) return;
+    document.addEventListener('payPalScriptInitialized', renderPayPalButton);
+    payPalListenerAttached = true;
+  }
+
+  var observer = new MutationObserver(function () {
+    renderPayPalButton();
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  renderPayPalButton();
+
+  if (typeof paypal_plenty_sdk === 'undefined' || typeof renderPayPalButtons !== 'function') {
+    ensurePayPalListener();
+  }
+});
+// End Section: PayPal Smart Button in basket preview
+
+
 
 
 // Section: Warenkorbvorschau "Warenkorb" zu "Weiter einkaufen" Funktion

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -3566,6 +3566,77 @@ shOnReady(function () {
 });
 // End Section: Trusted Shops Badge toggle during search overlay
 
+// Section: PayPal Smart Button in basket preview
+shOnReady(function () {
+  var PAYPAL_BUTTON_ID = 'basketPreview';
+  var CONTAINER_ID = 'paypal-button-container_' + PAYPAL_BUTTON_ID;
+  var CONTAINER_CLASS = 'paypalSmartButtons basket-preview-paypal';
+  var PREVIEW_SELECTOR = '.basket-preview';
+  var FOOTER_SELECTOR = '.basket-preview-footer';
+  var payPalListenerAttached = false;
+
+  function hasBasketItems(preview) {
+    return Boolean(preview.querySelector('.basket-preview-item, [data-basket-item]'));
+  }
+
+  function ensureContainer(footer) {
+    var existing = footer.querySelector('#' + CONTAINER_ID);
+
+    if (existing) return existing;
+
+    var container = document.createElement('div');
+    container.id = CONTAINER_ID;
+    container.className = CONTAINER_CLASS;
+    container.setAttribute('data-uuid', PAYPAL_BUTTON_ID);
+    footer.insertBefore(container, footer.firstChild);
+    return container;
+  }
+
+  function renderPayPalButton() {
+    var preview = document.querySelector(PREVIEW_SELECTOR);
+    if (!preview) return;
+
+    var footer = preview.querySelector(FOOTER_SELECTOR);
+    if (!footer) return;
+
+    var container = ensureContainer(footer);
+
+    if (!hasBasketItems(preview)) {
+      container.setAttribute('hidden', '');
+      return;
+    }
+
+    container.removeAttribute('hidden');
+
+    if (container.getAttribute('data-paypal-rendered') === 'true') return;
+
+    if (typeof renderPayPalButtons !== 'function') return;
+
+    renderPayPalButtons(PAYPAL_BUTTON_ID, 'paypal', 'checkout', 'pill', 'gold');
+    container.setAttribute('data-paypal-rendered', 'true');
+  }
+
+  function ensurePayPalListener() {
+    if (payPalListenerAttached) return;
+    document.addEventListener('payPalScriptInitialized', renderPayPalButton);
+    payPalListenerAttached = true;
+  }
+
+  var observer = new MutationObserver(function () {
+    renderPayPalButton();
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  renderPayPalButton();
+
+  if (typeof paypal_plenty_sdk === 'undefined' || typeof renderPayPalButtons !== 'function') {
+    ensurePayPalListener();
+  }
+});
+// End Section: PayPal Smart Button in basket preview
+
+
 
 
 // Section: Warenkorbvorschau "Warenkorb" zu "Weiter einkaufen" Funktion

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Variiert den Platzhaltertext im Suchfeld, solange das Feld sichtbar, aber nicht 
 ### „Weiter einkaufen“-Button im Warenkorb-Overlay
 Benennt die Schaltfläche „Warenkorb“ im Overlay um, ergänzt ein Pfeil-Icon und sorgt dafür, dass der Klick das Overlay schließt, statt auf die Warenkorbseite zu wechseln.
 
+### PayPal Smart Button in der Warenkorbvorschau
+Rendert die PayPal-Smart-Buttons im Warenkorb-Overlay, sobald der PayPal-Checkout geladen ist, und blendet sie aus, wenn keine Artikel im Warenkorb liegen.
+
 ## Weiterer Fahrplan
 
 * Bestehende Skripte dienen nur als Zwischenlösung – langfristig sollen daraus eigenständige, wartbare Plugins entstehen.

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3618,6 +3618,18 @@ button[data-testing="quantity-btn-decrease"] {
 
 /* End Section: Warenkorb->Weiter einkaufen Button Styling */
 
+/* Section: PayPal Smart Button in basket preview */
+.basket-preview-footer .basket-preview-paypal {
+  margin-top: 12px;
+  width: 100%;
+}
+
+.basket-preview-footer .basket-preview-paypal[hidden] {
+  display: none;
+}
+/* End Section: PayPal Smart Button in basket preview */
+
+
 /* Section: Controls List Icon Margin */
 #controlsList .fa {
   margin-right: 0px !important;


### PR DESCRIPTION
### Motivation
- Enable the existing PayPal Smart Payment Buttons that are already loaded by the PayPal checkout plugin to appear inside the basket preview overlay without modifying the plugin.

### Description
- Add mounting logic to `JavaScript im Head/FH - JS im Head.js` and `JavaScript im Head/SH - JS im Head.js` that inserts a container `#paypal-button-container_basketPreview`, waits for the PayPal SDK (or listens for `payPalScriptInitialized`) and calls `renderPayPalButtons('basketPreview', 'paypal', 'checkout', 'pill', 'gold')` when the basket preview contains items.
- Ensure the button is only rendered once by tracking `data-paypal-rendered` and hide the container when the preview has no items; the code also uses a `MutationObserver` to re-check the preview when DOM changes occur.
- Add styling hooks in `FH - Stylesheets.css` and `SH - Stylesheets.css` to control spacing and hidden state for the PayPal container (`.basket-preview-paypal`).
- Document the new behavior in `README.md` under "PayPal Smart Button in der Warenkorbvorschau".

### Testing
- No automated tests were executed for this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971eedf52208331b5939d36147fa542)