### PR TITLE
Add GTM table of contents snippet for legal pages

### DIFF
--- a/Javascript/GTM Snippets/Legal-Table-of-Contents.js
+++ b/Javascript/GTM Snippets/Legal-Table-of-Contents.js
@@ -5,12 +5,31 @@
   var CONTAINER_SELECTOR = '.widget-legal-texts';
   var HEADING_SELECTOR = 'h1, h2, h3';
 
+  // Sticky header height (px) + a little breathing room
+  var HEADER_OFFSET_PX = 250;
+
+  function injectScrollOffsetCss() {
+    if (document.getElementById('legal-toc-scroll-offset-css')) return;
+
+    var style = document.createElement('style');
+    style.id = 'legal-toc-scroll-offset-css';
+    style.type = 'text/css';
+    style.textContent =
+      CONTAINER_SELECTOR + ' ' + HEADING_SELECTOR + ' {' +
+      '  scroll-margin-top: ' + HEADER_OFFSET_PX + 'px;' +
+      '}' +
+      // optional: if you ever land with a hash on initial load, help ensure offset is respected
+      'html { scroll-behavior: smooth; }';
+
+    document.head.appendChild(style);
+  }
+
   function slugify(text) {
     return (text || '')
       .trim()
       .toLowerCase()
-      .replace(/[^a-z0-9\s-]/g, '')
-      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9\\s-]/g, '')
+      .replace(/\\s+/g, '-')
       .replace(/-+/g, '-')
       .replace(/^-|-$/g, '') || 'toc-heading';
   }
@@ -23,7 +42,9 @@
     if (!container) return;
 
     var headings = Array.prototype.slice.call(container.querySelectorAll(HEADING_SELECTOR));
-    if (headings.length < 2) return; // adjust if you want it with 1 heading
+    if (headings.length < 2) return;
+
+    injectScrollOffsetCss();
 
     // Ensure unique ids (global uniqueness)
     var slugCounts = Object.create(null);
@@ -77,8 +98,26 @@
       var a = document.createElement('a');
       a.href = '#' + id;
       a.textContent = heading.textContent.trim();
-      li.appendChild(a);
 
+      // JS fallback offset scroll (works even if CSS scroll-margin is ignored)
+      a.addEventListener('click', function (e) {
+        e.preventDefault();
+        var target = document.getElementById(id);
+        if (!target) return;
+
+        var y = target.getBoundingClientRect().top + window.pageYOffset - HEADER_OFFSET_PX;
+
+        // Update URL hash without jumping
+        if (history && history.pushState) {
+          history.pushState(null, '', '#' + id);
+        } else {
+          window.location.hash = id;
+        }
+
+        window.scrollTo({ top: y, behavior: 'smooth' });
+      });
+
+      li.appendChild(a);
       return li;
     }
 
@@ -106,9 +145,7 @@
 
       if (tag === 'H2') {
         // If no H1 exists before, create an implicit bucket under root
-        var parentForH2 = currentH1Item || rootList;
-        if (parentForH2 === rootList) {
-          // no H1 yet: append as level-1 item to keep structure valid
+        if (!currentH1Item) {
           var li2NoH1 = makeItem(heading, 1);
           rootList.appendChild(li2NoH1);
           currentH1Item = li2NoH1;
@@ -124,22 +161,18 @@
       }
 
       if (tag === 'H3') {
-        // Prefer nesting under the latest H2; fallback to latest H1; fallback root
         if (currentH2Item) {
           var ul3 = ensureChildList(currentH2Item, 3);
-          var li3 = makeItem(heading, 3);
-          ul3.appendChild(li3);
+          ul3.appendChild(makeItem(heading, 3));
           return;
         }
 
         if (currentH1Item) {
           var ul3UnderH1 = ensureChildList(currentH1Item, 2);
-          var li3UnderH1 = makeItem(heading, 2);
-          ul3UnderH1.appendChild(li3UnderH1);
+          ul3UnderH1.appendChild(makeItem(heading, 2));
           return;
         }
 
-        // no previous headings: just add to root
         rootList.appendChild(makeItem(heading, 1));
       }
     });

--- a/Javascript/GTM Snippets/Legal-Table-of-Contents.js
+++ b/Javascript/GTM Snippets/Legal-Table-of-Contents.js
@@ -85,6 +85,7 @@
 
   const placeholder = document.getElementById('legal-toc');
   if (!placeholder) {
+    console.error('Legal TOC placeholder with id "legal-toc" was not found.');
     return;
   }
 

