### PR TITLE
Toggle PayPal smart button based on stock availability

### DIFF
--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -2681,6 +2681,7 @@ fhOnReady(function () {
     const availabilityText = document.querySelector(availabilityTextSelector);
     const availabilityIcon = document.querySelector('#kjvItemAvailabilityIcon, .availability .availability-icon, [data-testing="availability-icon"]');
     const availabilityContainer = document.querySelector(availabilityContainerSelector);
+    const smartButton = document.querySelector('#smart.paypal-smart-button, #smart.widget.paypal-smart-button');
 
     if (availabilityText) {
       if (!availabilityText.id) availabilityText.id = 'kjvItemAvailabilityText';
@@ -2701,11 +2702,15 @@ fhOnReady(function () {
       availabilityContainer.classList.toggle('is-available', !!isSalable);
     }
 
+    window.shAvailabilityIsSalable = !!isSalable;
+
     window.shAvailabilityHideCountdown = !isSalable;
 
     const countdown = document.getElementById('cutoff-countdown');
 
     if (countdown) countdown.style.display = isSalable ? '' : 'none';
+
+    if (smartButton) smartButton.style.display = isSalable ? '' : 'none';
   }
 
   function bootstrapAvailabilityWatcher() {
@@ -2791,6 +2796,18 @@ fhOnReady(function () {
   }
 
   startAvailabilityHandling(6);
+
+  const smartButtonObserver = new MutationObserver(function () {
+    if (typeof window.shAvailabilityIsSalable !== 'boolean') return;
+
+    const smartButton = document.querySelector('#smart.paypal-smart-button, #smart.widget.paypal-smart-button');
+
+    if (!smartButton) return;
+
+    smartButton.style.display = window.shAvailabilityIsSalable ? '' : 'none';
+  });
+
+  smartButtonObserver.observe(document.body, { childList: true, subtree: true });
 });
 // End Section: Availability state handling for product page
 

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -2658,6 +2658,7 @@ shOnReady(function () {
     const availabilityText = document.querySelector(availabilityTextSelector);
     const availabilityIcon = document.querySelector('#kjvItemAvailabilityIcon, .availability .availability-icon, [data-testing="availability-icon"]');
     const availabilityContainer = document.querySelector(availabilityContainerSelector);
+    const smartButton = document.querySelector('#smart.paypal-smart-button, #smart.widget.paypal-smart-button');
 
     if (availabilityText) {
       if (!availabilityText.id) availabilityText.id = 'kjvItemAvailabilityText';
@@ -2678,11 +2679,15 @@ shOnReady(function () {
       availabilityContainer.classList.toggle('is-available', !!isSalable);
     }
 
+    window.shAvailabilityIsSalable = !!isSalable;
+
     window.shAvailabilityHideCountdown = !isSalable;
 
     const countdown = document.getElementById('cutoff-countdown');
 
     if (countdown) countdown.style.display = isSalable ? '' : 'none';
+
+    if (smartButton) smartButton.style.display = isSalable ? '' : 'none';
   }
 
   function bootstrapAvailabilityWatcher() {
@@ -2768,6 +2773,18 @@ shOnReady(function () {
   }
 
   startAvailabilityHandling(6);
+
+  const smartButtonObserver = new MutationObserver(function () {
+    if (typeof window.shAvailabilityIsSalable !== 'boolean') return;
+
+    const smartButton = document.querySelector('#smart.paypal-smart-button, #smart.widget.paypal-smart-button');
+
+    if (!smartButton) return;
+
+    smartButton.style.display = window.shAvailabilityIsSalable ? '' : 'none';
+  });
+
+  smartButtonObserver.observe(document.body, { childList: true, subtree: true });
 });
 // End Section: Availability state handling for product page
 


### PR DESCRIPTION
### Motivation
- Hide the PayPal smart button on product pages when the item is out of stock and show it when stock is available. 
- Ensure the solution works when the PayPal button is inserted asynchronously by the plugin by using a lightweight DOM observer. 

### Description
- Added selection for the smart button using the selectors `#smart.paypal-smart-button` and `#smart.widget.paypal-smart-button` in both `JavaScript im Head/FH - JS im Head.js` and `JavaScript im Head/SH - JS im Head.js`. 
- Store the resolved availability state in `window.shAvailabilityIsSalable` and apply show/hide logic inside `applyAvailabilityUi`. 
- Added a small `MutationObserver` that watches the document for asynchronously inserted smart buttons and applies the stored availability state when the element appears. 
- Changes were applied to both FH and SH product-page availability handling blocks to keep shops in sync. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69731a1901788331b70b3d3c635625aa)