### PR TITLE
feat(nav): add start highlight preview cards

### DIFF
--- a/Custom Components/FH Custom FW Start Highlight Category Nav.html
+++ b/Custom Components/FH Custom FW Start Highlight Category Nav.html
@@ -4,37 +4,49 @@
     <ul class="fh-start-highlight-nav__list">
       <li class="fh-start-highlight-nav__item">
         <a href="/schloesser" class="fh-start-highlight-nav__card">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Schloesser_Kategorie_Nav_Vorschau_360x120.jpg" alt="Schlösser Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          <span class="fh-start-highlight-nav__media">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Schloesser_Kategorie_Nav_Vorschau_360x120.jpg" alt="Schlösser Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          </span>
           <span class="fh-start-highlight-nav__label">Schlösser</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
         <a href="/beschlaege" class="fh-start-highlight-nav__card">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Beschlaege_Kategorie_Nav_Vorschau_360x120.jpg" alt="Beschläge Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          <span class="fh-start-highlight-nav__media">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Beschlaege_Kategorie_Nav_Vorschau_360x120.jpg" alt="Beschläge Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          </span>
           <span class="fh-start-highlight-nav__label">Beschläge</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
         <a href="/fenster-sicherheit/" class="fh-start-highlight-nav__card">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Fenster_und_Sicherheit_Kategorie_Nav_Vorschau_360x120.jpg" alt="Fenster &amp; Sicherheit Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          <span class="fh-start-highlight-nav__media">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Fenster_und_Sicherheit_Kategorie_Nav_Vorschau_360x120.jpg" alt="Fenster &amp; Sicherheit Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          </span>
           <span class="fh-start-highlight-nav__label">Fenster &amp; Sicherheit</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
         <a href="/terrasse" class="fh-start-highlight-nav__card">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Garten_Kategorie_Nav_Vorschau_360x120.jpg" alt="Garten Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          <span class="fh-start-highlight-nav__media">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Garten_Kategorie_Nav_Vorschau_360x120.jpg" alt="Garten Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          </span>
           <span class="fh-start-highlight-nav__label">Garten</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
         <a href="/chemische-befestigung" class="fh-start-highlight-nav__card">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Bauchemie_Kategorie_Nav_Vorschau_360x120.jpg" alt="Bauchemie Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          <span class="fh-start-highlight-nav__media">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Bauchemie_Kategorie_Nav_Vorschau_360x120.jpg" alt="Bauchemie Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          </span>
           <span class="fh-start-highlight-nav__label">Bauchemie</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
         <a href="/zubehoer" class="fh-start-highlight-nav__card">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Zubehoer_Kategorie_Nav_Vorschau_360x120.jpg" alt="Zubehör Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          <span class="fh-start-highlight-nav__media">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Zubehoer_Kategorie_Nav_Vorschau_360x120.jpg" alt="Zubehör Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          </span>
           <span class="fh-start-highlight-nav__label">Zubehör</span>
         </a>
       </li>

