### PR TITLE
Switch FH/SH asset hosts to bilder.* subdomains

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,4 @@ Die folgende Übersicht fasst alle relevanten Versionen der offiziellen plentySh
 * Verwende für Shop-Verlinkungen immer relative Pfade (z. B. `/start` statt `https://www.fenster-hammer.de/start` oder `https://www.schraubenhammer.de/start`).
 * Halte README und begleitende Dokumentation aktuell, wenn du neue Features oder Abhängigkeiten ergänzt.
 * Verwende für die direkte Anrede konsequent die Du-Form und schreibe Du/Dir/Dich/Dein usw. immer mit großem Anfangsbuchstaben – unabhängig von der Position im Satz.
+* Wenn Du mir Raw-URLs mit `cdn02.plentymarkets.com/nteqnk1xxnkn` gibst, konvertiere ich sie automatisch zu First-Party-Hosts: für FH zu `https://bilder.fenster-hammer.de/...`, für SH zu `https://bilder.schrauben-hammer.de/...` (Pfad bleibt identisch).

--- a/Custom Components/FH - Mein-Konto-Nav.html
+++ b/Custom Components/FH - Mein-Konto-Nav.html
@@ -71,7 +71,7 @@
         <a href="tel:02204910980" class="fh-header__panel-contact-chip">
           <span class="fh-header__panel-contact-icon" aria-hidden="true">
             <img
-              src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/phone.svg"
+              src="https://bilder.fenster-hammer.de/frontend/UI_Icons/phone.svg"
               alt=""
               class="fh-header__panel-contact-icon-image"
             >

--- a/Custom Components/SH - Mein-Konto-Nav.html
+++ b/Custom Components/SH - Mein-Konto-Nav.html
@@ -71,7 +71,7 @@
         <a href="tel:02204910980" class="sh-header__panel-contact-chip">
           <span class="sh-header__panel-contact-icon" aria-hidden="true">
             <img
-              src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/phone.svg"
+              src="https://bilder.schrauben-hammer.de/frontend/UI_Icons/phone.svg"
               alt=""
               class="sh-header__panel-contact-icon-image"
             >

--- a/FH - Metatags.html
+++ b/FH - Metatags.html
@@ -1,7 +1,7 @@
 <meta name="theme-color" content="#31a5f0" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#11192c" media="(prefers-color-scheme: dark)">
