### PR TITLE
Sync sold-out availability label on item pages

### DIFF
--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3651,6 +3651,36 @@ fhOnReady(function () {
 
 })();
 
+// Section: FH availability text sync on item pages
+fhOnReady(function () {
+  if (!document.body || !document.body.classList.contains('page-singleitem')) return;
+
+  function syncAvailabilityText() {
+    var availabilityText = document.querySelector('#kjvItemAvailabilityText.is-sold-out');
+    if (!availabilityText) return false;
+
+    var badgeText = document.querySelector('.widget-availability .availability.is-sold-out > span');
+    if (!badgeText) return false;
+
+    var nextText = badgeText.textContent.trim();
+    if (!nextText) return false;
+
+    if (availabilityText.textContent !== nextText) {
+      availabilityText.textContent = nextText;
+    }
+
+    return true;
+  }
+
+  if (syncAvailabilityText()) return;
+
+  var observer = new MutationObserver(function () {
+    if (syncAvailabilityText()) observer.disconnect();
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+});
+
 // Section: Signature console log by David M. Abdin
 (function fhSignatureLog() {
   var headingStyle = [

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3656,14 +3656,13 @@ fhOnReady(function () {
   if (!document.body || !document.body.classList.contains('page-singleitem')) return;
 
   function syncAvailabilityText() {
-    var availabilityText = document.querySelector('#kjvItemAvailabilityText.is-sold-out');
+    var availabilityText = document.querySelector('#kjvItemAvailabilityText');
     if (!availabilityText) return false;
 
-    var badgeText = document.querySelector('.widget-availability .availability.is-sold-out > span');
+    var badgeText = document.querySelector('.widget-availability .availability > span');
     if (!badgeText) return false;
 
-    var nextText = badgeText.textContent.trim();
-    if (!nextText) return false;
+    var nextText = badgeText.textContent ? badgeText.textContent.trim() : '';
 
     if (availabilityText.textContent !== nextText) {
       availabilityText.textContent = nextText;

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3672,13 +3672,17 @@ fhOnReady(function () {
     return true;
   }
 
-  if (syncAvailabilityText()) return;
+  syncAvailabilityText();
 
   var observer = new MutationObserver(function () {
-    if (syncAvailabilityText()) observer.disconnect();
+    syncAvailabilityText();
   });
 
-  observer.observe(document.body, { childList: true, subtree: true });
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  });
 });
 
 // Section: Signature console log by David M. Abdin

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -3650,13 +3650,17 @@ shOnReady(function () {
     return true;
   }
 
-  if (syncAvailabilityText()) return;
+  syncAvailabilityText();
 
   var observer = new MutationObserver(function () {
-    if (syncAvailabilityText()) observer.disconnect();
+    syncAvailabilityText();
   });
 
-  observer.observe(document.body, { childList: true, subtree: true });
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  });
 });
 
 // Section: Signature console log by David M. Abdin

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -3634,14 +3634,13 @@ shOnReady(function () {
   if (!document.body || !document.body.classList.contains('page-singleitem')) return;
 
   function syncAvailabilityText() {
-    var availabilityText = document.querySelector('#kjvItemAvailabilityText.is-sold-out');
+    var availabilityText = document.querySelector('#kjvItemAvailabilityText');
     if (!availabilityText) return false;
 
-    var badgeText = document.querySelector('.widget-availability .availability.is-sold-out > span');
+    var badgeText = document.querySelector('.widget-availability .availability > span');
     if (!badgeText) return false;
 
-    var nextText = badgeText.textContent.trim();
-    if (!nextText) return false;
+    var nextText = badgeText.textContent ? badgeText.textContent.trim() : '';
 
     if (availabilityText.textContent !== nextText) {
       availabilityText.textContent = nextText;

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -3629,6 +3629,36 @@ shOnReady(function () {
 
 })();
 
+// Section: SH availability text sync on item pages
+shOnReady(function () {
+  if (!document.body || !document.body.classList.contains('page-singleitem')) return;
+
+  function syncAvailabilityText() {
+    var availabilityText = document.querySelector('#kjvItemAvailabilityText.is-sold-out');
+    if (!availabilityText) return false;
+
+    var badgeText = document.querySelector('.widget-availability .availability.is-sold-out > span');
+    if (!badgeText) return false;
+
+    var nextText = badgeText.textContent.trim();
+    if (!nextText) return false;
+
+    if (availabilityText.textContent !== nextText) {
+      availabilityText.textContent = nextText;
+    }
+
+    return true;
+  }
+
+  if (syncAvailabilityText()) return;
+
+  var observer = new MutationObserver(function () {
+    if (syncAvailabilityText()) observer.disconnect();
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+});
+
 // Section: Signature console log by David M. Abdin
 (function shSignatureLog() {
   var headingStyle = [


### PR DESCRIPTION
### Motivation
- Replace the default sold-out label on item pages with the more informative badge text (e.g. replace "Artikel nicht lieferbar" with "Nicht auf Lager - Lieferzeit 3-4 Wochen**) when the product is marked sold-out, and keep FH and SH shops synchronized.

### Description
- Added a lightweight vanilla JS snippet to `JavaScript im Head/FH - JS im Head.js` and `JavaScript im Head/SH - JS im Head.js` that runs on pages with the `page-singleitem` class, looks for `#kjvItemAvailabilityText.is-sold-out` and copies the text from `.widget-availability .availability.is-sold-out > span` into it, and uses a `MutationObserver` to wait for elements if they are injected later.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69721f907cdc8331ab35543a5759bed2)