--- a/Custom Components/FH Custom FW Start Highlight Category Nav.html
+++ b/Custom Components/FH Custom FW Start Highlight Category Nav.html
@@ -7,8 +7,13 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Schloesser_Kategorie_Nav_Vorschau_360x120.jpg" alt="Schlösser Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">🔐 Schlösser</span>
-          <span class="fh-start-highlight-nav__intro">Mach dein Zuhause sicherer – mit Schließtechnik, auf die du dich verlassen kannst. Ob Einsteckschlösser, Profilzylinder oder Vorhängeschlösser: Hier findest du Lösungen für Haus, Garage und Gewerbe, die Schutz, Komfort und Langlebigkeit vereinen.</span>
+          <span class="fh-start-highlight-nav__label">
+            <span class="fh-start-highlight-nav__label-icon" aria-hidden="true">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Schloesser_icon_2.svg" alt="">
+            </span>
+            Schlösser
+          </span>
+          <span class="fh-start-highlight-nav__intro">Passende Lösungen für Haustüren, Wohnungstüren, Zimmer und Tore: Entdecke robuste Schlösser, elektrische Türöffner sowie Profilzylinder inklusive Zubehör für maximale Sicherheit.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -16,8 +21,13 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Beschlaege_Kategorie_Nav_Vorschau_360x120.jpg" alt="Beschläge Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">🚪 Beschläge</span>
-          <span class="fh-start-highlight-nav__intro">Gib Türen und Fenstern den letzten Feinschliff. Mit hochwertigen Griffen, Rosetten, Schildern und Glasbeschlägen bringst du Funktion und Design zusammen – für Räume, die nicht nur gut aussehen, sondern sich auch gut anfühlen.</span>
+          <span class="fh-start-highlight-nav__label">
+            <span class="fh-start-highlight-nav__label-icon" aria-hidden="true">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Beschlaege_icon_2.svg" alt="">
+            </span>
+            Beschläge
+          </span>
+          <span class="fh-start-highlight-nav__intro">Gib Türen und Fenstern den letzten Feinschliff mit Griffen, Rosetten, Schildern und Glasbeschlägen für funktionale, langlebige Lösungen.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -25,8 +35,13 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Fenster_und_Sicherheit_Kategorie_Nav_Vorschau_360x120.jpg" alt="Fenster &amp; Sicherheit Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">🛡 Fenster &amp; Sicherheit</span>
-          <span class="fh-start-highlight-nav__intro">Sorge für ein gutes Gefühl in den eigenen vier Wänden. Mit Fensterbeschlägen, Sicherungselementen und cleveren Nachrüstlösungen machst du dein Zuhause spürbar sicherer – einfach montiert, dauerhaft wirksam.</span>
+          <span class="fh-start-highlight-nav__label">
+            <span class="fh-start-highlight-nav__label-icon" aria-hidden="true">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Fenster_Sicherheit_icon_2.svg" alt="">
+            </span>
+            Fenster &amp; Sicherheit
+          </span>
+          <span class="fh-start-highlight-nav__intro">Fensterbeschläge, Sicherungselemente und Nachrüstlösungen für ein sicheres Zuhause – schnell montiert und dauerhaft wirksam.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -34,8 +49,13 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Garten_Kategorie_Nav_Vorschau_360x120.jpg" alt="Garten Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">🌿 Terrasse</span>
-          <span class="fh-start-highlight-nav__intro">Schaffe dir deinen persönlichen Wohlfühlplatz im Freien. Von Terrassenschrauben über Unterkonstruktionen bis zu passenden Zubehörteilen findest du hier alles, um deine Terrasse stabil, langlebig und schön umzusetzen.</span>
+          <span class="fh-start-highlight-nav__label">
+            <span class="fh-start-highlight-nav__label-icon" aria-hidden="true">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Gartnebau_icon.svg" alt="">
+            </span>
+            Terrasse
+          </span>
+          <span class="fh-start-highlight-nav__intro">Terrassenschrauben, Unterkonstruktionen und Zubehör für eine stabile, langlebige Terrasse mit sauberem Finish.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -43,8 +63,13 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Bauchemie_Kategorie_Nav_Vorschau_360x120.jpg" alt="Bauchemie Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">🧪 Bauchemie</span>
-          <span class="fh-start-highlight-nav__intro">Verleihe deinen Projekten dauerhaft festen Halt. Mit Injektionsmörtel, Dicht- und Anschlussbändern sowie weiteren bauchemischen Produkten sorgst du für sichere Befestigungen und saubere Abschlüsse – auch bei anspruchsvollen Anwendungen.</span>
+          <span class="fh-start-highlight-nav__label">
+            <span class="fh-start-highlight-nav__label-icon" aria-hidden="true">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Bauchemie_icon.svg" alt="">
+            </span>
+            Bauchemie
+          </span>
+          <span class="fh-start-highlight-nav__intro">Injektionsmörtel, Dicht- und Anschlussbänder sowie bauchemische Produkte für sichere Befestigungen und saubere Abschlüsse.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -52,8 +77,13 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Zubehoer_Kategorie_Nav_Vorschau_360x120.jpg" alt="Zubehör Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">🧰 Zubehör</span>
-          <span class="fh-start-highlight-nav__intro">Arbeite schneller, sauberer und präziser. Mit passenden Bits, Bohrern, Klebebändern und Werkzeugen hast du die richtigen Helfer zur Hand – für effiziente Montage und professionelle Ergebnisse.</span>
+          <span class="fh-start-highlight-nav__label">
+            <span class="fh-start-highlight-nav__label-icon" aria-hidden="true">
+              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Zubehoer_icon_2.svg" alt="">
+            </span>
+            Zubehör
+          </span>
+          <span class="fh-start-highlight-nav__intro">Bits, Bohrer, Klebebänder und Werkzeuge für schnelle, saubere und präzise Montage.</span>
         </a>
       </li>
     </ul>

