### PR TITLE
fix(header): align top bar background

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -348,10 +348,9 @@ div.external-brand-logo img {
   content: "";
   position: absolute;
   top: 0;
-  left: 50%;
-  width: 100vw;
+  left: 0;
+  width: 100%;
   height: 100%;
-  transform: translateX(-50%);
   background: linear-gradient(90deg, var(--fh-color-navy-blue), var(--fh-color-dark-blue));
   z-index: -1;
   pointer-events: none;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -351,10 +351,9 @@ div.external-brand-logo img {
   content: "";
   position: absolute;
   top: 0;
-  left: 50%;
-  width: 100vw;
+  left: 0;
+  width: 100%;
   height: 100%;
-  transform: translateX(-50%);
   background: linear-gradient(
     90deg,
     var(--sh-color-secondary-red),


### PR DESCRIPTION
### Motivation
- Ensure the Top-Bar background runs flush across the header without a visible side edge by avoiding viewport-centering hacks (`left: 50%` / `transform`) that can cause seams.

### Description
- Update the pseudo-element for the top bar in `FH - Stylesheets.css` and `SH - Stylesheets.css` to use `left: 0` and `width: 100%` instead of `left: 50%` + `width: 100vw` + `transform: translateX(-50%)` so the gradient fills the header container cleanly.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c809e9384833195bc794abcd02ff4)