### PR TITLE
Add PayPal express checkout CSS adjustments to FH and SH stylesheets

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3868,3 +3868,18 @@ button[data-testing="quantity-btn-decrease"] {
     margin-top: 30px
 }
 /* End Section: Paqato Track & Trace Styling */
+
+/* Section: PayPal Express Checkout */
+.paypalSmartButtons div {
+    margin-left: auto; /* fixes weird margin */
+}
+
+.page-checkout .widget-fast-checkout .fc-container_left-inner .cmp-method-list .method-list-item[data-id="6001"] {
+  display: none !important;
+}
+
+body:has(.invoice-addresses-select .dropdown.items > div:first-child.disabled) #smart,
+body:has(.invoice-addresses-select .dropdown.items > div:first-child.disabled) .paypalSmartButtons {
+  display: none !important;
+}
+/* End Section: PayPal Express Checkout */

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3850,3 +3850,18 @@ button[data-testing="quantity-btn-decrease"] {
     margin-top: 30px
 }
 /* End Section: Paqato Track & Trace Styling */
+
+/* Section: PayPal Express Checkout */
+.paypalSmartButtons div {
+    margin-left: auto; /* fixes weird margin */
+}
+
+.page-checkout .widget-fast-checkout .fc-container_left-inner .cmp-method-list .method-list-item[data-id="6001"] {
+  display: none !important;
+}
+
+body:has(.invoice-addresses-select .dropdown.items > div:first-child.disabled) #smart,
+body:has(.invoice-addresses-select .dropdown.items > div:first-child.disabled) .paypalSmartButtons {
+  display: none !important;
+}
+/* End Section: PayPal Express Checkout */


### PR DESCRIPTION
### Motivation

- Fix layout issues for the PayPal smart buttons and remove a duplicate PayPal payment method that appears with the new PayPal Checkout plugin.
- Ensure the checkout UI hides PayPal controls when invoice address selection is in a disabled state.
- Apply the same fixes to both shop variants so FH and SH remain in sync.

### Description

- Inserted a new `PayPal Express Checkout` CSS section into `FH - Stylesheets.css` and `SH - Stylesheets.css`.
- Added `.paypalSmartButtons div { margin-left: auto; }` to correct an unexpected left margin on the smart button container.
- Added a rule to hide the additional PayPal payment item: `.page-checkout .widget-fast-checkout .fc-container_left-inner .cmp-method-list .method-list-item[data-id="6001"] { display: none !important; }`.
- Added a conditional hide using `:has()` to remove `#smart` and `.paypalSmartButtons` when the invoice-address selector is disabled: `body:has(.invoice-addresses-select .dropdown.items > div:first-child.disabled) #smart, body:has(.invoice-addresses-select .dropdown.items > div:first-child.disabled) .paypalSmartButtons { display: none !important; }`.

### Testing

- No automated tests were run because this is a CSS-only change; changes were committed to the repository for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697321a1359c8331bf64696089f3e86a)