--- a/Custom Components/FH Custom FW Start Highlight Category Nav.html
+++ b/Custom Components/FH Custom FW Start Highlight Category Nav.html
@@ -7,7 +7,8 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Schloesser_Kategorie_Nav_Vorschau_360x120.jpg" alt="Schlösser Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">Schlösser</span>
+          <span class="fh-start-highlight-nav__label">🔐 Schlösser</span>
+          <span class="fh-start-highlight-nav__intro">Mach dein Zuhause sicherer – mit Schließtechnik, auf die du dich verlassen kannst. Ob Einsteckschlösser, Profilzylinder oder Vorhängeschlösser: Hier findest du Lösungen für Haus, Garage und Gewerbe, die Schutz, Komfort und Langlebigkeit vereinen.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -15,7 +16,8 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Beschlaege_Kategorie_Nav_Vorschau_360x120.jpg" alt="Beschläge Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">Beschläge</span>
+          <span class="fh-start-highlight-nav__label">🚪 Beschläge</span>
+          <span class="fh-start-highlight-nav__intro">Gib Türen und Fenstern den letzten Feinschliff. Mit hochwertigen Griffen, Rosetten, Schildern und Glasbeschlägen bringst du Funktion und Design zusammen – für Räume, die nicht nur gut aussehen, sondern sich auch gut anfühlen.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -23,7 +25,8 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Fenster_und_Sicherheit_Kategorie_Nav_Vorschau_360x120.jpg" alt="Fenster &amp; Sicherheit Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">Fenster &amp; Sicherheit</span>
+          <span class="fh-start-highlight-nav__label">🛡 Fenster &amp; Sicherheit</span>
+          <span class="fh-start-highlight-nav__intro">Sorge für ein gutes Gefühl in den eigenen vier Wänden. Mit Fensterbeschlägen, Sicherungselementen und cleveren Nachrüstlösungen machst du dein Zuhause spürbar sicherer – einfach montiert, dauerhaft wirksam.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -31,7 +34,8 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Garten_Kategorie_Nav_Vorschau_360x120.jpg" alt="Garten Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">Garten</span>
+          <span class="fh-start-highlight-nav__label">🌿 Terrasse</span>
+          <span class="fh-start-highlight-nav__intro">Schaffe dir deinen persönlichen Wohlfühlplatz im Freien. Von Terrassenschrauben über Unterkonstruktionen bis zu passenden Zubehörteilen findest du hier alles, um deine Terrasse stabil, langlebig und schön umzusetzen.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -39,7 +43,8 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Bauchemie_Kategorie_Nav_Vorschau_360x120.jpg" alt="Bauchemie Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">Bauchemie</span>
+          <span class="fh-start-highlight-nav__label">🧪 Bauchemie</span>
+          <span class="fh-start-highlight-nav__intro">Verleihe deinen Projekten dauerhaft festen Halt. Mit Injektionsmörtel, Dicht- und Anschlussbändern sowie weiteren bauchemischen Produkten sorgst du für sichere Befestigungen und saubere Abschlüsse – auch bei anspruchsvollen Anwendungen.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -47,7 +52,8 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Zubehoer_Kategorie_Nav_Vorschau_360x120.jpg" alt="Zubehör Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">Zubehör</span>
+          <span class="fh-start-highlight-nav__label">🧰 Zubehör</span>
+          <span class="fh-start-highlight-nav__intro">Arbeite schneller, sauberer und präziser. Mit passenden Bits, Bohrern, Klebebändern und Werkzeugen hast du die richtigen Helfer zur Hand – für effiziente Montage und professionelle Ergebnisse.</span>
         </a>
       </li>
     </ul>

--- a/Custom Components/FH Custom FW Start Highlight Category Nav.html
+++ b/Custom Components/FH Custom FW Start Highlight Category Nav.html
@@ -1,6 +1,6 @@
 <nav class="fh-start-highlight-nav" data-fh-start-highlight-nav aria-label="Start Kategorien">
   <div class="fh-start-highlight-nav__inner">
-    <h2 class="fh-start-highlight-nav__title">Top-Kategorien</h2>
+    <h2 class="fh-start-highlight-nav__title">Deine Hammer-Kategorien</h2>
     <ul class="fh-start-highlight-nav__list">
       <li class="fh-start-highlight-nav__item">
         <a href="/schloesser" class="fh-start-highlight-nav__card">
@@ -8,7 +8,7 @@
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Schloesser_Kategorie_Nav_Vorschau_360x120.jpg" alt="Schlösser Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
           <span class="fh-start-highlight-nav__label">Schlösser</span>
-          <span class="fh-start-highlight-nav__intro">Mehr Sicherheit für dein Zuhause – mit zuverlässigen Schlössern für Türen, Tore und mehr. Einfach auswählen, einbauen, sicher fühlen.</span>
+          <span class="fh-start-highlight-nav__intro">Mehr Sicherheit für dein Zuhause – mit zuverlässigen Schlössern für Türen, Tore und mehr.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">

