### PR TITLE
PayPal-Render an lazy-loaded `basket-preview` koppeln

### DIFF
--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -2578,6 +2578,103 @@ fhOnReady(function () {
 });
 // End Section: Basket preview attribute cleanup
 
+// Section: PayPal render after basket preview lazy load
+fhOnReady(function () {
+  const BASKET_COMPONENT = 'basket-preview';
+  const FOOTER_SELECTOR = '.basket-preview-footer';
+  const PAYPAL_RENDERED_ATTR = 'data-paypal-rendered';
+  const MAX_POLL_ATTEMPTS = 25;
+  const POLL_INTERVAL = 200;
+
+  function getStore() {
+    if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
+    if (window.ceresStore) return window.ceresStore;
+    return null;
+  }
+
+  function isPayPalReady() {
+    return typeof window.renderPayPalButtons === 'function';
+  }
+
+  function markRendered(footer) {
+    if (!footer) return;
+    footer.setAttribute(PAYPAL_RENDERED_ATTR, 'true');
+  }
+
+  function hasRendered(footer) {
+    if (!footer) return false;
+    return footer.getAttribute(PAYPAL_RENDERED_ATTR) === 'true';
+  }
+
+  function tryRender() {
+    const footer = document.querySelector(FOOTER_SELECTOR);
+
+    if (!footer || hasRendered(footer) || !isPayPalReady()) return false;
+
+    window.renderPayPalButtons();
+    markRendered(footer);
+    return true;
+  }
+
+  let pollTimer = null;
+
+  function startPolling() {
+    if (pollTimer) return;
+
+    let attempts = 0;
+
+    pollTimer = window.setInterval(function () {
+      attempts += 1;
+
+      if (tryRender() || attempts >= MAX_POLL_ATTEMPTS) {
+        window.clearInterval(pollTimer);
+        pollTimer = null;
+      }
+    }, POLL_INTERVAL);
+  }
+
+  function handleLazyComponentLoaded() {
+    window.requestAnimationFrame(startPolling);
+  }
+
+  function subscribeLazyComponentLoaded() {
+    const store = getStore();
+
+    if (!store || typeof store.subscribe !== 'function') return false;
+
+    store.subscribe(function (mutation) {
+      if (!mutation) return;
+
+      const payload = mutation.payload || {};
+      const type = mutation.type || '';
+      const isSetComponent = type === 'setComponent' || type.endsWith('/setComponent');
+
+      if (!isSetComponent) return;
+
+      if (payload.component === BASKET_COMPONENT && payload.loaded) {
+        handleLazyComponentLoaded();
+      }
+    });
+
+    return true;
+  }
+
+  const store = getStore();
+  const alreadyLoaded =
+    store &&
+    store.state &&
+    store.state.lazyComponent &&
+    store.state.lazyComponent.components &&
+    store.state.lazyComponent.components[BASKET_COMPONENT];
+
+  if (alreadyLoaded) handleLazyComponentLoaded();
+
+  if (!subscribeLazyComponentLoaded()) {
+    startPolling();
+  }
+});
+// End Section: PayPal render after basket preview lazy load
+
 // Section: Ensure auth modals load their Vue components before opening
 fhOnReady(function () {
   function getVueStore() {

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -2582,6 +2582,7 @@ fhOnReady(function () {
 fhOnReady(function () {
   const BASKET_COMPONENT = 'basket-preview';
   const FOOTER_SELECTOR = '.basket-preview-footer';
+  const FUNDING_SELECTOR = '[data-paypal-funding-source]';
   const PAYPAL_RENDERED_ATTR = 'data-paypal-rendered';
   const MAX_POLL_ATTEMPTS = 25;
   const POLL_INTERVAL = 200;
@@ -2606,10 +2607,23 @@ fhOnReady(function () {
     return footer.getAttribute(PAYPAL_RENDERED_ATTR) === 'true';
   }
 
+  function hasFundingSource(footer) {
+    if (!footer) return false;
+
+    const fundingElement = footer.querySelector(FUNDING_SELECTOR);
+
+    if (!fundingElement) return false;
+
+    const fundingValue = fundingElement.getAttribute('data-paypal-funding-source');
+
+    return Boolean(fundingValue);
+  }
+
   function tryRender() {
     const footer = document.querySelector(FOOTER_SELECTOR);
 
     if (!footer || hasRendered(footer) || !isPayPalReady()) return false;
+    if (!hasFundingSource(footer)) return false;
 
     window.renderPayPalButtons();
     markRendered(footer);

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -2583,6 +2583,9 @@ fhOnReady(function () {
   const BASKET_COMPONENT = 'basket-preview';
   const FOOTER_SELECTOR = '.basket-preview-footer';
   const FUNDING_SELECTOR = '[data-paypal-funding-source]';
+  const PAYPAL_CONTAINER_CLASS = 'basket-preview-paypal';
+  const PAYPAL_BUTTON_ID = 'smart-basket-preview';
+  const PAYPAL_FUNDING_FALLBACK = 'paypal';
   const PAYPAL_RENDERED_ATTR = 'data-paypal-rendered';
   const MAX_POLL_ATTEMPTS = 25;
   const POLL_INTERVAL = 200;
@@ -2607,23 +2610,52 @@ fhOnReady(function () {
     return footer.getAttribute(PAYPAL_RENDERED_ATTR) === 'true';
   }
 
-  function hasFundingSource(footer) {
-    if (!footer) return false;
+  function resolveFundingSource() {
+    const fundingElement = document.querySelector(FUNDING_SELECTOR);
 
-    const fundingElement = footer.querySelector(FUNDING_SELECTOR);
+    if (fundingElement) {
+      const fundingValue = fundingElement.getAttribute('data-paypal-funding-source');
+      if (fundingValue) return fundingValue;
+    }
 
-    if (!fundingElement) return false;
+    return PAYPAL_FUNDING_FALLBACK;
+  }
 
-    const fundingValue = fundingElement.getAttribute('data-paypal-funding-source');
+  function ensurePayPalContainer(footer) {
+    if (!footer) return null;
 
-    return Boolean(fundingValue);
+    let container = footer.querySelector('.' + PAYPAL_CONTAINER_CLASS);
+
+    if (!container) {
+      container = document.createElement('div');
+      container.className = PAYPAL_CONTAINER_CLASS;
+      footer.appendChild(container);
+    }
+
+    let button = container.querySelector('#' + PAYPAL_BUTTON_ID);
+
+    if (!button) {
+      button = document.createElement('div');
+      button.id = PAYPAL_BUTTON_ID;
+      button.className = 'paypal-smart-button';
+      container.appendChild(button);
+    }
+
+    const fundingSource = resolveFundingSource();
+
+    if (fundingSource) {
+      button.setAttribute('data-paypal-funding-source', fundingSource);
+    }
+
+    return button;
   }
 
   function tryRender() {
     const footer = document.querySelector(FOOTER_SELECTOR);
+    const button = ensurePayPalContainer(footer);
 
-    if (!footer || hasRendered(footer) || !isPayPalReady()) return false;
-    if (!hasFundingSource(footer)) return false;
+    if (!footer || !button || hasRendered(footer) || !isPayPalReady()) return false;
+    if (!button.getAttribute('data-paypal-funding-source')) return false;
 
     window.renderPayPalButtons();
     markRendered(footer);

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -2560,6 +2560,9 @@ shOnReady(function () {
   const BASKET_COMPONENT = 'basket-preview';
   const FOOTER_SELECTOR = '.basket-preview-footer';
   const FUNDING_SELECTOR = '[data-paypal-funding-source]';
+  const PAYPAL_CONTAINER_CLASS = 'basket-preview-paypal';
+  const PAYPAL_BUTTON_ID = 'smart-basket-preview';
+  const PAYPAL_FUNDING_FALLBACK = 'paypal';
   const PAYPAL_RENDERED_ATTR = 'data-paypal-rendered';
   const MAX_POLL_ATTEMPTS = 25;
   const POLL_INTERVAL = 200;
@@ -2584,23 +2587,52 @@ shOnReady(function () {
     return footer.getAttribute(PAYPAL_RENDERED_ATTR) === 'true';
   }
 
-  function hasFundingSource(footer) {
-    if (!footer) return false;
+  function resolveFundingSource() {
+    const fundingElement = document.querySelector(FUNDING_SELECTOR);
 
-    const fundingElement = footer.querySelector(FUNDING_SELECTOR);
+    if (fundingElement) {
+      const fundingValue = fundingElement.getAttribute('data-paypal-funding-source');
+      if (fundingValue) return fundingValue;
+    }
 
-    if (!fundingElement) return false;
+    return PAYPAL_FUNDING_FALLBACK;
+  }
 
-    const fundingValue = fundingElement.getAttribute('data-paypal-funding-source');
+  function ensurePayPalContainer(footer) {
+    if (!footer) return null;
 
-    return Boolean(fundingValue);
+    let container = footer.querySelector('.' + PAYPAL_CONTAINER_CLASS);
+
+    if (!container) {
+      container = document.createElement('div');
+      container.className = PAYPAL_CONTAINER_CLASS;
+      footer.appendChild(container);
+    }
+
+    let button = container.querySelector('#' + PAYPAL_BUTTON_ID);
+
+    if (!button) {
+      button = document.createElement('div');
+      button.id = PAYPAL_BUTTON_ID;
+      button.className = 'paypal-smart-button';
+      container.appendChild(button);
+    }
+
+    const fundingSource = resolveFundingSource();
+
+    if (fundingSource) {
+      button.setAttribute('data-paypal-funding-source', fundingSource);
+    }
+
+    return button;
   }
 
   function tryRender() {
     const footer = document.querySelector(FOOTER_SELECTOR);
+    const button = ensurePayPalContainer(footer);
 
-    if (!footer || hasRendered(footer) || !isPayPalReady()) return false;
-    if (!hasFundingSource(footer)) return false;
+    if (!footer || !button || hasRendered(footer) || !isPayPalReady()) return false;
+    if (!button.getAttribute('data-paypal-funding-source')) return false;
 
     window.renderPayPalButtons();
     markRendered(footer);

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -2555,6 +2555,103 @@ shOnReady(function () {
 });
 // End Section: Basket preview attribute cleanup
 
+// Section: PayPal render after basket preview lazy load
+shOnReady(function () {
+  const BASKET_COMPONENT = 'basket-preview';
+  const FOOTER_SELECTOR = '.basket-preview-footer';
+  const PAYPAL_RENDERED_ATTR = 'data-paypal-rendered';
+  const MAX_POLL_ATTEMPTS = 25;
+  const POLL_INTERVAL = 200;
+
+  function getStore() {
+    if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
+    if (window.ceresStore) return window.ceresStore;
+    return null;
+  }
+
+  function isPayPalReady() {
+    return typeof window.renderPayPalButtons === 'function';
+  }
+
+  function markRendered(footer) {
+    if (!footer) return;
+    footer.setAttribute(PAYPAL_RENDERED_ATTR, 'true');
+  }
+
+  function hasRendered(footer) {
+    if (!footer) return false;
+    return footer.getAttribute(PAYPAL_RENDERED_ATTR) === 'true';
+  }
+
+  function tryRender() {
+    const footer = document.querySelector(FOOTER_SELECTOR);
+
+    if (!footer || hasRendered(footer) || !isPayPalReady()) return false;
+
+    window.renderPayPalButtons();
+    markRendered(footer);
+    return true;
+  }
+
+  let pollTimer = null;
+
+  function startPolling() {
+    if (pollTimer) return;
+
+    let attempts = 0;
+
+    pollTimer = window.setInterval(function () {
+      attempts += 1;
+
+      if (tryRender() || attempts >= MAX_POLL_ATTEMPTS) {
+        window.clearInterval(pollTimer);
+        pollTimer = null;
+      }
+    }, POLL_INTERVAL);
+  }
+
+  function handleLazyComponentLoaded() {
+    window.requestAnimationFrame(startPolling);
+  }
+
+  function subscribeLazyComponentLoaded() {
+    const store = getStore();
+
+    if (!store || typeof store.subscribe !== 'function') return false;
+
+    store.subscribe(function (mutation) {
+      if (!mutation) return;
+
+      const payload = mutation.payload || {};
+      const type = mutation.type || '';
+      const isSetComponent = type === 'setComponent' || type.endsWith('/setComponent');
+
+      if (!isSetComponent) return;
+
+      if (payload.component === BASKET_COMPONENT && payload.loaded) {
+        handleLazyComponentLoaded();
+      }
+    });
+
+    return true;
+  }
+
+  const store = getStore();
+  const alreadyLoaded =
+    store &&
+    store.state &&
+    store.state.lazyComponent &&
+    store.state.lazyComponent.components &&
+    store.state.lazyComponent.components[BASKET_COMPONENT];
+
+  if (alreadyLoaded) handleLazyComponentLoaded();
+
+  if (!subscribeLazyComponentLoaded()) {
+    startPolling();
+  }
+});
+// End Section: PayPal render after basket preview lazy load
+
 // Section: Ensure auth modals load their Vue components before opening
 shOnReady(function () {
   function getVueStore() {

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -2559,6 +2559,7 @@ shOnReady(function () {
 shOnReady(function () {
   const BASKET_COMPONENT = 'basket-preview';
   const FOOTER_SELECTOR = '.basket-preview-footer';
+  const FUNDING_SELECTOR = '[data-paypal-funding-source]';
   const PAYPAL_RENDERED_ATTR = 'data-paypal-rendered';
   const MAX_POLL_ATTEMPTS = 25;
   const POLL_INTERVAL = 200;
@@ -2583,10 +2584,23 @@ shOnReady(function () {
     return footer.getAttribute(PAYPAL_RENDERED_ATTR) === 'true';
   }
 
+  function hasFundingSource(footer) {
+    if (!footer) return false;
+
+    const fundingElement = footer.querySelector(FUNDING_SELECTOR);
+
+    if (!fundingElement) return false;
+
+    const fundingValue = fundingElement.getAttribute('data-paypal-funding-source');
+
+    return Boolean(fundingValue);
+  }
+
   function tryRender() {
     const footer = document.querySelector(FOOTER_SELECTOR);
 
     if (!footer || hasRendered(footer) || !isPayPalReady()) return false;
+    if (!hasFundingSource(footer)) return false;
 
     window.renderPayPalButtons();
     markRendered(footer);


### PR DESCRIPTION
### Motivation
- Stelle sicher, dass die PayPal-Buttons erst gerendert werden, wenn die `basket-preview`-Komponente tatsächlich lazy-geladen und im DOM vorhanden ist, und vermeide fehleranfällige alleinige Abhängigkeit von `MutationObserver`.
- Verhindere Doppel-Rendering durch eine einfache DOM-Guard (`data-paypal-rendered`) und sorge dafür, dass das Rendering erst ausgeführt wird, wenn die PayPal-SDK-Funktion verfügbar ist.

### Description
- Ergänzt in `JavaScript im Head/FH - JS im Head.js` und `JavaScript im Head/SH - JS im Head.js` einen Abschnitt, der auf Vuex-`setComponent`-Mutationen lauscht und auf das Laden der `basket-preview` reagiert.
- Implementiert eine Polling-Fallback-Strategie (`MAX_POLL_ATTEMPTS`, `POLL_INTERVAL`) die prüft, ob die Footer-DOM-Node (`.basket-preview-footer`) vorhanden und `window.renderPayPalButtons` verfügbar ist, und dann `window.renderPayPalButtons()` aufruft.
- Nutzt die Attribute-/DOM-Guard `data-paypal-rendered` um ein einmaliges Rendern sicherzustellen und startet das Polling über `requestAnimationFrame` nach Erkennen des Lazy-Load-Ereignisses; falls kein Vuex-Subscriber verfügbar ist, fällt der Code direkt auf Polling zurück.
- Prüft beim Initialisieren, ob `store.state.lazyComponent.components['basket-preview']` bereits geladen ist und löst dann sofort die gleiche Logik aus.

### Testing
- Keine automatisierten Tests ausgeführt; Änderungen lokal in den beiden Head-Scripts eingefügt und committed.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972024e7c988331a3447c2da7b8ee3d)