-<meta property="og:image" content="http://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Open-Graph-etc-Social-Media-Share/Open-Graph-FENSTER-HAMMER-Banner-1200x630px.jpg">
-<meta property="og:image:secure_url" content="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Open-Graph-etc-Social-Media-Share/Open-Graph-FENSTER-HAMMER-Banner-1200x630px.jpg">
+<meta property="og:image" content="https://bilder.fenster-hammer.de/frontend/Open-Graph-etc-Social-Media-Share/Open-Graph-FENSTER-HAMMER-Banner-1200x630px.jpg">
+<meta property="og:image:secure_url" content="https://bilder.fenster-hammer.de/frontend/Open-Graph-etc-Social-Media-Share/Open-Graph-FENSTER-HAMMER-Banner-1200x630px.jpg">
 <meta property="og:image:type" content="image/jpeg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1713,7 +1713,7 @@ a.logo {
 .fh-header__logout-icon {
   width: 20px;
   height: 20px;
-  background-image: url("https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/log-out-icon.svg");
+  background-image: url("https://bilder.fenster-hammer.de/frontend/UI_Icons/log-out-icon.svg");
   background-repeat: no-repeat;
   background-position: center;
   background-size: contain;

--- a/Footer/FH-Footer.html
+++ b/Footer/FH-Footer.html
@@ -10,7 +10,7 @@
       <section class="fh-footer__column fh-footer__column--info">
         <h5 class="fh-footer__heading">
           <span class="fh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/info_14574710.svg" alt="Infos" loading="lazy" decoding="async" width="18" height="18">
+            <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/info_14574710.svg" alt="Infos" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Infos
         </h5>
@@ -26,7 +26,7 @@
       <section class="fh-footer__column fh-footer__column--community">
         <h5 class="fh-footer__heading">
           <span class="fh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/workgroup_12886873.svg" alt="Community" loading="lazy" decoding="async" width="18" height="18">
+            <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/workgroup_12886873.svg" alt="Community" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Community
         </h5>
@@ -41,7 +41,7 @@
       <section class="fh-footer__column fh-footer__column--legal">
         <h5 class="fh-footer__heading">
           <span class="fh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/balance_2970715.svg" alt="Rechtliches" loading="lazy" decoding="async" width="18" height="18">
+            <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/balance_2970715.svg" alt="Rechtliches" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Rechtliches
         </h5>
@@ -57,7 +57,7 @@
       <section class="fh-footer__column fh-footer__column--benefits">
         <h5 class="fh-footer__heading">
           <span class="fh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/raise_1054356.svg" alt="Vorteile" loading="lazy" decoding="async" width="18" height="18">
+            <img src="https://bilder.fenster-hammer.de/frontend/raise_1054356.svg" alt="Vorteile" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Vorteile
         </h5>
@@ -75,17 +75,17 @@
       <div class="fh-footer__brand-section">
         <div class="fh-footer__brands">
         <a href="https://schrauben-hammer.de" target="_blank" rel="noopener noreferrer">
-       <img class="fh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="Schraubenhammer" loading="lazy" decoding="async" width="335" height="150">
+       <img class="fh-footer__brand-logo" src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="Schraubenhammer" loading="lazy" decoding="async" width="335" height="150">
       </a>
        <a href="https://fenster-hammer.de" target="_blank" rel="noopener noreferrer">
-        <img class="fh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer" loading="lazy" decoding="async" width="300" height="300">
+        <img class="fh-footer__brand-logo" src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer" loading="lazy" decoding="async" width="300" height="300">
        </a>
       </div>
         <div class="fh-footer__legal">
           <p>
             Onlineshops der INTRA-TEC GmbH
             <a class="fh-footer__social-link" href="https://www.linkedin.com/company/intra-tec-gmbh/" aria-label="LinkedIn">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/LinkedIn.png" alt="LinkedIn" loading="lazy" decoding="async" width="16" height="16">
+              <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/LinkedIn.png" alt="LinkedIn" loading="lazy" decoding="async" width="16" height="16">
             </a>
           </p>
           <p>
@@ -106,29 +106,29 @@
         <div class="fh-footer__logistics-section">
           <h6 class="fh-footer__sub-heading">Unsere Zahlungsarten</h6>
           <div class="fh-footer__badge-grid fh-footer__badge-grid--payments" aria-label="Akzeptierte Zahlungsarten">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Apple_Pay.png" alt="Apple Pay" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/PayPal.png" alt="PayPal" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Klarna.png" alt="Klarna" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/American_Express.png" alt="American Express" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Mastercard.png" alt="Mastercard" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Visa.png" alt="Visa" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Billie_Rechnungskauf_fuer_Fimrnen.png" alt="Billie Rechnungskauf für Firmen" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Vorkasse.png" alt="Vorkasse" loading="lazy" decoding="async">
+            <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/Apple_Pay.png" alt="Apple Pay" loading="lazy" decoding="async">
+            <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/PayPal.png" alt="PayPal" loading="lazy" decoding="async">
+            <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/Klarna.png" alt="Klarna" loading="lazy" decoding="async">
+            <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/American_Express.png" alt="American Express" loading="lazy" decoding="async">
+            <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/Mastercard.png" alt="Mastercard" loading="lazy" decoding="async">
+            <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/Visa.png" alt="Visa" loading="lazy" decoding="async">
+            <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/Billie_Rechnungskauf_fuer_Fimrnen.png" alt="Billie Rechnungskauf für Firmen" loading="lazy" decoding="async">
+            <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/Vorkasse.png" alt="Vorkasse" loading="lazy" decoding="async">
           </div>
         </div>
         <div class="fh-footer__logistics-section">
           <h6 class="fh-footer__sub-heading">Unsere Versandarten</h6>
           <div class="fh-footer__badge-grid fh-footer__badge-grid--shipping" aria-label="Versanddienstleister">
             <div class="fh-footer__shipping-item">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand" loading="lazy" decoding="async">
+              <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand" loading="lazy" decoding="async">
               <span class="fh-footer__shipping-label">Standardversand</span>
             </div>
             <div class="fh-footer__shipping-item">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express" loading="lazy" decoding="async">
+              <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express" loading="lazy" decoding="async">
               <span class="fh-footer__shipping-label">Expressversand</span>
             </div>
             <div class="fh-footer__shipping-item">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer" loading="lazy" decoding="async">
+              <img src="https://bilder.fenster-hammer.de/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer" loading="lazy" decoding="async">
               <span class="fh-footer__shipping-label">Selbstabholung</span>
             </div>
           </div>
@@ -139,9 +139,9 @@
           © 2014–2026 FENSTER-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
         </div>
         <div class="fh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
-          <img class="fh-footer__trust-badge fh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" title="FENSTER-HAMMER (fenster-hammer.de) gibt es seit 2014" loading="lazy" decoding="async">
-          <img class="fh-footer__trust-badge fh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" title="Standardmäßige Verschlüsselung Deiner Daten" loading="lazy" decoding="async">
-          <img class="fh-footer__trust-badge fh-footer__trust-badge--company" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" title="Unternehmen unter deutscher Führung und Besitz sowie Sitz in Nordrhein-Westfalen" loading="lazy" decoding="async">
+          <img class="fh-footer__trust-badge fh-footer__trust-badge--anniversary" src="https://bilder.fenster-hammer.de/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" title="FENSTER-HAMMER (fenster-hammer.de) gibt es seit 2014" loading="lazy" decoding="async">
+          <img class="fh-footer__trust-badge fh-footer__trust-badge--ssl" src="https://bilder.fenster-hammer.de/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" title="Standardmäßige Verschlüsselung Deiner Daten" loading="lazy" decoding="async">
+          <img class="fh-footer__trust-badge fh-footer__trust-badge--company" src="https://bilder.fenster-hammer.de/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" title="Unternehmen unter deutscher Führung und Besitz sowie Sitz in Nordrhein-Westfalen" loading="lazy" decoding="async">
         </div>
       </div>
     </div>

--- a/Footer/SH-Footer.html
+++ b/Footer/SH-Footer.html
@@ -11,7 +11,7 @@
       <section class="sh-footer__column sh-footer__column--info">
         <h5 class="sh-footer__heading">
           <span class="sh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/info_14574710.svg" alt="Infos" loading="lazy" decoding="async" width="18" height="18">
+            <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/info_14574710.svg" alt="Infos" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Infos
         </h5>
@@ -27,7 +27,7 @@
       <section class="sh-footer__column sh-footer__column--community">
         <h5 class="sh-footer__heading">
           <span class="sh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/workgroup_12886873.svg" alt="Community" loading="lazy" decoding="async" width="18" height="18">
+            <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/workgroup_12886873.svg" alt="Community" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Community
         </h5>
@@ -42,7 +42,7 @@
       <section class="sh-footer__column sh-footer__column--legal">
         <h5 class="sh-footer__heading">
           <span class="sh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/balance_2970715.svg" alt="Rechtliches" loading="lazy" decoding="async" width="18" height="18">
+            <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/balance_2970715.svg" alt="Rechtliches" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Rechtliches
         </h5>
@@ -58,7 +58,7 @@
       <section class="sh-footer__column sh-footer__column--benefits">
         <h5 class="sh-footer__heading">
           <span class="sh-footer__heading-icon">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/raise_1054356.svg" alt="Vorteile" loading="lazy" decoding="async" width="18" height="18">
+            <img src="https://bilder.schrauben-hammer.de/frontend/raise_1054356.svg" alt="Vorteile" loading="lazy" decoding="async" width="18" height="18">
           </span>
           Vorteile
         </h5>
@@ -76,17 +76,17 @@
       <div class="sh-footer__brand-section">
         <div class="sh-footer__brands">
         <a href="https://schrauben-hammer.de" target="_blank" rel="noopener noreferrer">
-       <img class="sh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="SCHRAUBEN-HAMMER" loading="lazy" decoding="async" width="335" height="150">
+       <img class="sh-footer__brand-logo" src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="SCHRAUBEN-HAMMER" loading="lazy" decoding="async" width="335" height="150">
       </a>
        <a href="https://fenster-hammer.de" target="_blank" rel="noopener noreferrer">
-        <img class="fh-footer__brand-logo" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer" loading="lazy" decoding="async" width="300" height="300">
+        <img class="fh-footer__brand-logo" src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/FH_Icon_big_Profile_Image_transparent_300px.png" alt="Fensterhammer" loading="lazy" decoding="async" width="300" height="300">
        </a>
       </div>
         <div class="sh-footer__legal">
           <p>
             Onlineshops der INTRA-TEC GmbH
             <a class="sh-footer__social-link" href="https://www.linkedin.com/company/intra-tec-gmbh/" aria-label="LinkedIn">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/LinkedIn.png" alt="LinkedIn" loading="lazy" decoding="async" width="16" height="16">
+              <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/LinkedIn.png" alt="LinkedIn" loading="lazy" decoding="async" width="16" height="16">
             </a>
           </p>
           <p>
@@ -107,29 +107,29 @@
         <div class="sh-footer__logistics-section">
           <h6 class="sh-footer__sub-heading">Unsere Zahlungsarten</h6>
           <div class="sh-footer__badge-grid sh-footer__badge-grid--payments" aria-label="Akzeptierte Zahlungsarten">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Apple_Pay.png" alt="Apple Pay" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/PayPal.png" alt="PayPal" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Klarna.png" alt="Klarna" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/American_Express.png" alt="American Express" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Mastercard.png" alt="Mastercard" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Visa.png" alt="Visa" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Billie_Rechnungskauf_fuer_Fimrnen.png" alt="Billie Rechnungskauf für Firmen" loading="lazy" decoding="async">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Vorkasse.png" alt="Vorkasse" loading="lazy" decoding="async">
+            <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/Apple_Pay.png" alt="Apple Pay" loading="lazy" decoding="async">
+            <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/PayPal.png" alt="PayPal" loading="lazy" decoding="async">
+            <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/Klarna.png" alt="Klarna" loading="lazy" decoding="async">
+            <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/American_Express.png" alt="American Express" loading="lazy" decoding="async">
+            <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/Mastercard.png" alt="Mastercard" loading="lazy" decoding="async">
+            <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/Visa.png" alt="Visa" loading="lazy" decoding="async">
+            <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/Billie_Rechnungskauf_fuer_Fimrnen.png" alt="Billie Rechnungskauf für Firmen" loading="lazy" decoding="async">
+            <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/Vorkasse.png" alt="Vorkasse" loading="lazy" decoding="async">
           </div>
         </div>
         <div class="sh-footer__logistics-section">
           <h6 class="sh-footer__sub-heading">Unsere Versandarten</h6>
           <div class="sh-footer__badge-grid sh-footer__badge-grid--shipping" aria-label="Versanddienstleister">
             <div class="sh-footer__shipping-item">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand" loading="lazy" decoding="async">
+              <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/DHL_Standardversand.png" alt="DHL Standardversand" loading="lazy" decoding="async">
               <span class="sh-footer__shipping-label">Standardversand</span>
             </div>
             <div class="sh-footer__shipping-item">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express" loading="lazy" decoding="async">
+              <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/GO__Express.png" alt="GO! Express" loading="lazy" decoding="async">
               <span class="sh-footer__shipping-label">Expressversand</span>
             </div>
             <div class="sh-footer__shipping-item">
-              <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer" loading="lazy" decoding="async">
+              <img src="https://bilder.schrauben-hammer.de/frontend/Footer_v2_Media/Selbstabholer.png" alt="Selbstabholer" loading="lazy" decoding="async">
               <span class="sh-footer__shipping-label">Selbstabholung</span>
             </div>
           </div>
@@ -140,9 +140,9 @@
           © 2014–2026 SCHRAUBEN-HAMMER | INTRA-TEC GmbH. Alle Rechte vorbehalten.
         </div>
         <div class="sh-footer__trust-badges" aria-label="Sicherheits- und Unternehmensbadges">
-          <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" title="SCHRAUBEN-HAMMER (schrauben-hammer.de) gibt es seit 2014" loading="lazy" decoding="async">
-          <img class="sh-footer__trust-badge sh-footer__trust-badge--ssl" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" title="Standardmäßige Verschlüsselung Deiner Daten" loading="lazy" decoding="async">
-          <img class="sh-footer__trust-badge sh-footer__trust-badge--company" src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" title="Unternehmen unter deutscher Führung und Besitz sowie Sitz in Nordrhein-Westfalen" loading="lazy" decoding="async">
+          <img class="sh-footer__trust-badge sh-footer__trust-badge--anniversary" src="https://bilder.schrauben-hammer.de/frontend/UI_Icons/Badges/10__Jahre_Onlineshop_blau_v2.svg" alt="10 Jahre Onlineshop" title="SCHRAUBEN-HAMMER (schrauben-hammer.de) gibt es seit 2014" loading="lazy" decoding="async">
+          <img class="sh-footer__trust-badge sh-footer__trust-badge--ssl" src="https://bilder.schrauben-hammer.de/frontend/UI_Icons/Badges/Sicher_Shoppen-SSL-Verschluesselung_300px.png" alt="Sicher shoppen mit SSL-Verschlüsselung" title="Standardmäßige Verschlüsselung Deiner Daten" loading="lazy" decoding="async">
+          <img class="sh-footer__trust-badge sh-footer__trust-badge--company" src="https://bilder.schrauben-hammer.de/frontend/UI_Icons/Badges/Deutsches_Unternehmen_Badge_v2.svg" alt="Deutsches Unternehmen" title="Unternehmen unter deutscher Führung und Besitz sowie Sitz in Nordrhein-Westfalen" loading="lazy" decoding="async">
         </div>
       </div>
     </div>

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -29,7 +29,7 @@
   </div>
   <div class="fh-header__main">
     <a href="/" class="fh-header__logo">
-      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Logo_neu/FH_Icon_big_Profile_Image_transparent_385x200px.png" alt="FENSTER-HAMMER">
+      <img src="https://bilder.fenster-hammer.de/frontend/Logo_neu/FH_Icon_big_Profile_Image_transparent_385x200px.png" alt="FENSTER-HAMMER">
     </a>
     <div class="fh-header__search-area">
       <button type="button" class="fh-header__burger" data-fh-mobile-menu-toggle aria-controls="fh-mobile-menu" aria-expanded="false" aria-label="Menü">
@@ -188,7 +188,7 @@
                 <a href="tel:02204910980" class="fh-header__panel-contact-chip">
                   <span class="fh-header__panel-contact-icon" aria-hidden="true">
                     <img
-                      src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/phone.svg"
+                      src="https://bilder.fenster-hammer.de/frontend/UI_Icons/phone.svg"
                       alt=""
                       class="fh-header__panel-contact-icon-image"
                     >
@@ -334,7 +334,7 @@
             <li class="nav-item dropdown fh-header__nav-item">
               <a class="nav-link fh-header__nav-link" href="/schloesser" data-fh-mobile-submenu-target="schloesser" aria-controls="fh-mobile-submenu-schloesser" aria-expanded="false">
                 <span class="fh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Schloesser_icon_2.svg" alt="">
+                  <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/Schloesser_icon_2.svg" alt="">
                 </span>
                 <span class="fh-header__nav-text">Schlösser</span>
               </a>
@@ -375,7 +375,7 @@
                   </div>
                   <div class="fh-header__dropdown-column fh-header__dropdown-column--preview">
                     <a href="/schloesser" class="fh-header__dropdown-preview-link">
-                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Schloesser_Kategorie_Nav_Vorschau_360x120.jpg" alt="Schlösser Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
+                      <img src="https://bilder.fenster-hammer.de/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Schloesser_Kategorie_Nav_Vorschau_360x120.jpg" alt="Schlösser Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
                     </a>
                   </div>
                   <div class="fh-header__dropdown-footer">
@@ -391,7 +391,7 @@
             <li class="nav-item dropdown fh-header__nav-item">
               <a class="nav-link fh-header__nav-link" href="/beschlaege" data-fh-mobile-submenu-target="beschlaege" aria-controls="fh-mobile-submenu-beschlaege" aria-expanded="false">
                 <span class="fh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Beschlaege_icon_2.svg" alt="">
+                  <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/Beschlaege_icon_2.svg" alt="">
                 </span>
                 <span class="fh-header__nav-text">Beschläge</span>
               </a>
@@ -416,7 +416,7 @@
                   </div>
                   <div class="fh-header__dropdown-column fh-header__dropdown-column--preview">
                     <a href="/beschlaege" class="fh-header__dropdown-preview-link">
-                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Beschlaege_Kategorie_Nav_Vorschau_360x120.jpg" alt="Beschläge Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
+                      <img src="https://bilder.fenster-hammer.de/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Beschlaege_Kategorie_Nav_Vorschau_360x120.jpg" alt="Beschläge Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
                     </a>
                   </div>
                   <div class="fh-header__dropdown-footer">
@@ -429,7 +429,7 @@
             <li class="nav-item dropdown fh-header__nav-item">
               <a class="nav-link fh-header__nav-link" href="/fenster-sicherheit/" data-fh-mobile-submenu-target="fenster-sicherheit" aria-controls="fh-mobile-submenu-fenster-sicherheit" aria-expanded="false">
                 <span class="fh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Fenster_Sicherheit_icon_2.svg" alt="">
+                  <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/Fenster_Sicherheit_icon_2.svg" alt="">
                 </span>
                 <span class="fh-header__nav-text">Fenster &amp; Sicherheit</span>
               </a>
@@ -451,7 +451,7 @@
                   </div>
                   <div class="fh-header__dropdown-column fh-header__dropdown-column--preview">
                     <a href="/fenster-sicherheit/" class="fh-header__dropdown-preview-link">
-                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Fenster_und_Sicherheit_Kategorie_Nav_Vorschau_360x120.jpg" alt="Fenster &amp; Sicherheit Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
+                      <img src="https://bilder.fenster-hammer.de/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Fenster_und_Sicherheit_Kategorie_Nav_Vorschau_360x120.jpg" alt="Fenster &amp; Sicherheit Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
                     </a>
                   </div>
                   <div class="fh-header__dropdown-footer">
@@ -464,7 +464,7 @@
             <li class="nav-item dropdown fh-header__nav-item">
               <a class="nav-link fh-header__nav-link" href="/terrasse" data-fh-mobile-submenu-target="gartenbau" aria-controls="fh-mobile-submenu-gartenbau" aria-expanded="false">
                 <span class="fh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Gartnebau_icon.svg" alt="">
+                  <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/Gartnebau_icon.svg" alt="">
                 </span>
                 <span class="fh-header__nav-text">Gartenbau</span>
               </a>
@@ -496,7 +496,7 @@
                   </div>
                   <div class="fh-header__dropdown-column fh-header__dropdown-column--preview">
                     <a href="/terrasse" class="fh-header__dropdown-preview-link">
-                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Garten_Kategorie_Nav_Vorschau_360x120.jpg" alt="Gartenbau Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
+                      <img src="https://bilder.fenster-hammer.de/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Garten_Kategorie_Nav_Vorschau_360x120.jpg" alt="Gartenbau Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
                     </a>
                   </div>
                   <div class="fh-header__dropdown-footer">
@@ -509,7 +509,7 @@
             <li class="nav-item dropdown fh-header__nav-item">
               <a class="nav-link fh-header__nav-link" href="/chemische-befestigung" data-fh-mobile-submenu-target="bauchemie" aria-controls="fh-mobile-submenu-bauchemie" aria-expanded="false">
                 <span class="fh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Bauchemie_icon.svg" alt="">
+                  <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/Bauchemie_icon.svg" alt="">
                 </span>
                 <span class="fh-header__nav-text">Bauchemie</span>
               </a>
@@ -526,7 +526,7 @@
                   </div>
                   <div class="fh-header__dropdown-column fh-header__dropdown-column--preview">
                     <a href="/chemische-befestigung" class="fh-header__dropdown-preview-link">
-                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Bauchemie_Kategorie_Nav_Vorschau_360x120.jpg" alt="Bauchemie Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
+                      <img src="https://bilder.fenster-hammer.de/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Bauchemie_Kategorie_Nav_Vorschau_360x120.jpg" alt="Bauchemie Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
                     </a>
                   </div>
                   <div class="fh-header__dropdown-footer">
@@ -539,7 +539,7 @@
             <li class="nav-item dropdown fh-header__nav-item">
               <a class="nav-link fh-header__nav-link" href="/zubehoer" data-fh-mobile-submenu-target="zubehoer" aria-controls="fh-mobile-submenu-zubehoer" aria-expanded="false">
                 <span class="fh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Zubehoer_icon_2.svg" alt="">
+                  <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/Zubehoer_icon_2.svg" alt="">
                 </span>
                 <span class="fh-header__nav-text">Zubehör</span>
               </a>
@@ -569,7 +569,7 @@
                   </div>
                   <div class="fh-header__dropdown-column fh-header__dropdown-column--preview">
                     <a href="/zubehoer" class="fh-header__dropdown-preview-link">
-                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Zubehoer_Kategorie_Nav_Vorschau_360x120.jpg" alt="Zubehör Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
+                      <img src="https://bilder.fenster-hammer.de/frontend/Kategorie_Bilder_Shop/Nav_Vorschau_Bilder/Zubehoer_Kategorie_Nav_Vorschau_360x120.jpg" alt="Zubehör Kategorie Vorschau" class="fh-header__dropdown-preview-image" width="360" height="120">
                     </a>
                   </div>
                   <div class="fh-header__dropdown-footer">
@@ -582,7 +582,7 @@
             <li class="nav-item dropdown fh-header__nav-item">
               <a class="nav-link fh-header__nav-link" href="/top-marken" data-fh-mobile-submenu-target="marken" aria-controls="fh-mobile-submenu-marken" aria-expanded="false">
                 <span class="fh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Marken_icon.svg" alt="">
+                  <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/Marken_icon.svg" alt="">
                 </span>
                 <span class="fh-header__nav-text">Marken</span>
               </a>
@@ -590,22 +590,22 @@
                 <div class="fh-header__dropdown-grid fh-header__dropdown-grid--brands">
                   <div class="fh-header__brand-logos">
                     <a href="/top-marken/abus" class="fh-header__brand-logo-link">
-                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Header_Menu_Images-and-Icons/ABUS_Logo_FH_Submenu.png" alt="ABUS" class="fh-header__brand-logo">
+                      <img src="https://bilder.fenster-hammer.de/frontend/Header_Menu_Images-and-Icons/ABUS_Logo_FH_Submenu.png" alt="ABUS" class="fh-header__brand-logo">
                     </a>
                     <a href="/top-marken/bever" class="fh-header__brand-logo-link">
-                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Header_Menu_Images-and-Icons/BEVER_Logo_FH_Submenu.png" alt="BEVER" class="fh-header__brand-logo">
+                      <img src="https://bilder.fenster-hammer.de/frontend/Header_Menu_Images-and-Icons/BEVER_Logo_FH_Submenu.png" alt="BEVER" class="fh-header__brand-logo">
                     </a>
                     <a href="/top-marken/index" class="fh-header__brand-logo-link">
-                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Header_Menu_Images-and-Icons/INDEX_Logo_FH_Submenu.png" alt="INDEX" class="fh-header__brand-logo">
+                      <img src="https://bilder.fenster-hammer.de/frontend/Header_Menu_Images-and-Icons/INDEX_Logo_FH_Submenu.png" alt="INDEX" class="fh-header__brand-logo">
                     </a>
                     <a href="/top-marken/pica" class="fh-header__brand-logo-link">
-                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Header_Menu_Images-and-Icons/PICA_Logo_FH_Submenu.png" alt="Pica" class="fh-header__brand-logo">
+                      <img src="https://bilder.fenster-hammer.de/frontend/Header_Menu_Images-and-Icons/PICA_Logo_FH_Submenu.png" alt="Pica" class="fh-header__brand-logo">
                     </a>
                     <a href="/top-marken/screwrebel" class="fh-header__brand-logo-link">
-                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Header_Menu_Images-and-Icons/SCREWREBEL_Logo_FH_Submenu.png" alt="SCREWREBEL" class="fh-header__brand-logo">
+                      <img src="https://bilder.fenster-hammer.de/frontend/Header_Menu_Images-and-Icons/SCREWREBEL_Logo_FH_Submenu.png" alt="SCREWREBEL" class="fh-header__brand-logo">
                     </a>
                     <a href="/top-marken/wera" class="fh-header__brand-logo-link">
-                      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Header_Menu_Images-and-Icons/WERA_Logo_FH_Submenu.png" alt="WERA" class="fh-header__brand-logo">
+                      <img src="https://bilder.fenster-hammer.de/frontend/Header_Menu_Images-and-Icons/WERA_Logo_FH_Submenu.png" alt="WERA" class="fh-header__brand-logo">
                     </a>
                   </div>
                   <div class="fh-header__brand-divider" aria-hidden="true"></div>
@@ -628,7 +628,7 @@
             <li class="nav-item dropdown fh-header__nav-item">
               <a class="nav-link fh-header__nav-link fh-header__nav-link--highlight" href="/aktion" data-fh-mobile-submenu-target="aktionen" aria-controls="fh-mobile-submenu-aktionen" aria-expanded="false">
                 <span class="fh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Aktionen_icon_2.svg" alt="">
+                  <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/Aktionen_icon_2.svg" alt="">
                 </span>
                 <span class="fh-header__nav-text">Aktionen</span>
               </a>

--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -29,7 +29,7 @@
   </div>
   <div class="sh-header__main">
     <a href="/" class="sh-header__logo">
-      <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Logo_neu/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="FENSTER-HAMMER">
+      <img src="https://bilder.schrauben-hammer.de/frontend/Logo_neu/SCHRAUBEN-HAMMER_Logo_335x150px.png" alt="FENSTER-HAMMER">
     </a>
     <div class="sh-header__search-area">
       <button type="button" class="sh-header__burger" data-sh-mobile-menu-toggle aria-controls="sh-mobile-menu" aria-expanded="false" aria-label="Menü">
@@ -188,7 +188,7 @@
                 <a href="tel:02204910980" class="sh-header__panel-contact-chip">
                   <span class="sh-header__panel-contact-icon" aria-hidden="true">
                     <img
-                      src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/phone.svg"
+                      src="https://bilder.schrauben-hammer.de/frontend/UI_Icons/phone.svg"
                       alt=""
                       class="sh-header__panel-contact-icon-image"
                     >
@@ -334,7 +334,7 @@
             <li class="nav-item dropdown sh-header__nav-item">
               <a class="nav-link sh-header__nav-link" href="/anwendungsgebiet/" data-sh-mobile-submenu-target="anwendungsgebiet" aria-controls="sh-mobile-submenu-anwendungsgebiet" aria-expanded="false">
                 <span class="sh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Anwendungsgebiete_icon.svg" alt="">
+                  <img src="https://bilder.schrauben-hammer.de/frontend/UI_Icons/Anwendungsgebiete_icon.svg" alt="">
                 </span>
                 <span class="sh-header__nav-text">Anwendungsgebiet</span>
               </a>
@@ -462,7 +462,7 @@
                   aria-expanded="false"
               >
                 <span class="sh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Bauchemie_icon.svg" alt="">
+                  <img src="https://bilder.schrauben-hammer.de/frontend/UI_Icons/Bauchemie_icon.svg" alt="">
                 </span>
                 <span class="sh-header__nav-text">Trockenbau</span>
               </a>
@@ -490,7 +490,7 @@
             <li class="nav-item dropdown sh-header__nav-item">
               <a class="nav-link sh-header__nav-link" href="/schrauben/" data-sh-mobile-submenu-target="schrauben" aria-controls="sh-mobile-submenu-schrauben" aria-expanded="false">
                 <span class="sh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Schraubensortiment_icon.svg" alt="">
+                  <img src="https://bilder.schrauben-hammer.de/frontend/UI_Icons/Schraubensortiment_icon.svg" alt="">
                 </span>
                 <span class="sh-header__nav-text">Schraubensortiment</span>
               </a>
@@ -537,7 +537,7 @@
             <li class="nav-item dropdown sh-header__nav-item">
               <a class="nav-link sh-header__nav-link" href="/duebel/" data-sh-mobile-submenu-target="duebel" aria-controls="sh-mobile-submenu-duebel" aria-expanded="false">
                 <span class="sh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Duebel_icon.svg" alt="">
+                  <img src="https://bilder.schrauben-hammer.de/frontend/UI_Icons/Duebel_icon.svg" alt="">
                 </span>
                 <span class="sh-header__nav-text">Dübel</span>
               </a>
@@ -564,7 +564,7 @@
             <li class="nav-item dropdown sh-header__nav-item">
               <a class="nav-link sh-header__nav-link" href="/normteile/" data-sh-mobile-submenu-target="normteile" aria-controls="sh-mobile-submenu-normteile" aria-expanded="false">
                 <span class="sh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Normteile_Icon.svg" alt="">
+                  <img src="https://bilder.schrauben-hammer.de/frontend/UI_Icons/Normteile_Icon.svg" alt="">
                 </span>
                 <span class="sh-header__nav-text">Normteile</span>
               </a>
@@ -589,7 +589,7 @@
             <li class="nav-item dropdown sh-header__nav-item">
               <a class="nav-link sh-header__nav-link" href="/zubehoer/" data-sh-mobile-submenu-target="zubehoer" aria-controls="sh-mobile-submenu-zubehoer" aria-expanded="false">
                 <span class="sh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Zubehoer_icon_2.svg" alt="">
+                  <img src="https://bilder.schrauben-hammer.de/frontend/UI_Icons/Zubehoer_icon_2.svg" alt="">
                 </span>
                 <span class="sh-header__nav-text">Zubehör</span>
               </a>
@@ -629,7 +629,7 @@
             <li class="nav-item dropdown sh-header__nav-item">
               <a class="nav-link sh-header__nav-link" href="/top-marken" data-sh-mobile-submenu-target="marken" aria-controls="sh-mobile-submenu-marken" aria-expanded="false">
                 <span class="sh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Marken_icon.svg" alt="">
+                  <img src="https://bilder.schrauben-hammer.de/frontend/UI_Icons/Marken_icon.svg" alt="">
                 </span>
                 <span class="sh-header__nav-text">Marken</span>
               </a>
@@ -664,7 +664,7 @@
             <li class="nav-item dropdown sh-header__nav-item">
               <a class="nav-link sh-header__nav-link sh-header__nav-link--highlight" href="/aktion/" data-sh-mobile-submenu-target="aktionen" aria-controls="sh-mobile-submenu-aktionen" aria-expanded="false">
                 <span class="sh-header__nav-icon" aria-hidden="true">
-                  <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/Aktionen_icon_2.svg" alt="">
+                  <img src="https://bilder.schrauben-hammer.de/frontend/UI_Icons/Aktionen_icon_2.svg" alt="">
                 </span>
                 <span class="sh-header__nav-text">Aktionen</span>
               </a>

--- a/JavaScript im Head/FH - JS Libs im Head (mit script-tag anzugeben, 1 pro zeile).js
+++ b/JavaScript im Head/FH - JS Libs im Head (mit script-tag anzugeben, 1 pro zeile).js
@@ -1,5 +1,5 @@
 <script src="https://integrations.etrusted.com/applications/widget.js/v2" defer async></script>
 <script src="https://cdn.lottielab.com/s/lottie-player@1.x/player-web.min.js"></script>
-<script src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Custom_JS_Code/FH_Custom_JS_Code/FH_-_Javascript_am_Ende_der_Seite_pr408.js" async></script>
+<script src="https://bilder.fenster-hammer.de/frontend/Custom_JS_Code/FH_Custom_JS_Code/FH_-_Javascript_am_Ende_der_Seite_pr408.js" async></script>
 <script src="https://unpkg.com/@lottiefiles/dotlottie-wc@0.6.2/dist/dotlottie-wc.js" type="module"></script>
 <script src="https://eu1-config.doofinder.com/2.x/915effe0-ee43-4db2-9567-5ee87a7bc008.js" async></script>

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -2943,7 +2943,7 @@ fhOnReady(function () {
     }
     return t + '</span>';
   }
-  var iconUrl = "https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/shipping_9288277.svg";
+  var iconUrl = "https://bilder.fenster-hammer.de/frontend/shipping_9288277.svg";
   var iconHtml = '<img src="' + iconUrl + '" alt="" style="height:2.6em;width:auto;vertical-align:middle;display:block;">';
   function waitForCountdownDiv(){
     var elem = document.getElementById('cutoff-countdown');
@@ -3038,19 +3038,19 @@ fhOnReady(function () {
       match: function (labelText) {
         return labelText.includes('dhl');
       },
-      src: 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/DHLVersand_Icon_D1.png'
+      src: 'https://bilder.fenster-hammer.de/frontend/DHLVersand_Icon_D1.png'
     },
     {
       match: function (labelText) {
         return labelText.includes('general overnight express') || labelText.includes('go express');
       },
-      src: 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/GO_Express_Versand_Icon_D1.1.png'
+      src: 'https://bilder.fenster-hammer.de/frontend/GO_Express_Versand_Icon_D1.1.png'
     },
     {
       match: function (labelText) {
         return labelText.includes('selbstabholung');
       },
-      src: 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Selbstabholung_Lager_Versand_Icon_D1.1.png'
+      src: 'https://bilder.fenster-hammer.de/frontend/Selbstabholung_Lager_Versand_Icon_D1.1.png'
     }
   ];
 

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -2920,7 +2920,7 @@ shOnReady(function () {
     }
     return t + '</span>';
   }
-  var iconUrl = "https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/shipping_9288277.svg";
+  var iconUrl = "https://bilder.schrauben-hammer.de/frontend/shipping_9288277.svg";
   var iconHtml = '<img src="' + iconUrl + '" alt="" style="height:2.6em;width:auto;vertical-align:middle;display:block;">';
   function waitForCountdownDiv(){
     var elem = document.getElementById('cutoff-countdown');
@@ -3015,19 +3015,19 @@ shOnReady(function () {
       match: function (labelText) {
         return labelText.includes('dhl');
       },
-      src: 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/DHLVersand_Icon_D1.png'
+      src: 'https://bilder.schrauben-hammer.de/frontend/DHLVersand_Icon_D1.png'
     },
     {
       match: function (labelText) {
         return labelText.includes('general overnight express') || labelText.includes('go express');
       },
-      src: 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/GO_Express_Versand_Icon_D1.1.png'
+      src: 'https://bilder.schrauben-hammer.de/frontend/GO_Express_Versand_Icon_D1.1.png'
     },
     {
       match: function (labelText) {
         return labelText.includes('selbstabholung');
       },
-      src: 'https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Selbstabholung_Lager_Versand_Icon_D1.1.png'
+      src: 'https://bilder.schrauben-hammer.de/frontend/Selbstabholung_Lager_Versand_Icon_D1.1.png'
     }
   ];
 

--- a/Kundenbetreuer Kontaktseiten/Kontaktseite Andreas Fischermann.html
+++ b/Kundenbetreuer Kontaktseiten/Kontaktseite Andreas Fischermann.html
@@ -7,7 +7,7 @@
     style="width:min(560px,100%);background-color:#ffffff;border-radius:14px;box-shadow:0 24px 48px rgba(15,23,42,0.12);overflow:hidden;position:relative;"
   >
     <img
-      src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/default-halftone-bg_Kopie.avif"
+      src="https://bilder.fenster-hammer.de/frontend/default-halftone-bg_Kopie.avif"
       alt="Abstraktes Bannerbild"
       loading="lazy"
       style="width:100%;height:160px;object-fit:cover;display:block;"
@@ -17,7 +17,7 @@
         style="position:absolute;top:-64px;left:50%;transform:translateX(-50%);width:128px;height:128px;border-radius:50%;padding:6px;background:linear-gradient(140deg,#2563eb,#38bdf8);box-shadow:0 16px 32px rgba(15,23,42,0.2);"
       >
         <img
-          src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/avatar_simple_grey_andreas.svg"
+          src="https://bilder.fenster-hammer.de/frontend/UI_Icons/avatar_simple_grey_andreas.svg"
           alt="Profilfoto von Andreas Fischermann"
           loading="lazy"+
           style="width:100%;height:100%;object-fit:cover;border-radius:50%;border:4px solid #ffffff;display:block;"
@@ -32,7 +32,7 @@
           style="display:inline-flex;align-items:center;gap:8px;padding:12px 20px;border-radius:14px;border:none;font-size:0.95rem;font-weight:600;text-decoration:none;color:#111827;background-color:#e5e7eb;box-shadow:0 8px 16px rgba(148,163,184,0.22);"
         >
           <span aria-hidden="true" style="display:inline-flex;width:20px;height:20px;">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/phone.svg" alt="" style="width:100%;height:100%;display:block;" />
+            <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/phone.svg" alt="" style="width:100%;height:100%;display:block;" />
           </span>
           <span>Telefon</span>
         </a>
@@ -55,7 +55,7 @@
           style="display:inline-flex;align-items:center;gap:8px;padding:12px 20px;border-radius:14px;border:none;font-size:0.95rem;font-weight:600;text-decoration:none;color:#0f172a;background-color:#25d366;box-shadow:0 8px 16px rgba(148,163,184,0.22);"
         >
           <span aria-hidden="true" style="display:inline-flex;width:20px;height:20px;">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/whatsapp_icon.svg" alt="" style="width:100%;height:100%;display:block;" />
+            <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/whatsapp_icon.svg" alt="" style="width:100%;height:100%;display:block;" />
           </span>
           <span>WhatsApp</span>
         </a>

--- a/Kundenbetreuer Kontaktseiten/Kontaktseite Gabriele Sprenger.html
+++ b/Kundenbetreuer Kontaktseiten/Kontaktseite Gabriele Sprenger.html
@@ -7,7 +7,7 @@
     style="width:min(560px,100%);background-color:#ffffff;border-radius:14px;box-shadow:0 24px 48px rgba(15,23,42,0.12);overflow:hidden;position:relative;"
   >
     <img
-      src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/default-halftone-bg_Kopie.avif"
+      src="https://bilder.fenster-hammer.de/frontend/default-halftone-bg_Kopie.avif"
       alt="Abstraktes Bannerbild"
       loading="lazy"
       style="width:100%;height:160px;object-fit:cover;display:block;"
@@ -17,7 +17,7 @@
         style="position:absolute;top:-64px;left:50%;transform:translateX(-50%);width:128px;height:128px;border-radius:50%;padding:6px;background:linear-gradient(140deg,#2563eb,#38bdf8);box-shadow:0 16px 32px rgba(15,23,42,0.2);"
       >
         <img
-          src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/avatar_simple_grey_gabi.svg"
+          src="https://bilder.fenster-hammer.de/frontend/UI_Icons/avatar_simple_grey_gabi.svg"
           alt="Profilfoto von Gabriele Sprenger"
           loading="lazy"
           style="width:100%;height:100%;object-fit:cover;border-radius:50%;border:4px solid #ffffff;display:block;"
@@ -32,7 +32,7 @@
           style="display:inline-flex;align-items:center;gap:8px;padding:12px 20px;border-radius:14px;border:none;font-size:0.95rem;font-weight:600;text-decoration:none;color:#111827;background-color:#e5e7eb;box-shadow:0 8px 16px rgba(148,163,184,0.22);"
         >
           <span aria-hidden="true" style="display:inline-flex;width:20px;height:20px;">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/phone.svg" alt="" style="width:100%;height:100%;display:block;" />
+            <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/phone.svg" alt="" style="width:100%;height:100%;display:block;" />
           </span>
           <span>Telefon</span>
         </a>
@@ -55,7 +55,7 @@
           style="display:inline-flex;align-items:center;gap:8px;padding:12px 20px;border-radius:14px;border:none;font-size:0.95rem;font-weight:600;text-decoration:none;color:#0f172a;background-color:#25d366;box-shadow:0 8px 16px rgba(148,163,184,0.22);"
         >
           <span aria-hidden="true" style="display:inline-flex;width:20px;height:20px;">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/whatsapp_icon.svg" alt="" style="width:100%;height:100%;display:block;" />
+            <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/whatsapp_icon.svg" alt="" style="width:100%;height:100%;display:block;" />
           </span>
           <span>WhatsApp</span>
         </a>

--- a/Kundenbetreuer Kontaktseiten/Kontaktseite Ulrich Vorländer.html
+++ b/Kundenbetreuer Kontaktseiten/Kontaktseite Ulrich Vorländer.html
@@ -7,7 +7,7 @@
     style="width:min(560px,100%);background-color:#ffffff;border-radius:14px;box-shadow:0 24px 48px rgba(15,23,42,0.12);overflow:hidden;position:relative;"
   >
     <img
-      src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/default-halftone-bg_Kopie.avif"
+      src="https://bilder.fenster-hammer.de/frontend/default-halftone-bg_Kopie.avif"
       alt="Abstraktes Bannerbild"
       loading="lazy"
       style="width:100%;height:160px;object-fit:cover;display:block;"
@@ -17,7 +17,7 @@
         style="position:absolute;top:-64px;left:50%;transform:translateX(-50%);width:128px;height:128px;border-radius:50%;padding:6px;background:linear-gradient(140deg,#2563eb,#38bdf8);box-shadow:0 16px 32px rgba(15,23,42,0.2);"
       >
         <img
-          src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/avatar_simple_grey_uli.svg"
+          src="https://bilder.fenster-hammer.de/frontend/UI_Icons/avatar_simple_grey_uli.svg"
           alt="Profilfoto von Ulrich Vorländer"
           loading="lazy"+
           style="width:100%;height:100%;object-fit:cover;border-radius:50%;border:4px solid #ffffff;display:block;"
@@ -32,7 +32,7 @@
           style="display:inline-flex;align-items:center;gap:8px;padding:12px 20px;border-radius:14px;border:none;font-size:0.95rem;font-weight:600;text-decoration:none;color:#111827;background-color:#e5e7eb;box-shadow:0 8px 16px rgba(148,163,184,0.22);"
         >
           <span aria-hidden="true" style="display:inline-flex;width:20px;height:20px;">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/phone.svg" alt="" style="width:100%;height:100%;display:block;" />
+            <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/phone.svg" alt="" style="width:100%;height:100%;display:block;" />
           </span>
           <span>Telefon</span>
         </a>
@@ -55,7 +55,7 @@
           style="display:inline-flex;align-items:center;gap:8px;padding:12px 20px;border-radius:14px;border:none;font-size:0.95rem;font-weight:600;text-decoration:none;color:#0f172a;background-color:#25d366;box-shadow:0 8px 16px rgba(148,163,184,0.22);"
         >
           <span aria-hidden="true" style="display:inline-flex;width:20px;height:20px;">
-            <img src="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/whatsapp_icon.svg" alt="" style="width:100%;height:100%;display:block;" />
+            <img src="https://bilder.fenster-hammer.de/frontend/UI_Icons/whatsapp_icon.svg" alt="" style="width:100%;height:100%;display:block;" />
           </span>
           <span>WhatsApp</span>
         </a>

--- a/SH - Metatags.html
+++ b/SH - Metatags.html
@@ -1,7 +1,7 @@
 <meta name="theme-color" content="#f20000" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#11192c" media="(prefers-color-scheme: dark)">
-<meta property="og:image" content="http://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Open-Graph-etc-Social-Media-Share/Open-Graph-FENSTER-HAMMER-Banner-1200x630px.jpg">
-<meta property="og:image:secure_url" content="https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/Open-Graph-etc-Social-Media-Share/Open-Graph-FENSTER-HAMMER-Banner-1200x630px.jpg">
+<meta property="og:image" content="https://bilder.schrauben-hammer.de/frontend/Open-Graph-etc-Social-Media-Share/Open-Graph-FENSTER-HAMMER-Banner-1200x630px.jpg">
+<meta property="og:image:secure_url" content="https://bilder.schrauben-hammer.de/frontend/Open-Graph-etc-Social-Media-Share/Open-Graph-FENSTER-HAMMER-Banner-1200x630px.jpg">
 <meta property="og:image:type" content="image/jpeg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1730,7 +1730,7 @@ a.logo {
 .sh-header__logout-icon {
   width: 20px;
   height: 20px;
-  background-image: url("https://cdn02.plentymarkets.com/nteqnk1xxnkn/frontend/UI_Icons/log-out-icon.svg");
+  background-image: url("https://bilder.schrauben-hammer.de/frontend/UI_Icons/log-out-icon.svg");
   background-repeat: no-repeat;
   background-position: center;
   background-size: contain;


### PR DESCRIPTION
### Motivation

* Ensure first‑party hosting for media assets by using the correct `bilder.fenster-hammer.de` and `bilder.schrauben-hammer.de` hosts instead of the external CDN or plain domain, improving privacy, caching and branding.
* Keep the FH and SH codebases synchronized so both shops reference the same first‑party media hosts.

### Description

* Replaced occurrences of `cdn02.plentymarkets.com/nteqnk1xxnkn` and plain `fenster-hammer.de` / `schrauben-hammer.de` asset URLs with `https://bilder.fenster-hammer.de/...` for FH and `https://bilder.schrauben-hammer.de/...` for SH across headers, footers, meta tags, stylesheets, JS and contact pages (17 files updated). 
* Updated JS assets and inlined icon variables so shipping icons and countdown images now point to the new `bilder.*` hosts. 
* Updated CSS background-image references to use the new `bilder.*` hosts. 
* Adjusted `AGENTS.md` conversion rule to document that raw CDN URLs will be auto-converted to `https://bilder.fenster-hammer.de/...` for FH and `https://bilder.schrauben-hammer.de/...` for SH.

### Testing

* Verified replacements and remaining occurrences using `rg -n "cdn02\.plentymarkets\.com/nteqnk1xxnkn"` and `rg -n "bilder\.(fenster-hammer|schrauben-hammer)\.de/frontend"`; the old CDN no longer appears and the `bilder.*` URLs are present. 
* Performed the in-place replacements with `perl -pi -e 's#https://fenster-hammer\.de/#https://bilder.fenster-hammer.de/#g; s#https://schrauben-hammer\.de/#https://bilder.schrauben-hammer.de/#g'` and validated sample files with `nl`; inspections succeeded. 
* Committed the changes (`git commit` resulted in 17 files changed) with no CI/unit tests run in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cc376ca4c8331a2c709158d01c562)