--- a/Custom Components/FH Custom FW Start Highlight Category Nav.html
+++ b/Custom Components/FH Custom FW Start Highlight Category Nav.html
@@ -7,13 +7,8 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Schloesser_Kategorie_Nav_Vorschau_360x120.jpg" alt="Schlösser Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">
-            <span class="fh-start-highlight-nav__label-icon" aria-hidden="true">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Schloesser_icon_2.svg" alt="">
-            </span>
-            Schlösser
-          </span>
-          <span class="fh-start-highlight-nav__intro">Passende Lösungen für Haustüren, Wohnungstüren, Zimmer und Tore: Entdecke robuste Schlösser, elektrische Türöffner sowie Profilzylinder inklusive Zubehör für maximale Sicherheit.</span>
+          <span class="fh-start-highlight-nav__label">Schlösser</span>
+          <span class="fh-start-highlight-nav__intro">Mehr Sicherheit für dein Zuhause – mit zuverlässigen Schlössern für Türen, Tore und mehr. Einfach auswählen, einbauen, sicher fühlen.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -21,13 +16,8 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Beschlaege_Kategorie_Nav_Vorschau_360x120.jpg" alt="Beschläge Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">
-            <span class="fh-start-highlight-nav__label-icon" aria-hidden="true">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Beschlaege_icon_2.svg" alt="">
-            </span>
-            Beschläge
-          </span>
-          <span class="fh-start-highlight-nav__intro">Gib Türen und Fenstern den letzten Feinschliff mit Griffen, Rosetten, Schildern und Glasbeschlägen für funktionale, langlebige Lösungen.</span>
+          <span class="fh-start-highlight-nav__label">Beschläge</span>
+          <span class="fh-start-highlight-nav__intro">Verleihe Türen und Fenstern neuen Charakter – mit Griffen, Rosetten und Beschlägen für Funktion und Stil.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -35,13 +25,8 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Fenster_und_Sicherheit_Kategorie_Nav_Vorschau_360x120.jpg" alt="Fenster &amp; Sicherheit Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">
-            <span class="fh-start-highlight-nav__label-icon" aria-hidden="true">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Fenster_Sicherheit_icon_2.svg" alt="">
-            </span>
-            Fenster &amp; Sicherheit
-          </span>
-          <span class="fh-start-highlight-nav__intro">Fensterbeschläge, Sicherungselemente und Nachrüstlösungen für ein sicheres Zuhause – schnell montiert und dauerhaft wirksam.</span>
+          <span class="fh-start-highlight-nav__label">Fenster &amp; Sicherheit</span>
+          <span class="fh-start-highlight-nav__intro">Mehr Schutz für dein Zuhause – mit cleveren Fenster- und Sicherheitslösungen zum Nachrüsten.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -49,13 +34,8 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Garten_Kategorie_Nav_Vorschau_360x120.jpg" alt="Garten Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">
-            <span class="fh-start-highlight-nav__label-icon" aria-hidden="true">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Gartnebau_icon.svg" alt="">
-            </span>
-            Terrasse
-          </span>
-          <span class="fh-start-highlight-nav__intro">Terrassenschrauben, Unterkonstruktionen und Zubehör für eine stabile, langlebige Terrasse mit sauberem Finish.</span>
+          <span class="fh-start-highlight-nav__label">Terrasse</span>
+          <span class="fh-start-highlight-nav__intro">Baue dir deinen Lieblingsplatz draußen – mit Terrassenschrauben und Zubehör für stabile Ergebnisse.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -63,13 +43,8 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Bauchemie_Kategorie_Nav_Vorschau_360x120.jpg" alt="Bauchemie Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">
-            <span class="fh-start-highlight-nav__label-icon" aria-hidden="true">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Bauchemie_icon.svg" alt="">
-            </span>
-            Bauchemie
-          </span>
-          <span class="fh-start-highlight-nav__intro">Injektionsmörtel, Dicht- und Anschlussbänder sowie bauchemische Produkte für sichere Befestigungen und saubere Abschlüsse.</span>
+          <span class="fh-start-highlight-nav__label">Bauchemie</span>
+          <span class="fh-start-highlight-nav__intro">Fester Halt für anspruchsvolle Montagen – mit Mörtel, Dichtungen und Bauchemie.</span>
         </a>
       </li>
       <li class="fh-start-highlight-nav__item">
@@ -77,13 +52,8 @@
           <span class="fh-start-highlight-nav__media">
             <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Zubehoer_Kategorie_Nav_Vorschau_360x120.jpg" alt="Zubehör Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
           </span>
-          <span class="fh-start-highlight-nav__label">
-            <span class="fh-start-highlight-nav__label-icon" aria-hidden="true">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Zubehoer_icon_2.svg" alt="">
-            </span>
-            Zubehör
-          </span>
-          <span class="fh-start-highlight-nav__intro">Bits, Bohrer, Klebebänder und Werkzeuge für schnelle, saubere und präzise Montage.</span>
+          <span class="fh-start-highlight-nav__label">Zubehör</span>
+          <span class="fh-start-highlight-nav__intro">Die richtigen Helfer für jedes Projekt – Bits, Bohrer und Werkzeuge für saubere Arbeit.</span>
         </a>
       </li>
     </ul>

--- a/Custom Components/FH Custom FW Start Highlight Category Nav.html
+++ b/Custom Components/FH Custom FW Start Highlight Category Nav.html
@@ -2,7 +2,42 @@
   <div class="fh-start-highlight-nav__inner">
     <h2 class="fh-start-highlight-nav__title">Top-Kategorien</h2>
     <ul class="fh-start-highlight-nav__list">
