### PR TITLE
feat(components): add FH/SH start slider and category nav components

### DIFF
--- a/Custom Components/FH Custom FW Start Highlight Category Nav.html
+++ b/Custom Components/FH Custom FW Start Highlight Category Nav.html
@@ -1,0 +1,8 @@
+<nav class="fh-start-highlight-nav" data-fh-start-highlight-nav aria-label="Start Kategorien">
+  <div class="fh-start-highlight-nav__inner">
+    <h2 class="fh-start-highlight-nav__title">Top-Kategorien</h2>
+    <ul class="fh-start-highlight-nav__list">
+      <!-- TODO: Kategorie-Links ergänzen und auf Ceres-Template-Struktur abstimmen. -->
+    </ul>
+  </div>
+</nav>

--- a/Custom Components/FH Custom FW Start Slider.html
+++ b/Custom Components/FH Custom FW Start Slider.html
@@ -1,0 +1,11 @@
+<section class="fh-start-slider" data-fh-start-slider>
+  <div class="fh-start-slider__inner">
+    <header class="fh-start-slider__header">
+      <h2 class="fh-start-slider__title">Start-Highlights</h2>
+      <p class="fh-start-slider__subtitle">Platziere hier die wichtigsten Kampagnen für Deine Startseite.</p>
+    </header>
+    <div class="fh-start-slider__content">
+      <!-- TODO: Slider-Items in plentyShop LTS ergänzen und mit Ceres-Struktur abgleichen. -->
+    </div>
+  </div>
+</section>

--- a/Custom Components/SH Custom FW Start Highlight Category Nav.html
+++ b/Custom Components/SH Custom FW Start Highlight Category Nav.html
@@ -1,0 +1,8 @@
+<nav class="sh-start-highlight-nav" data-sh-start-highlight-nav aria-label="Start Kategorien">
+  <div class="sh-start-highlight-nav__inner">
+    <h2 class="sh-start-highlight-nav__title">Top-Kategorien</h2>
+    <ul class="sh-start-highlight-nav__list">
+      <!-- TODO: Kategorie-Links ergänzen und auf Ceres-Template-Struktur abstimmen. -->
+    </ul>
+  </div>
+</nav>

--- a/Custom Components/SH Custom FW Start Slider.html
+++ b/Custom Components/SH Custom FW Start Slider.html
@@ -1,0 +1,11 @@
+<section class="sh-start-slider" data-sh-start-slider>
+  <div class="sh-start-slider__inner">
+    <header class="sh-start-slider__header">
+      <h2 class="sh-start-slider__title">Start-Highlights</h2>
+      <p class="sh-start-slider__subtitle">Platziere hier die wichtigsten Kampagnen für Deine Startseite.</p>
+    </header>
+    <div class="sh-start-slider__content">
+      <!-- TODO: Slider-Items in plentyShop LTS ergänzen und mit Ceres-Struktur abgleichen. -->
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
### Motivation
- Provide scaffolded custom components for FH and SH start-page slider and top-category navigation to enable building the new start blocks and to align with Ceres templates.

### Description
- Add four new HTML stubs: `Custom Components/FH Custom FW Start Slider.html`, `Custom Components/SH Custom FW Start Slider.html`, `Custom Components/FH Custom FW Start Highlight Category Nav.html`, and `Custom Components/SH Custom FW Start Highlight Category Nav.html`; each file contains minimal markup and TODO notes to align the implementation with plentyShop LTS (Ceres).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b5a0331ac8331a6e1bb90e818da06)