--- a/Javascript/GTM Snippets/Legal-Table-of-Contents.js
+++ b/Javascript/GTM Snippets/Legal-Table-of-Contents.js
@@ -2,13 +2,13 @@
 (function () {
   var TOC_PLACEHOLDER_ID = 'legal-toc';
   var TOC_NAV_ID = 'legal-toc-nav';
-  var SELECTOR = 'h1, h2, h3';
+  var CONTAINER_SELECTOR = '.widget-legal-texts';
+  var HEADING_SELECTOR = 'h1, h2, h3';
 
   function slugify(text) {
     return (text || '')
       .trim()
       .toLowerCase()
-      // basic latin slug; keeps numbers
       .replace(/[^a-z0-9\s-]/g, '')
       .replace(/\s+/g, '-')
       .replace(/-+/g, '-')
@@ -19,11 +19,13 @@
     // prevent duplicates
     if (document.getElementById(TOC_NAV_ID)) return;
 
-    var headings = Array.prototype.slice.call(document.querySelectorAll(SELECTOR));
-    // build TOC if there are at least 2 headings (adjust if you want)
-    if (headings.length < 2) return;
+    var container = document.querySelector(CONTAINER_SELECTOR);
+    if (!container) return;
 
-    // Ensure unique ids
+    var headings = Array.prototype.slice.call(container.querySelectorAll(HEADING_SELECTOR));
+    if (headings.length < 2) return; // adjust if you want it with 1 heading
+
+    // Ensure unique ids (global uniqueness)
     var slugCounts = Object.create(null);
     function ensureId(heading) {
       if (heading.id) return heading.id;
@@ -53,35 +55,104 @@
     title.textContent = 'Inhalt';
     nav.appendChild(title);
 
-    var list = document.createElement('ul');
-    list.className = 'legal-toc__list';
+    // Root list
+    var rootList = document.createElement('ul');
+    rootList.className = 'legal-toc__list legal-toc__list--level-1';
+    nav.appendChild(rootList);
 
-    headings.forEach(function (heading) {
+    // Hierarchy builders
+    var currentH1Item = null;
+    var currentH2Item = null;
+
+    function makeItem(heading, level) {
       var id = ensureId(heading);
 
-      var item = document.createElement('li');
-      item.className = 'legal-toc__item legal-toc__item--' + heading.tagName.toLowerCase();
+      var li = document.createElement('li');
+      li.className =
+        'legal-toc__item legal-toc__item--' +
+        heading.tagName.toLowerCase() +
+        ' legal-toc__item--level-' +
+        level;
 
-      var link = document.createElement('a');
-      link.href = '#' + id;
-      link.textContent = heading.textContent.trim();
+      var a = document.createElement('a');
+      a.href = '#' + id;
+      a.textContent = heading.textContent.trim();
+      li.appendChild(a);
 
-      item.appendChild(link);
-      list.appendChild(item);
+      return li;
+    }
+
+    function ensureChildList(parentLi, level) {
+      var existing = parentLi.querySelector(':scope > ul');
+      if (existing) return existing;
+
+      var ul = document.createElement('ul');
+      ul.className = 'legal-toc__list legal-toc__list--level-' + level;
+      parentLi.appendChild(ul);
+      return ul;
+    }
+
+    // Build nested structure: H1 > H2 > H3
+    headings.forEach(function (heading) {
+      var tag = heading.tagName.toUpperCase();
+
+      if (tag === 'H1') {
+        var li1 = makeItem(heading, 1);
+        rootList.appendChild(li1);
+        currentH1Item = li1;
+        currentH2Item = null;
+        return;
+      }
+
+      if (tag === 'H2') {
+        // If no H1 exists before, create an implicit bucket under root
+        var parentForH2 = currentH1Item || rootList;
+        if (parentForH2 === rootList) {
+          // no H1 yet: append as level-1 item to keep structure valid
+          var li2NoH1 = makeItem(heading, 1);
+          rootList.appendChild(li2NoH1);
+          currentH1Item = li2NoH1;
+          currentH2Item = null;
+          return;
+        }
+
+        var ul2 = ensureChildList(currentH1Item, 2);
+        var li2 = makeItem(heading, 2);
+        ul2.appendChild(li2);
+        currentH2Item = li2;
+        return;
+      }
+
+      if (tag === 'H3') {
+        // Prefer nesting under the latest H2; fallback to latest H1; fallback root
+        if (currentH2Item) {
+          var ul3 = ensureChildList(currentH2Item, 3);
+          var li3 = makeItem(heading, 3);
+          ul3.appendChild(li3);
+          return;
+        }
+
+        if (currentH1Item) {
+          var ul3UnderH1 = ensureChildList(currentH1Item, 2);
+          var li3UnderH1 = makeItem(heading, 2);
+          ul3UnderH1.appendChild(li3UnderH1);
+          return;
+        }
+
+        // no previous headings: just add to root
+        rootList.appendChild(makeItem(heading, 1));
+      }
     });
 
-    nav.appendChild(list);
-
-    // Place it: replace placeholder if present, otherwise insert before first heading
+    // Place it: replace placeholder if present, otherwise insert before container
     var placeholder = document.getElementById(TOC_PLACEHOLDER_ID);
     if (placeholder) {
       placeholder.replaceWith(nav);
       return;
     }
 
-    var firstHeading = headings[0];
-    if (firstHeading && firstHeading.parentNode) {
-      firstHeading.parentNode.insertBefore(nav, firstHeading);
+    if (container && container.parentNode) {
+      container.parentNode.insertBefore(nav, container);
       return;
     }
 
@@ -89,11 +160,11 @@
   }
 
   function runWhenReady() {
-    // Try now, then retry a few times for late-rendered content (common with CMPs/SPAs)
     buildToc();
 
+    // retry for late-rendered content
     var attempts = 0;
-    var maxAttempts = 20; // ~5s total
+    var maxAttempts = 20; // ~5s
     var interval = setInterval(function () {
       attempts += 1;
       buildToc();

--- a/Javascript/GTM Snippets/Legal-Table-of-Contents.js
+++ b/Javascript/GTM Snippets/Legal-Table-of-Contents.js
@@ -57,6 +57,7 @@
   };
 
   const nav = document.createElement('nav');
+  nav.id = 'legal-toc';
   nav.className = 'legal-toc';
   nav.setAttribute('aria-label', 'Inhaltsverzeichnis');
 
@@ -82,11 +83,10 @@
 
   nav.appendChild(list);
 
-  const main = document.querySelector('main') || document.body;
-  const insertBefore = main.querySelector(tocSelector) || main.firstChild;
-  if (!insertBefore) {
+  const placeholder = document.getElementById('legal-toc');
+  if (!placeholder) {
     return;
   }
 
-  main.insertBefore(nav, insertBefore);
+  placeholder.replaceWith(nav);
 })();

--- a/Javascript/GTM Snippets/Legal-Table-of-Contents.js
+++ b/Javascript/GTM Snippets/Legal-Table-of-Contents.js
@@ -1,93 +1,112 @@
-(() => {
-  const tocSelector = 'h1, h2, h3';
-  const headings = Array.from(document.querySelectorAll(tocSelector));
-  if (headings.length === 0) {
-    return;
-  }
+<script>
+(function () {
+  var TOC_PLACEHOLDER_ID = 'legal-toc';
+  var TOC_NAV_ID = 'legal-toc-nav';
+  var SELECTOR = 'h1, h2, h3';
 
-  const counts = headings.reduce(
-    (acc, heading) => {
-      const tag = heading.tagName;
-      acc[tag] = (acc[tag] || 0) + 1;
-      return acc;
-    },
-    { H1: 0, H2: 0, H3: 0 },
-  );
-
-  const eligibleTags = Object.keys(counts).filter((tag) => counts[tag] > 1);
-  if (eligibleTags.length === 0) {
-    return;
-  }
-
-  const eligibleHeadings = headings.filter((heading) => eligibleTags.includes(heading.tagName));
-  if (eligibleHeadings.length === 0) {
-    return;
-  }
-
-  const slugCounts = new Map();
-  const ensureId = (heading) => {
-    if (heading.id) {
-      return heading.id;
-    }
-
-    const baseSlug = heading.textContent
+  function slugify(text) {
+    return (text || '')
       .trim()
       .toLowerCase()
+      // basic latin slug; keeps numbers
       .replace(/[^a-z0-9\s-]/g, '')
       .replace(/\s+/g, '-')
       .replace(/-+/g, '-')
       .replace(/^-|-$/g, '') || 'toc-heading';
-
-    const currentCount = slugCounts.get(baseSlug) || 0;
-    slugCounts.set(baseSlug, currentCount + 1);
-
-    let candidate = baseSlug;
-    if (currentCount > 0) {
-      candidate = `${baseSlug}-${currentCount + 1}`;
-    }
-
-    while (document.getElementById(candidate)) {
-      const nextCount = (slugCounts.get(baseSlug) || 1) + 1;
-      slugCounts.set(baseSlug, nextCount);
-      candidate = `${baseSlug}-${nextCount}`;
-    }
-
-    heading.id = candidate;
-    return candidate;
-  };
-
-  const nav = document.createElement('nav');
-  nav.id = 'legal-toc';
-  nav.className = 'legal-toc';
-  nav.setAttribute('aria-label', 'Inhaltsverzeichnis');
-
-  const title = document.createElement('strong');
-  title.textContent = 'Inhalt';
-  nav.appendChild(title);
-
-  const list = document.createElement('ul');
-  list.className = 'legal-toc__list';
-
-  eligibleHeadings.forEach((heading) => {
-    const id = ensureId(heading);
-    const item = document.createElement('li');
-    item.className = `legal-toc__item legal-toc__item--${heading.tagName.toLowerCase()}`;
-
-    const link = document.createElement('a');
-    link.href = `#${id}`;
-    link.textContent = heading.textContent.trim();
-
-    item.appendChild(link);
-    list.appendChild(item);
-  });
-
-  nav.appendChild(list);
-
-  const placeholder = document.getElementById('legal-toc');
-  if (!placeholder) {
-    console.error('Legal TOC placeholder with id "legal-toc" was not found.');
-    return;
   }
 
-  placeholder.replaceWith(nav);
+  function buildToc() {
+    // prevent duplicates
+    if (document.getElementById(TOC_NAV_ID)) return;
+
+    var headings = Array.prototype.slice.call(document.querySelectorAll(SELECTOR));
+    // build TOC if there are at least 2 headings (adjust if you want)
+    if (headings.length < 2) return;
+
+    // Ensure unique ids
+    var slugCounts = Object.create(null);
+    function ensureId(heading) {
+      if (heading.id) return heading.id;
+
+      var base = slugify(heading.textContent);
+      var n = slugCounts[base] || 0;
+      slugCounts[base] = n + 1;
+
+      var candidate = n === 0 ? base : (base + '-' + (n + 1));
+      while (document.getElementById(candidate)) {
+        n += 1;
+        slugCounts[base] = n + 1;
+        candidate = base + '-' + (n + 1);
+      }
+
+      heading.id = candidate;
+      return candidate;
+    }
+
+    // Create nav
+    var nav = document.createElement('nav');
+    nav.id = TOC_NAV_ID;
+    nav.className = 'legal-toc';
+    nav.setAttribute('aria-label', 'Inhaltsverzeichnis');
+
+    var title = document.createElement('strong');
+    title.textContent = 'Inhalt';
+    nav.appendChild(title);
+
+    var list = document.createElement('ul');
+    list.className = 'legal-toc__list';
+
+    headings.forEach(function (heading) {
+      var id = ensureId(heading);
+
+      var item = document.createElement('li');
+      item.className = 'legal-toc__item legal-toc__item--' + heading.tagName.toLowerCase();
+
+      var link = document.createElement('a');
+      link.href = '#' + id;
+      link.textContent = heading.textContent.trim();
+
+      item.appendChild(link);
+      list.appendChild(item);
+    });
+
+    nav.appendChild(list);
+
+    // Place it: replace placeholder if present, otherwise insert before first heading
+    var placeholder = document.getElementById(TOC_PLACEHOLDER_ID);
+    if (placeholder) {
+      placeholder.replaceWith(nav);
+      return;
+    }
+
+    var firstHeading = headings[0];
+    if (firstHeading && firstHeading.parentNode) {
+      firstHeading.parentNode.insertBefore(nav, firstHeading);
+      return;
+    }
+
+    (document.querySelector('main') || document.body).insertBefore(nav, (document.body.firstChild || null));
+  }
+
+  function runWhenReady() {
+    // Try now, then retry a few times for late-rendered content (common with CMPs/SPAs)
+    buildToc();
+
+    var attempts = 0;
+    var maxAttempts = 20; // ~5s total
+    var interval = setInterval(function () {
+      attempts += 1;
+      buildToc();
+      if (document.getElementById(TOC_NAV_ID) || attempts >= maxAttempts) {
+        clearInterval(interval);
+      }
+    }, 250);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', runWhenReady);
+  } else {
+    runWhenReady();
+  }
 })();
+</script>

--- a/Javascript/GTM Snippets/Legal-Table-of-Contents.js
+++ b/Javascript/GTM Snippets/Legal-Table-of-Contents.js
@@ -1,0 +1,92 @@
+(() => {
+  const tocSelector = 'h1, h2, h3';
+  const headings = Array.from(document.querySelectorAll(tocSelector));
+  if (headings.length === 0) {
+    return;
+  }
+
+  const counts = headings.reduce(
+    (acc, heading) => {
+      const tag = heading.tagName;
+      acc[tag] = (acc[tag] || 0) + 1;
+      return acc;
+    },
+    { H1: 0, H2: 0, H3: 0 },
+  );
+
+  const eligibleTags = Object.keys(counts).filter((tag) => counts[tag] > 1);
+  if (eligibleTags.length === 0) {
+    return;
+  }
+
+  const eligibleHeadings = headings.filter((heading) => eligibleTags.includes(heading.tagName));
+  if (eligibleHeadings.length === 0) {
+    return;
+  }
+
+  const slugCounts = new Map();
+  const ensureId = (heading) => {
+    if (heading.id) {
+      return heading.id;
+    }
+
+    const baseSlug = heading.textContent
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '') || 'toc-heading';
+
+    const currentCount = slugCounts.get(baseSlug) || 0;
+    slugCounts.set(baseSlug, currentCount + 1);
+
+    let candidate = baseSlug;
+    if (currentCount > 0) {
+      candidate = `${baseSlug}-${currentCount + 1}`;
+    }
+
+    while (document.getElementById(candidate)) {
+      const nextCount = (slugCounts.get(baseSlug) || 1) + 1;
+      slugCounts.set(baseSlug, nextCount);
+      candidate = `${baseSlug}-${nextCount}`;
+    }
+
+    heading.id = candidate;
+    return candidate;
+  };
+
+  const nav = document.createElement('nav');
+  nav.className = 'legal-toc';
+  nav.setAttribute('aria-label', 'Inhaltsverzeichnis');
+
+  const title = document.createElement('strong');
+  title.textContent = 'Inhalt';
+  nav.appendChild(title);
+
+  const list = document.createElement('ul');
+  list.className = 'legal-toc__list';
+
+  eligibleHeadings.forEach((heading) => {
+    const id = ensureId(heading);
+    const item = document.createElement('li');
+    item.className = `legal-toc__item legal-toc__item--${heading.tagName.toLowerCase()}`;
+
+    const link = document.createElement('a');
+    link.href = `#${id}`;
+    link.textContent = heading.textContent.trim();
+
+    item.appendChild(link);
+    list.appendChild(item);
+  });
+
+  nav.appendChild(list);
+
+  const main = document.querySelector('main') || document.body;
+  const insertBefore = main.querySelector(tocSelector) || main.firstChild;
+  if (!insertBefore) {
+    return;
+  }
+
+  main.insertBefore(nav, insertBefore);
+})();

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Variiert den Platzhaltertext im Suchfeld, solange das Feld sichtbar, aber nicht 
 ### „Weiter einkaufen“-Button im Warenkorb-Overlay
 Benennt die Schaltfläche „Warenkorb“ im Overlay um, ergänzt ein Pfeil-Icon und sorgt dafür, dass der Klick das Overlay schließt, statt auf die Warenkorbseite zu wechseln.
 
+### Inhaltsverzeichnis für Rechtstexte (GTM-Snippet)
+Erzeugt für rechtliche Content-Seiten ein dynamisches Inhaltsverzeichnis aus allen `h1`, `h2` und `h3`-Elementen, sofern je Typ mehr als eine Überschrift vorhanden ist. Die Ausgabe wird per Google Tag Manager eingebunden und liegt unter `Javascript/GTM Snippets/Legal-Table-of-Contents.js`.
+
 ## Weiterer Fahrplan
 
 * Bestehende Skripte dienen nur als Zwischenlösung – langfristig sollen daraus eigenständige, wartbare Plugins entstehen.


### PR DESCRIPTION
### Motivation
- Provide a lightweight, GTM-deployable script that automatically creates a table-of-contents on legal content pages (e.g. Terms, Privacy) to improve navigation. 
- Only surface heading levels that are meaningful on a page by including `h1`, `h2`, and `h3` entries when more than one of that tag exists.  
- Ensure generated anchors are unique and non-destructive to existing IDs so the snippet is safe to run alongside existing Ceres templates.

### Description
- Added a GTM-ready, self-invoking script at `Javascript/GTM Snippets/Legal-Table-of-Contents.js` that: selects `h1`, `h2`, `h3`, counts occurrences, and only includes headings for tag types where count > 1.  
- The script generates URL-safe slugs, ensures unique IDs (avoiding collisions with existing IDs), creates a semantic `<nav>` with an `<ul>` of links, and inserts the TOC before the first heading inside `main` (or `document.body` fallback).  
- The TOC element is given accessible attributes (`aria-label`) and CSS class names (`legal-toc`, `legal-toc__list`, `legal-toc__item`) for easy styling.  
- Documented the new snippet in `README.md` under the feature list and noted the file location (`Javascript/GTM Snippets/Legal-Table-of-Contents.js`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69787090f6088331a9a555b83ef7e63d)