-      <!-- TODO: Kategorie-Links ergänzen und auf Ceres-Template-Struktur abstimmen. -->
+      <li class="fh-start-highlight-nav__item">
+        <a href="/schloesser" class="fh-start-highlight-nav__card">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Schloesser_Kategorie_Nav_Vorschau_360x120.jpg" alt="Schlösser Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          <span class="fh-start-highlight-nav__label">Schlösser</span>
+        </a>
+      </li>
+      <li class="fh-start-highlight-nav__item">
+        <a href="/beschlaege" class="fh-start-highlight-nav__card">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Beschlaege_Kategorie_Nav_Vorschau_360x120.jpg" alt="Beschläge Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          <span class="fh-start-highlight-nav__label">Beschläge</span>
+        </a>
+      </li>
+      <li class="fh-start-highlight-nav__item">
+        <a href="/fenster-sicherheit/" class="fh-start-highlight-nav__card">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Fenster_und_Sicherheit_Kategorie_Nav_Vorschau_360x120.jpg" alt="Fenster &amp; Sicherheit Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          <span class="fh-start-highlight-nav__label">Fenster &amp; Sicherheit</span>
+        </a>
+      </li>
+      <li class="fh-start-highlight-nav__item">
+        <a href="/terrasse" class="fh-start-highlight-nav__card">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Garten_Kategorie_Nav_Vorschau_360x120.jpg" alt="Garten Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          <span class="fh-start-highlight-nav__label">Garten</span>
+        </a>
+      </li>
+      <li class="fh-start-highlight-nav__item">
+        <a href="/chemische-befestigung" class="fh-start-highlight-nav__card">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Bauchemie_Kategorie_Nav_Vorschau_360x120.jpg" alt="Bauchemie Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          <span class="fh-start-highlight-nav__label">Bauchemie</span>
+        </a>
+      </li>
+      <li class="fh-start-highlight-nav__item">
+        <a href="/zubehoer" class="fh-start-highlight-nav__card">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Zubehoer_Kategorie_Nav_Vorschau_360x120.jpg" alt="Zubehör Kategorie Vorschau" class="fh-start-highlight-nav__image" width="360" height="120">
+          <span class="fh-start-highlight-nav__label">Zubehör</span>
+        </a>
+      </li>
     </ul>
   </div>
 </nav>

--- a/Custom Components/SH Custom FW Start Highlight Category Nav.html
+++ b/Custom Components/SH Custom FW Start Highlight Category Nav.html
@@ -4,19 +4,25 @@
     <ul class="sh-start-highlight-nav__list">
       <li class="sh-start-highlight-nav__item">
         <a href="/schrauben/" class="sh-start-highlight-nav__card">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Schraubensortiment_360x120.jpg" alt="Schraubensortiment Kategorie Vorschau" class="sh-start-highlight-nav__image" width="360" height="120">
+          <span class="sh-start-highlight-nav__media">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Schraubensortiment_360x120.jpg" alt="Schraubensortiment Kategorie Vorschau" class="sh-start-highlight-nav__image" width="360" height="120">
+          </span>
           <span class="sh-start-highlight-nav__label">Schraubensortiment</span>
         </a>
       </li>
       <li class="sh-start-highlight-nav__item">
         <a href="/duebel/" class="sh-start-highlight-nav__card">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Duebel_360x120.jpg" alt="Dübel Kategorie Vorschau" class="sh-start-highlight-nav__image" width="360" height="120">
+          <span class="sh-start-highlight-nav__media">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Duebel_360x120.jpg" alt="Dübel Kategorie Vorschau" class="sh-start-highlight-nav__image" width="360" height="120">
+          </span>
           <span class="sh-start-highlight-nav__label">Dübel</span>
         </a>
       </li>
       <li class="sh-start-highlight-nav__item">
         <a href="/zubehoer" class="sh-start-highlight-nav__card">
-          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Zubehoer_Kategorie_Nav_Vorschau_360x120.jpg" alt="Zubehör Kategorie Vorschau" class="sh-start-highlight-nav__image" width="360" height="120">
+          <span class="sh-start-highlight-nav__media">
+            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Zubehoer_Kategorie_Nav_Vorschau_360x120.jpg" alt="Zubehör Kategorie Vorschau" class="sh-start-highlight-nav__image" width="360" height="120">
+          </span>
           <span class="sh-start-highlight-nav__label">Zubehör</span>
         </a>
       </li>

--- a/Custom Components/SH Custom FW Start Highlight Category Nav.html
+++ b/Custom Components/SH Custom FW Start Highlight Category Nav.html
@@ -2,7 +2,24 @@
   <div class="sh-start-highlight-nav__inner">
     <h2 class="sh-start-highlight-nav__title">Top-Kategorien</h2>
     <ul class="sh-start-highlight-nav__list">
