### PR TITLE
style(header): allow full-width header layout

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -314,8 +314,8 @@ div.external-brand-logo img {
   margin: 0 auto;
   color: #1a1a1a;
   font-family: "Open Sans", Arial, sans-serif;
-  width: 1600px; /* Do not change this for Desktop viewport*/
-  max-width: 1600px; /* Do not change this for Desktop viewport*/
+  width: 100%;
+  max-width: 100%;
   --fh-top-bar-max-height: 72px;
   --fh-top-bar-padding-y: 14px;
 }
@@ -3400,7 +3400,8 @@ body.fh-mobile-menu-open {
 }
 
 #page-header > div {
-  max-width: 1600px;
+  width: 100%;
+  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -317,8 +317,8 @@ div.external-brand-logo img {
   margin: 0 auto;
   color: #1a1a1a;
   font-family: "Open Sans", Arial, sans-serif;
-  width: 1600px; /* Do not change this for Desktop viewport*/
-  max-width: 1600px; /* Do not change this for Desktop viewport*/
+  width: 100%;
+  max-width: 100%;
   --sh-top-bar-max-height: 72px;
   --sh-top-bar-padding-y: 14px;
 }
@@ -3372,7 +3372,8 @@ body.sh-mobile-menu-open {
 }
 
 #page-header > div {
-  max-width: 1600px;
+  width: 100%;
+  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
### Motivation
- Make the header bar span the full viewport width while keeping the internal layout centered and intact. 
- Keep FH and SH visually consistent by applying the same container sizing change to both shops.

### Description
- Change `width`/`max-width` of `.fh-header` from `1600px` to `100%` to allow a full-width header and keep centering via existing `margin: 0 auto` and internal containers. 
- Apply the same `width: 100%` / `max-width: 100%` update to `.sh-header` for parity across shops. 
- Remove the `1600px` cap on the page wrapper by setting `#page-header > div` to `width: 100%` and `max-width: 100%` in both `FH - Stylesheets.css` and `SH - Stylesheets.css`, while leaving responsive media queries intact.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c84668be48331ac32fc9919baa0fb)