### PR TITLE
Improve wishlist refresh handling

### DIFF
--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3715,6 +3715,8 @@ fhOnReady(function () {
   let isOpen = false;
   let storeWatcherCleanup = null;
   let refreshTimeout = null;
+  let apiServiceRetryCount = 0;
+  let apiServiceRetryTimeout = null;
   let storeRetryCount = 0;
 
   function openMenu() {
@@ -3787,12 +3789,38 @@ fhOnReady(function () {
     }, 150);
   }
 
+  function scheduleApiServiceRetry(store) {
+    if (!store) return;
+
+    if (window.ApiService && typeof window.ApiService.get === 'function') {
+      apiServiceRetryCount = 0;
+      return;
+    }
+
+    if (apiServiceRetryTimeout) return;
+
+    apiServiceRetryCount += 1;
+    if (apiServiceRetryCount > 20) return;
+
+    apiServiceRetryTimeout = window.setTimeout(function () {
+      apiServiceRetryTimeout = null;
+      refreshWishListItemsSilently(store);
+    }, 300);
+  }
+
   function refreshWishListItemsSilently(store) {
     if (!store || !store.state || !store.state.wishList) return;
     if (!window.ApiService || typeof window.ApiService.get !== 'function') {
-      if (store._actions && store._actions.initWishListItems && (!store.state.wishList.wishListItems || !store.state.wishList.wishListItems.length)) {
-        store.dispatch('initWishListItems');
+      if (store._actions && store._actions.initWishListItems) {
+        try {
+          const result = store.dispatch('initWishListItems');
+
+          if (result && typeof result.catch === 'function') result.catch(function () {});
+        } catch (error) {
+          /* Ignore dispatch errors in the custom integration to avoid breaking the UI. */
+        }
       }
+      scheduleApiServiceRetry(store);
       return;
     }
 
@@ -3805,6 +3833,23 @@ fhOnReady(function () {
           store.commit('setWishListItems', response.documents);
         }
       });
+  }
+
+  function handleWishListToggle(event) {
+    const trigger = event.target.closest('.widget-add-to-wish-list .btn');
+
+    if (!trigger) return;
+
+    window.setTimeout(function () {
+      const store = getVueStore();
+
+      if (store) {
+        ensureStoreWatcher(store);
+        scheduleWishListRefresh(store);
+      } else {
+        resolveStore();
+      }
+    }, 300);
   }
 
   function ensureStoreWatcher(store) {
@@ -3836,6 +3881,8 @@ fhOnReady(function () {
       window.setTimeout(resolveStore, 300);
     }
   }
+
+  document.addEventListener('click', handleWishListToggle);
 
   resolveStore();
 });

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -3693,6 +3693,8 @@ shOnReady(function () {
   let isOpen = false;
   let storeWatcherCleanup = null;
   let refreshTimeout = null;
+  let apiServiceRetryCount = 0;
+  let apiServiceRetryTimeout = null;
   let storeRetryCount = 0;
 
   function openMenu() {
@@ -3765,12 +3767,38 @@ shOnReady(function () {
     }, 150);
   }
 
+  function scheduleApiServiceRetry(store) {
+    if (!store) return;
+
+    if (window.ApiService && typeof window.ApiService.get === 'function') {
+      apiServiceRetryCount = 0;
+      return;
+    }
+
+    if (apiServiceRetryTimeout) return;
+
+    apiServiceRetryCount += 1;
+    if (apiServiceRetryCount > 20) return;
+
+    apiServiceRetryTimeout = window.setTimeout(function () {
+      apiServiceRetryTimeout = null;
+      refreshWishListItemsSilently(store);
+    }, 300);
+  }
+
   function refreshWishListItemsSilently(store) {
     if (!store || !store.state || !store.state.wishList) return;
     if (!window.ApiService || typeof window.ApiService.get !== 'function') {
-      if (store._actions && store._actions.initWishListItems && (!store.state.wishList.wishListItems || !store.state.wishList.wishListItems.length)) {
-        store.dispatch('initWishListItems');
+      if (store._actions && store._actions.initWishListItems) {
+        try {
+          const result = store.dispatch('initWishListItems');
+
+          if (result && typeof result.catch === 'function') result.catch(function () {});
+        } catch (error) {
+          /* Ignore dispatch errors in the custom integration to avoid breaking the UI. */
+        }
       }
+      scheduleApiServiceRetry(store);
       return;
     }
 
@@ -3783,6 +3811,23 @@ shOnReady(function () {
           store.commit('setWishListItems', response.documents);
         }
       });
+  }
+
+  function handleWishListToggle(event) {
+    const trigger = event.target.closest('.widget-add-to-wish-list .btn');
+
+    if (!trigger) return;
+
+    window.setTimeout(function () {
+      const store = getVueStore();
+
+      if (store) {
+        ensureStoreWatcher(store);
+        scheduleWishListRefresh(store);
+      } else {
+        resolveStore();
+      }
+    }, 300);
   }
 
   function ensureStoreWatcher(store) {
@@ -3814,6 +3859,8 @@ shOnReady(function () {
       window.setTimeout(resolveStore, 300);
     }
   }
+
+  document.addEventListener('click', handleWishListToggle);
 
   resolveStore();
 });


### PR DESCRIPTION
### Motivation

- Ensure wishlist item data is refreshed whenever `state.wishList.wishListIds` changes so the dropdown always shows up-to-date items.
- Make refresh work even if `window.ApiService` is not yet initialized by retrying the fetch and by falling back to the store action. 
- Trigger a refresh after user add/remove actions on `.widget-add-to-wish-list .btn` so changes appear immediately without a full page reload.

### Description

- Updated `JavaScript im Head/FH - JS im Head.js` and `JavaScript im Head/SH - JS im Head.js` to always dispatch `initWishListItems` when a store is available, wrapped in `try/catch` and swallowing promise errors to avoid UI breaks. 
- Added `apiServiceRetryCount` and `apiServiceRetryTimeout` plus a `scheduleApiServiceRetry` helper to retry `ApiService`-based fetches until `ApiService` becomes available (with a retry limit).
- Modified `refreshWishListItemsSilently` to call the store action when `ApiService` is not ready and to schedule API-retry attempts once `ApiService` is unavailable.
- Added `handleWishListToggle` which listens for clicks on `.widget-add-to-wish-list .btn` and triggers a delayed refresh (or resolves the store) so toggles immediately refresh the wishlist UI.
- Kept/extended the existing store watcher (`store.watch`) which observes `wishListIds.join(',')` and schedules refreshes; added defensive retry logic for resolving the Vue store.

### Testing

- No automated tests were executed for this change.`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c9373210c8331b91a54163fe40e95)