-      <!-- TODO: Kategorie-Links ergänzen und auf Ceres-Template-Struktur abstimmen. -->
+      <li class="sh-start-highlight-nav__item">
+        <a href="/schrauben/" class="sh-start-highlight-nav__card">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Schraubensortiment_360x120.jpg" alt="Schraubensortiment Kategorie Vorschau" class="sh-start-highlight-nav__image" width="360" height="120">
+          <span class="sh-start-highlight-nav__label">Schraubensortiment</span>
+        </a>
+      </li>
+      <li class="sh-start-highlight-nav__item">
+        <a href="/duebel/" class="sh-start-highlight-nav__card">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Duebel_360x120.jpg" alt="Dübel Kategorie Vorschau" class="sh-start-highlight-nav__image" width="360" height="120">
+          <span class="sh-start-highlight-nav__label">Dübel</span>
+        </a>
+      </li>
+      <li class="sh-start-highlight-nav__item">
+        <a href="/zubehoer" class="sh-start-highlight-nav__card">
+          <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Zubehoer_Kategorie_Nav_Vorschau_360x120.jpg" alt="Zubehör Kategorie Vorschau" class="sh-start-highlight-nav__image" width="360" height="120">
+          <span class="sh-start-highlight-nav__label">Zubehör</span>
+        </a>
+      </li>
     </ul>
   </div>
 </nav>

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2234,11 +2234,17 @@ a.logo {
 
 @media (max-width: 991.98px) {
   .fh-start-highlight-nav__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
   }
 }
 
 @media (max-width: 767.98px) {
+  .fh-start-highlight-nav__list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 575.98px) {
   .fh-start-highlight-nav__list {
     grid-template-columns: 1fr;
   }

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2131,6 +2131,68 @@ a.logo {
   grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 
+/* Section: Start Highlight Category Nav */
+.fh-start-highlight-nav {
+  padding: 48px 0;
+}
+
+.fh-start-highlight-nav__inner {
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.fh-start-highlight-nav__title {
+  margin-bottom: 24px;
+}
+
+.fh-start-highlight-nav__list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.fh-start-highlight-nav__card {
+  display: block;
+  width: 100%;
+  max-width: 360px;
+  margin: 0 auto;
+  text-decoration: none;
+  color: inherit;
+}
+
+.fh-start-highlight-nav__image {
+  display: block;
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+}
+
+.fh-start-highlight-nav__label {
+  display: block;
+  margin: 0;
+  padding: 0;
+  background-color: #f5f5f5;
+  text-align: center;
+  font-weight: 600;
+}
+
+@media (min-width: 768px) {
+  .fh-start-highlight-nav__list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1200px) {
+  .fh-start-highlight-nav__list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+/* End Section: Start Highlight Category Nav */
+
 .fh-header__dropdown-grid--brands {
   grid-template-columns: minmax(0, 1fr) 1px minmax(260px, 0.75fr);
   align-items: stretch;

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2139,7 +2139,7 @@ a.logo {
 .fh-start-highlight-nav__inner {
   width: 100%;
   margin: 0 auto;
-  padding: 0 24px;
+  padding: 0;
 }
 
 .fh-start-highlight-nav__title {
@@ -2232,7 +2232,7 @@ a.logo {
   transform: scale(1.06);
 }
 
-@media (max-width: 1199.98px) {
+@media (max-width: 991.98px) {
   .fh-start-highlight-nav__list {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2148,7 +2148,7 @@ a.logo {
 
 .fh-start-highlight-nav__list {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 24px;
   margin: 0;
   padding: 0;
@@ -2158,8 +2158,8 @@ a.logo {
 .fh-start-highlight-nav__card {
   display: block;
   width: 100%;
-  max-width: 360px;
-  margin: 0 auto;
+  border-radius: 8px;
+  overflow: hidden;
   text-decoration: none;
   color: inherit;
 }
@@ -2169,26 +2169,34 @@ a.logo {
   width: 100%;
   height: 120px;
   object-fit: cover;
+  transition: transform 0.3s ease;
 }
 
 .fh-start-highlight-nav__label {
   display: block;
   margin: 0;
-  padding: 0;
-  background-color: #f5f5f5;
-  text-align: center;
+  padding: 10px 12px;
+  background-color: #ffffff;
+  text-align: left;
+  font-size: 1.05rem;
   font-weight: 600;
+  line-height: 1.3;
 }
 
-@media (min-width: 768px) {
+.fh-start-highlight-nav__card:hover .fh-start-highlight-nav__image,
+.fh-start-highlight-nav__card:focus .fh-start-highlight-nav__image {
+  transform: scale(1.06);
+}
+
+@media (max-width: 1199.98px) {
   .fh-start-highlight-nav__list {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (min-width: 1200px) {
+@media (max-width: 767.98px) {
   .fh-start-highlight-nav__list {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: 1fr;
   }
 }
 /* End Section: Start Highlight Category Nav */

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2159,7 +2159,7 @@ a.logo {
 .fh-start-highlight-nav__card {
   display: block;
   width: 100%;
-  max-width: 360px;
+  max-width: 380px;
   border-radius: 8px;
   overflow: hidden;
   border: 1px solid #e6e6e6;
@@ -2171,7 +2171,7 @@ a.logo {
 .fh-start-highlight-nav__media {
   display: block;
   width: 100%;
-  max-width: 360px;
+  max-width: 380px;
   overflow: hidden;
   aspect-ratio: 3 / 1;
 }

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2150,6 +2150,7 @@ a.logo {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 24px;
+  justify-items: center;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2158,6 +2159,7 @@ a.logo {
 .fh-start-highlight-nav__card {
   display: block;
   width: 100%;
+  max-width: 360px;
   border-radius: 8px;
   overflow: hidden;
   border: 1px solid #e6e6e6;
@@ -2169,6 +2171,7 @@ a.logo {
 .fh-start-highlight-nav__media {
   display: block;
   width: 100%;
+  max-width: 360px;
   overflow: hidden;
   aspect-ratio: 3 / 1;
 }

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2160,14 +2160,23 @@ a.logo {
   width: 100%;
   border-radius: 8px;
   overflow: hidden;
+  border: 1px solid #e6e6e6;
+  background-color: #ffffff;
   text-decoration: none;
   color: inherit;
+}
+
+.fh-start-highlight-nav__media {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  aspect-ratio: 3 / 1;
 }
 
 .fh-start-highlight-nav__image {
   display: block;
   width: 100%;
-  height: 120px;
+  height: 100%;
   object-fit: cover;
   transition: transform 0.3s ease;
 }
@@ -2178,7 +2187,7 @@ a.logo {
   padding: 10px 12px;
   background-color: #ffffff;
   text-align: left;
-  font-size: 1.05rem;
+  font-size: 1.3rem;
   font-weight: 600;
   line-height: 1.3;
 }

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2195,6 +2195,26 @@ a.logo {
   line-height: 1.3;
 }
 
+.fh-start-highlight-nav__label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.fh-start-highlight-nav__label-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
+}
+
+.fh-start-highlight-nav__label-icon img {
+  width: 100%;
+  height: 100%;
+}
+
 .fh-start-highlight-nav__intro {
   display: block;
   margin: 0;
@@ -2204,6 +2224,27 @@ a.logo {
   font-size: 0.95rem;
   line-height: 1.5;
   color: #2f2f2f;
+}
+
+@media (min-width: 1200px) {
+  .fh-start-highlight-nav__list {
+    align-items: stretch;
+  }
+
+  .fh-start-highlight-nav__item {
+    display: flex;
+    height: 100%;
+  }
+
+  .fh-start-highlight-nav__card {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .fh-start-highlight-nav__intro {
+    flex-grow: 1;
+  }
 }
 
 .fh-start-highlight-nav__card:hover .fh-start-highlight-nav__image,

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2195,26 +2195,6 @@ a.logo {
   line-height: 1.3;
 }
 
-.fh-start-highlight-nav__label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.fh-start-highlight-nav__label-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  flex: 0 0 20px;
-}
-
-.fh-start-highlight-nav__label-icon img {
-  width: 100%;
-  height: 100%;
-}
-
 .fh-start-highlight-nav__intro {
   display: block;
   margin: 0;

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -2190,9 +2190,20 @@ a.logo {
   padding: 10px 12px;
   background-color: #ffffff;
   text-align: left;
-  font-size: 1.3rem;
+  font-size: 1.2rem;
   font-weight: 600;
   line-height: 1.3;
+}
+
+.fh-start-highlight-nav__intro {
+  display: block;
+  margin: 0;
+  padding: 0 12px 12px;
+  background-color: #ffffff;
+  text-align: left;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #2f2f2f;
 }
 
 .fh-start-highlight-nav__card:hover .fh-start-highlight-nav__image,

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -2160,6 +2160,7 @@ a.logo {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 24px;
+  justify-items: center;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -2168,6 +2169,7 @@ a.logo {
 .sh-start-highlight-nav__card {
   display: block;
   width: 100%;
+  max-width: 360px;
   border-radius: 8px;
   overflow: hidden;
   border: 1px solid #e6e6e6;
@@ -2179,6 +2181,7 @@ a.logo {
 .sh-start-highlight-nav__media {
   display: block;
   width: 100%;
+  max-width: 360px;
   overflow: hidden;
   aspect-ratio: 3 / 1;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -2170,14 +2170,23 @@ a.logo {
   width: 100%;
   border-radius: 8px;
   overflow: hidden;
+  border: 1px solid #e6e6e6;
+  background-color: #ffffff;
   text-decoration: none;
   color: inherit;
+}
+
+.sh-start-highlight-nav__media {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  aspect-ratio: 3 / 1;
 }
 
 .sh-start-highlight-nav__image {
   display: block;
   width: 100%;
-  height: 120px;
+  height: 100%;
   object-fit: cover;
   transition: transform 0.3s ease;
 }
@@ -2188,7 +2197,7 @@ a.logo {
   padding: 10px 12px;
   background-color: #ffffff;
   text-align: left;
-  font-size: 1.05rem;
+  font-size: 1.3rem;
   font-weight: 600;
   line-height: 1.3;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -2141,6 +2141,68 @@ a.logo {
   grid-template-columns: repeat(1, minmax(0, 1fr));
 }
 
+/* Section: Start Highlight Category Nav */
+.sh-start-highlight-nav {
+  padding: 48px 0;
+}
+
+.sh-start-highlight-nav__inner {
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.sh-start-highlight-nav__title {
+  margin-bottom: 24px;
+}
+
+.sh-start-highlight-nav__list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.sh-start-highlight-nav__card {
+  display: block;
+  width: 100%;
+  max-width: 360px;
+  margin: 0 auto;
+  text-decoration: none;
+  color: inherit;
+}
+
+.sh-start-highlight-nav__image {
+  display: block;
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+}
+
+.sh-start-highlight-nav__label {
+  display: block;
+  margin: 0;
+  padding: 0;
+  background-color: #f5f5f5;
+  text-align: center;
+  font-weight: 600;
+}
+
+@media (min-width: 768px) {
+  .sh-start-highlight-nav__list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1200px) {
+  .sh-start-highlight-nav__list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+/* End Section: Start Highlight Category Nav */
+
 .sh-header__dropdown-grid--brands {
   grid-template-columns: minmax(0, 1fr) 1px minmax(260px, 0.75fr);
   align-items: stretch;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -2169,7 +2169,7 @@ a.logo {
 .sh-start-highlight-nav__card {
   display: block;
   width: 100%;
-  max-width: 360px;
+  max-width: 380px;
   border-radius: 8px;
   overflow: hidden;
   border: 1px solid #e6e6e6;
@@ -2181,7 +2181,7 @@ a.logo {
 .sh-start-highlight-nav__media {
   display: block;
   width: 100%;
-  max-width: 360px;
+  max-width: 380px;
   overflow: hidden;
   aspect-ratio: 3 / 1;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -2158,7 +2158,7 @@ a.logo {
 
 .sh-start-highlight-nav__list {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 24px;
   margin: 0;
   padding: 0;
@@ -2168,8 +2168,8 @@ a.logo {
 .sh-start-highlight-nav__card {
   display: block;
   width: 100%;
-  max-width: 360px;
-  margin: 0 auto;
+  border-radius: 8px;
+  overflow: hidden;
   text-decoration: none;
   color: inherit;
 }
@@ -2179,26 +2179,34 @@ a.logo {
   width: 100%;
   height: 120px;
   object-fit: cover;
+  transition: transform 0.3s ease;
 }
 
 .sh-start-highlight-nav__label {
   display: block;
   margin: 0;
-  padding: 0;
-  background-color: #f5f5f5;
-  text-align: center;
+  padding: 10px 12px;
+  background-color: #ffffff;
+  text-align: left;
+  font-size: 1.05rem;
   font-weight: 600;
+  line-height: 1.3;
 }
 
-@media (min-width: 768px) {
+.sh-start-highlight-nav__card:hover .sh-start-highlight-nav__image,
+.sh-start-highlight-nav__card:focus .sh-start-highlight-nav__image {
+  transform: scale(1.06);
+}
+
+@media (max-width: 1199.98px) {
   .sh-start-highlight-nav__list {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (min-width: 1200px) {
+@media (max-width: 767.98px) {
   .sh-start-highlight-nav__list {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: 1fr;
   }
 }
 /* End Section: Start Highlight Category Nav */


### PR DESCRIPTION
### Motivation
- Provide a compact start-navigation preview with three visual category cards on large screens and responsive fallbacks to 2/1 columns, so start pages show prominent category entry points for SH and FH.

### Description
- Add markup for SH start highlight nav with three category preview cards and FH start highlight nav with six category preview cards (two rows of three) in `Custom Components/SH Custom FW Start Highlight Category Nav.html` and `Custom Components/FH Custom FW Start Highlight Category Nav.html` respectively.
- Add CSS rules in `SH - Stylesheets.css` and `FH - Stylesheets.css` to constrain card image width to `max-width: 360px` and height to `120px`, set a label area with zero margin/padding and a grey background (`#f5f5f5`), and style the card layout.
- Implement responsive grid breakpoints so the card list is 1 column by default, 2 columns at `min-width: 768px`, and 3 columns at `min-width: 1200px`, producing 3/2/1 column behavior across viewports.
- Use the provided CDN category images and relative links for each card to ensure consistency with the shop structure.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b5daca3348331aaeb8df7eff42e81)