### PR TITLE
Render wishlist in header dropdown via direct DOM + REST (bypass Vue)

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1164,6 +1164,71 @@ a.logo {
   display: none;
 }
 
+.fh-header__wishlist-items {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.fh-header__wishlist-item {
+  display: flex;
+  gap: 12px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.fh-header__wishlist-item:hover .fh-header__wishlist-name,
+.fh-header__wishlist-item:focus .fh-header__wishlist-name {
+  text-decoration: underline;
+}
+
+.fh-header__wishlist-media {
+  flex: 0 0 52px;
+  height: 52px;
+  border-radius: 10px;
+  overflow: hidden;
+  background-color: #f3f3f3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.fh-header__wishlist-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.fh-header__wishlist-image-placeholder {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: #d9d9d9;
+}
+
+.fh-header__wishlist-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fh-header__wishlist-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fh-color-dark-blue);
+}
+
+.fh-header__wishlist-number {
+  font-size: 12px;
+  color: #6c6c6c;
+}
+
+.fh-header__wishlist-empty {
+  font-size: 14px;
+  color: #6c6c6c;
+  padding: 8px 0;
+}
+
 .fh-header__panel-arrow {
   position: absolute;
   top: -10px;

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -76,7 +76,7 @@
             <a href="/wish-list" class="fh-header__panel-link fh-header__panel-link--wishlist">Zur Merkliste</a>
           </div>
           <div class="fh-header__wishlist-body" data-fh-wishlist-body>
-            <wish-list></wish-list>
+            <div data-fh-wishlist-items></div>
           </div>
         </div>
       </div>

--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -76,7 +76,7 @@
             <a href="/wish-list" class="sh-header__panel-link sh-header__panel-link--wishlist">Zur Merkliste</a>
           </div>
           <div class="sh-header__wishlist-body" data-sh-wishlist-body>
-            <wish-list></wish-list>
+            <div data-sh-wishlist-items></div>
           </div>
         </div>
       </div>

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3709,13 +3709,14 @@ fhOnReady(function () {
 
   const toggleButton = container.querySelector('[data-fh-wishlist-menu-toggle]');
   const menu = container.querySelector('[data-fh-wishlist-menu]');
+  const itemsContainer = container.querySelector('[data-fh-wishlist-items]');
+  const badgeCount = container.querySelector('.fh-header__badge span');
 
-  if (!toggleButton || !menu) return;
+  if (!toggleButton || !menu || !itemsContainer) return;
 
   let isOpen = false;
-  let storeWatcherCleanup = null;
   let refreshTimeout = null;
-  let storeRetryCount = 0;
+  let activeRequestId = 0;
 
   function openMenu() {
     if (isOpen) return;
@@ -3727,12 +3728,7 @@ fhOnReady(function () {
     document.addEventListener('keydown', handleKeydown);
     isOpen = true;
 
-    const store = getVueStore();
-
-    if (store) {
-      ensureStoreWatcher(store);
-      scheduleWishListRefresh(store);
-    }
+    scheduleWishListFetch(true);
   }
 
   function closeMenu() {
@@ -3765,79 +3761,187 @@ fhOnReady(function () {
     else openMenu();
   });
 
-  function getVueStore() {
-    if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
-
-    if (window.ceresStore && typeof window.ceresStore.dispatch === 'function') return window.ceresStore;
-
-    return null;
-  }
-
-  function scheduleWishListRefresh(store) {
-    if (!store) return;
-
+  function scheduleWishListFetch(showLoadingState) {
     if (refreshTimeout) {
       window.clearTimeout(refreshTimeout);
       refreshTimeout = null;
     }
 
+    if (showLoadingState) {
+      renderWishListLoading();
+    }
+
     refreshTimeout = window.setTimeout(function () {
       refreshTimeout = null;
-      refreshWishListItemsSilently(store);
-    }, 150);
+      fetchWishListItems();
+    }, 120);
   }
 
-  function refreshWishListItemsSilently(store) {
-    if (!store || !store.state || !store.state.wishList) return;
-    if (!window.ApiService || typeof window.ApiService.get !== 'function') {
-      if (store._actions && store._actions.initWishListItems && (!store.state.wishList.wishListItems || !store.state.wishList.wishListItems.length)) {
-        store.dispatch('initWishListItems');
-      }
-      return;
-    }
+  function renderWishListLoading() {
+    itemsContainer.innerHTML = '<div class="fh-header__wishlist-empty">Merkliste wird geladen ...</div>';
+  }
+
+  function fetchWishListItems() {
+    if (!window.ApiService || typeof window.ApiService.get !== 'function') return;
+
+    const requestId = ++activeRequestId;
 
     window.ApiService.get('/rest/io/itemWishList')
       .done(function (response) {
-        if (store._mutations && store._mutations.setInactiveVariationIds) {
-          store.commit('setInactiveVariationIds', response.inactiveVariationIds);
-        }
-        if (store._mutations && store._mutations.setWishListItems) {
-          store.commit('setWishListItems', response.documents);
-        }
+        if (requestId !== activeRequestId) return;
+        renderWishListItems(response);
+      })
+      .fail(function () {
+        if (requestId !== activeRequestId) return;
+        renderWishListError();
       });
   }
 
-  function ensureStoreWatcher(store) {
-    if (!store || typeof store.watch !== 'function' || storeWatcherCleanup) return;
-
-    storeWatcherCleanup = store.watch(
-      function (state) {
-        if (!state || !state.wishList || !Array.isArray(state.wishList.wishListIds)) return '';
-
-        return state.wishList.wishListIds.join(',');
-      },
-      function () {
-        scheduleWishListRefresh(store);
-      }
-    );
+  function renderWishListError() {
+    itemsContainer.innerHTML = '<div class="fh-header__wishlist-empty">Merkliste konnte gerade nicht geladen werden.</div>';
   }
 
-  function resolveStore() {
-    const store = getVueStore();
+  function renderWishListItems(response) {
+    const documents = response && Array.isArray(response.documents) ? response.documents : [];
 
-    if (store) {
-      ensureStoreWatcher(store);
-      scheduleWishListRefresh(store);
+    updateBadgeCount(response, documents);
+
+    if (!documents.length) {
+      itemsContainer.innerHTML = '<div class="fh-header__wishlist-empty">Du hast noch keine Artikel in der Merkliste.</div>';
       return;
     }
 
-    storeRetryCount += 1;
-    if (storeRetryCount < 20) {
-      window.setTimeout(resolveStore, 300);
+    const listMarkup = documents.map(function (entry) {
+      const name = escapeHtml(getWishListName(entry));
+      const url = escapeHtml(normalizeUrl(getWishListUrl(entry)));
+      const imageUrl = getWishListImage(entry);
+      const imageMarkup = imageUrl
+        ? '<img src="' + escapeHtml(imageUrl) + '" alt="' + name + '" loading="lazy" class="fh-header__wishlist-image">'
+        : '<span class="fh-header__wishlist-image-placeholder" aria-hidden="true"></span>';
+      const number = escapeHtml(getWishListNumber(entry));
+      const numberMarkup = number ? '<div class="fh-header__wishlist-number">' + number + '</div>' : '';
+
+      return (
+        '<a class="fh-header__wishlist-item" href="' + url + '">' +
+          '<div class="fh-header__wishlist-media">' + imageMarkup + '</div>' +
+          '<div class="fh-header__wishlist-content">' +
+            '<div class="fh-header__wishlist-name">' + name + '</div>' +
+            numberMarkup +
+          '</div>' +
+        '</a>'
+      );
+    }).join('');
+
+    itemsContainer.innerHTML = '<div class="fh-header__wishlist-items">' + listMarkup + '</div>';
+  }
+
+  function updateBadgeCount(response, documents) {
+    if (!badgeCount) return;
+
+    const nextCount = resolveWishListCount(response, documents);
+    if (typeof nextCount === 'number') {
+      badgeCount.textContent = nextCount;
     }
   }
 
-  resolveStore();
+  function resolveWishListCount(response, documents) {
+    if (response && typeof response.count === 'number') return response.count;
+    if (response && typeof response.totalCount === 'number') return response.totalCount;
+    if (response && response.totals && typeof response.totals.totalCount === 'number') return response.totals.totalCount;
+    if (response && response.totals && typeof response.totals.count === 'number') return response.totals.count;
+    if (Array.isArray(documents)) return documents.length;
+    return null;
+  }
+
+  function getWishListName(entry) {
+    if (!entry) return 'Artikel';
+    const source = entry.data || entry;
+    return source.texts && (source.texts.name1 || source.texts.name) ||
+      entry.item && entry.item.texts && (entry.item.texts.name1 || entry.item.texts.name) ||
+      entry.variation && entry.variation.texts && (entry.variation.texts.name1 || entry.variation.texts.name) ||
+      source.name ||
+      'Artikel';
+  }
+
+  function getWishListNumber(entry) {
+    if (!entry) return '';
+    const source = entry.data || entry;
+    return source.itemNumber ||
+      entry.item && entry.item.itemNumber ||
+      entry.variation && entry.variation.number ||
+      '';
+  }
+
+  function getWishListUrl(entry) {
+    if (!entry) return '/wish-list';
+    const source = entry.data || entry;
+    return source.texts && source.texts.urlPath ||
+      entry.item && entry.item.texts && entry.item.texts.urlPath ||
+      entry.variation && entry.variation.texts && entry.variation.texts.urlPath ||
+      source.urlPath ||
+      '/wish-list';
+  }
+
+  function getWishListImage(entry) {
+    if (!entry) return '';
+    const source = entry.data || entry;
+    if (source.images && source.images.length) {
+      return source.images[0].urlPreview || source.images[0].urlMiddle || source.images[0].url || '';
+    }
+    if (entry.images && entry.images.length) {
+      return entry.images[0].urlPreview || entry.images[0].urlMiddle || entry.images[0].url || '';
+    }
+    return '';
+  }
+
+  function normalizeUrl(url) {
+    if (!url) return '/wish-list';
+    if (typeof url !== 'string') return '/wish-list';
+    if (url.indexOf('http') === 0) {
+      try {
+        const parsed = new URL(url);
+        return parsed.pathname + parsed.search;
+      } catch (error) {
+        return '/wish-list';
+      }
+    }
+    return url.charAt(0) === '/' ? url : '/' + url;
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function handlePossibleWishListChange() {
+    scheduleWishListFetch(false);
+  }
+
+  document.addEventListener('click', function (event) {
+    const trigger = event.target.closest(
+      '[data-wishlist-add], [data-wishlist-remove], [data-wishlist-toggle], [data-add-to-wishlist], ' +
+      '.add-to-wishlist, .remove-from-wishlist, .wish-list-add, .wish-list-remove'
+    );
+
+    if (trigger) {
+      scheduleWishListFetch(false);
+    }
+  });
+
+  [
+    'wishList:changed',
+    'wishlist:changed',
+    'wishList:updated',
+    'wishlist:updated',
+    'ceres:wishlist:changed',
+    'ceres:changedWishList',
+  ].forEach(function (eventName) {
+    document.addEventListener(eventName, handlePossibleWishListChange);
+  });
 });
 
 // Section: Signature console log by David M. Abdin

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -3687,13 +3687,14 @@ shOnReady(function () {
 
   const toggleButton = container.querySelector('[data-sh-wishlist-menu-toggle]');
   const menu = container.querySelector('[data-sh-wishlist-menu]');
+  const itemsContainer = container.querySelector('[data-sh-wishlist-items]');
+  const badgeCount = container.querySelector('.sh-header__badge span');
 
-  if (!toggleButton || !menu) return;
+  if (!toggleButton || !menu || !itemsContainer) return;
 
   let isOpen = false;
-  let storeWatcherCleanup = null;
   let refreshTimeout = null;
-  let storeRetryCount = 0;
+  let activeRequestId = 0;
 
   function openMenu() {
     if (isOpen) return;
@@ -3705,12 +3706,7 @@ shOnReady(function () {
     document.addEventListener('keydown', handleKeydown);
     isOpen = true;
 
-    const store = getVueStore();
-
-    if (store) {
-      ensureStoreWatcher(store);
-      scheduleWishListRefresh(store);
-    }
+    scheduleWishListFetch(true);
   }
 
   function closeMenu() {
@@ -3743,79 +3739,187 @@ shOnReady(function () {
     else openMenu();
   });
 
-  function getVueStore() {
-    if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
-
-    if (window.ceresStore && typeof window.ceresStore.dispatch === 'function') return window.ceresStore;
-
-    return null;
-  }
-
-  function scheduleWishListRefresh(store) {
-    if (!store) return;
-
+  function scheduleWishListFetch(showLoadingState) {
     if (refreshTimeout) {
       window.clearTimeout(refreshTimeout);
       refreshTimeout = null;
     }
 
+    if (showLoadingState) {
+      renderWishListLoading();
+    }
+
     refreshTimeout = window.setTimeout(function () {
       refreshTimeout = null;
-      refreshWishListItemsSilently(store);
-    }, 150);
+      fetchWishListItems();
+    }, 120);
   }
 
-  function refreshWishListItemsSilently(store) {
-    if (!store || !store.state || !store.state.wishList) return;
-    if (!window.ApiService || typeof window.ApiService.get !== 'function') {
-      if (store._actions && store._actions.initWishListItems && (!store.state.wishList.wishListItems || !store.state.wishList.wishListItems.length)) {
-        store.dispatch('initWishListItems');
-      }
-      return;
-    }
+  function renderWishListLoading() {
+    itemsContainer.innerHTML = '<div class="sh-header__wishlist-empty">Merkliste wird geladen ...</div>';
+  }
+
+  function fetchWishListItems() {
+    if (!window.ApiService || typeof window.ApiService.get !== 'function') return;
+
+    const requestId = ++activeRequestId;
 
     window.ApiService.get('/rest/io/itemWishList')
       .done(function (response) {
-        if (store._mutations && store._mutations.setInactiveVariationIds) {
-          store.commit('setInactiveVariationIds', response.inactiveVariationIds);
-        }
-        if (store._mutations && store._mutations.setWishListItems) {
-          store.commit('setWishListItems', response.documents);
-        }
+        if (requestId !== activeRequestId) return;
+        renderWishListItems(response);
+      })
+      .fail(function () {
+        if (requestId !== activeRequestId) return;
+        renderWishListError();
       });
   }
 
-  function ensureStoreWatcher(store) {
-    if (!store || typeof store.watch !== 'function' || storeWatcherCleanup) return;
-
-    storeWatcherCleanup = store.watch(
-      function (state) {
-        if (!state || !state.wishList || !Array.isArray(state.wishList.wishListIds)) return '';
-
-        return state.wishList.wishListIds.join(',');
-      },
-      function () {
-        scheduleWishListRefresh(store);
-      }
-    );
+  function renderWishListError() {
+    itemsContainer.innerHTML = '<div class="sh-header__wishlist-empty">Merkliste konnte gerade nicht geladen werden.</div>';
   }
 
-  function resolveStore() {
-    const store = getVueStore();
+  function renderWishListItems(response) {
+    const documents = response && Array.isArray(response.documents) ? response.documents : [];
 
-    if (store) {
-      ensureStoreWatcher(store);
-      scheduleWishListRefresh(store);
+    updateBadgeCount(response, documents);
+
+    if (!documents.length) {
+      itemsContainer.innerHTML = '<div class="sh-header__wishlist-empty">Du hast noch keine Artikel in der Merkliste.</div>';
       return;
     }
 
-    storeRetryCount += 1;
-    if (storeRetryCount < 20) {
-      window.setTimeout(resolveStore, 300);
+    const listMarkup = documents.map(function (entry) {
+      const name = escapeHtml(getWishListName(entry));
+      const url = escapeHtml(normalizeUrl(getWishListUrl(entry)));
+      const imageUrl = getWishListImage(entry);
+      const imageMarkup = imageUrl
+        ? '<img src="' + escapeHtml(imageUrl) + '" alt="' + name + '" loading="lazy" class="sh-header__wishlist-image">'
+        : '<span class="sh-header__wishlist-image-placeholder" aria-hidden="true"></span>';
+      const number = escapeHtml(getWishListNumber(entry));
+      const numberMarkup = number ? '<div class="sh-header__wishlist-number">' + number + '</div>' : '';
+
+      return (
+        '<a class="sh-header__wishlist-item" href="' + url + '">' +
+          '<div class="sh-header__wishlist-media">' + imageMarkup + '</div>' +
+          '<div class="sh-header__wishlist-content">' +
+            '<div class="sh-header__wishlist-name">' + name + '</div>' +
+            numberMarkup +
+          '</div>' +
+        '</a>'
+      );
+    }).join('');
+
+    itemsContainer.innerHTML = '<div class="sh-header__wishlist-items">' + listMarkup + '</div>';
+  }
+
+  function updateBadgeCount(response, documents) {
+    if (!badgeCount) return;
+
+    const nextCount = resolveWishListCount(response, documents);
+    if (typeof nextCount === 'number') {
+      badgeCount.textContent = nextCount;
     }
   }
 
-  resolveStore();
+  function resolveWishListCount(response, documents) {
+    if (response && typeof response.count === 'number') return response.count;
+    if (response && typeof response.totalCount === 'number') return response.totalCount;
+    if (response && response.totals && typeof response.totals.totalCount === 'number') return response.totals.totalCount;
+    if (response && response.totals && typeof response.totals.count === 'number') return response.totals.count;
+    if (Array.isArray(documents)) return documents.length;
+    return null;
+  }
+
+  function getWishListName(entry) {
+    if (!entry) return 'Artikel';
+    const source = entry.data || entry;
+    return source.texts && (source.texts.name1 || source.texts.name) ||
+      entry.item && entry.item.texts && (entry.item.texts.name1 || entry.item.texts.name) ||
+      entry.variation && entry.variation.texts && (entry.variation.texts.name1 || entry.variation.texts.name) ||
+      source.name ||
+      'Artikel';
+  }
+
+  function getWishListNumber(entry) {
+    if (!entry) return '';
+    const source = entry.data || entry;
+    return source.itemNumber ||
+      entry.item && entry.item.itemNumber ||
+      entry.variation && entry.variation.number ||
+      '';
+  }
+
+  function getWishListUrl(entry) {
+    if (!entry) return '/wish-list';
+    const source = entry.data || entry;
+    return source.texts && source.texts.urlPath ||
+      entry.item && entry.item.texts && entry.item.texts.urlPath ||
+      entry.variation && entry.variation.texts && entry.variation.texts.urlPath ||
+      source.urlPath ||
+      '/wish-list';
+  }
+
+  function getWishListImage(entry) {
+    if (!entry) return '';
+    const source = entry.data || entry;
+    if (source.images && source.images.length) {
+      return source.images[0].urlPreview || source.images[0].urlMiddle || source.images[0].url || '';
+    }
+    if (entry.images && entry.images.length) {
+      return entry.images[0].urlPreview || entry.images[0].urlMiddle || entry.images[0].url || '';
+    }
+    return '';
+  }
+
+  function normalizeUrl(url) {
+    if (!url) return '/wish-list';
+    if (typeof url !== 'string') return '/wish-list';
+    if (url.indexOf('http') === 0) {
+      try {
+        const parsed = new URL(url);
+        return parsed.pathname + parsed.search;
+      } catch (error) {
+        return '/wish-list';
+      }
+    }
+    return url.charAt(0) === '/' ? url : '/' + url;
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function handlePossibleWishListChange() {
+    scheduleWishListFetch(false);
+  }
+
+  document.addEventListener('click', function (event) {
+    const trigger = event.target.closest(
+      '[data-wishlist-add], [data-wishlist-remove], [data-wishlist-toggle], [data-add-to-wishlist], ' +
+      '.add-to-wishlist, .remove-from-wishlist, .wish-list-add, .wish-list-remove'
+    );
+
+    if (trigger) {
+      scheduleWishListFetch(false);
+    }
+  });
+
+  [
+    'wishList:changed',
+    'wishlist:changed',
+    'wishList:updated',
+    'wishlist:updated',
+    'ceres:wishlist:changed',
+    'ceres:changedWishList',
+  ].forEach(function (eventName) {
+    document.addEventListener(eventName, handlePossibleWishListChange);
+  });
 });
 
 // Section: Signature console log by David M. Abdin

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1173,6 +1173,71 @@ a.logo {
   display: none;
 }
 
+.sh-header__wishlist-items {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sh-header__wishlist-item {
+  display: flex;
+  gap: 12px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.sh-header__wishlist-item:hover .sh-header__wishlist-name,
+.sh-header__wishlist-item:focus .sh-header__wishlist-name {
+  text-decoration: underline;
+}
+
+.sh-header__wishlist-media {
+  flex: 0 0 52px;
+  height: 52px;
+  border-radius: 10px;
+  overflow: hidden;
+  background-color: #f3f3f3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sh-header__wishlist-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.sh-header__wishlist-image-placeholder {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: #d9d9d9;
+}
+
+.sh-header__wishlist-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sh-header__wishlist-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--sh-color-dark);
+}
+
+.sh-header__wishlist-number {
+  font-size: 12px;
+  color: #6c6c6c;
+}
+
+.sh-header__wishlist-empty {
+  font-size: 14px;
+  color: #6c6c6c;
+  padding: 8px 0;
+}
+
 .sh-header__panel-arrow {
   position: absolute;
   top: -10px;


### PR DESCRIPTION
### Motivation
- Die bestehende `<wish-list>` Vue-Komponente im Header wurde durch direktes DOM-Rendering ersetzt, um das Vue-Mounting zu umgehen und sofortige, reload‑freie Updates zu erhalten. 
- Beim Öffnen des Dropdowns und nach Add/Remove-Operationen soll die aktuelle Wunschliste direkt vom IO-Endpoint abgerufen werden (`/rest/io/itemWishList`) und unmittelbar im DOM gerendert werden. 
- Beide Shops (FH & SH) müssen synchron funktionieren, daher wurden Änderungen parallel in den FH- und SH-Templates, Skripten und Styles vorgenommen.

### Description
- Ersetzt `<wish-list>` in den Header-Templates durch leere Container `<div data-fh-wishlist-items>` und `<div data-sh-wishlist-items>` in `Header/FH-Header.html` und `Header/SH-Header.html`.
- Implementiert in `JavaScript im Head/FH - JS im Head.js` und `JavaScript im Head/SH - JS im Head.js` neues Dropdown-Verhalten, das beim Öffnen und bei Wunschlisten-Änderungen debounced `window.ApiService.get('/rest/io/itemWishList')` aufruft, Antworten sichert (`activeRequestId`) und die Liste inkl. Badge-Count direkt ins DOM rendert; es enthält Fallback-States, HTML-Escaping sowie URL-/Bild-Normalisierung.
- Ergänzt Styles für das neue Markup in `FH - Stylesheets.css` und `SH - Stylesheets.css` (`.fh-header__wishlist-items`, `.sh-header__wishlist-items`, Item-, Media- und Placeholder-Klassen) zur optisch konsistenten Darstellung.

### Testing
- Es wurden keine automatisierten Tests auf den geänderten Dateien ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ca76d54b08331aad72d1cce6e4859)