### PR TITLE
feat(wishlist): show loading icon on toggle

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3950,6 +3950,22 @@ button[data-testing="quantity-btn-decrease"] {
   -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
   mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
 }
+
+.widget-add-to-wish-list .btn.is-loading {
+  color: #111827;
+}
+
+.widget-add-to-wish-list .btn.is-loading::before {
+  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M12%202a10%2010%200%201%200%2010%2010V20a8%208%200%201%201-8-8H2z'/%3E%3C/svg%3E") no-repeat center / contain;
+  mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M12%202a10%2010%200%201%200%2010%2010V20a8%208%200%201%201-8-8H2z'/%3E%3C/svg%3E") no-repeat center / contain;
+  animation: fh-wishlist-spinner 0.8s linear infinite;
+}
+
+@keyframes fh-wishlist-spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
 /* End Section: Wishlist button styling */
 
 /* Section: Temporary hidden blocks until external functions added */

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3907,12 +3907,12 @@ button[data-testing="quantity-btn-decrease"] {
   transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
 }
 
-.widget-add-to-wish-list .btn .loading-animation,
-.widget-add-to-wish-list .btn .loading,
-.widget-add-to-wish-list .btn .loader,
-.widget-add-to-wish-list .btn .spinner-border,
-.widget-add-to-wish-list .btn .fa-spinner,
-.widget-add-to-wish-list .btn .fa-circle-o-notch {
+.widget-add-to-wish-list .btn:not(.is-loading):not(.loading) .loading-animation,
+.widget-add-to-wish-list .btn:not(.is-loading):not(.loading) .loading,
+.widget-add-to-wish-list .btn:not(.is-loading):not(.loading) .loader,
+.widget-add-to-wish-list .btn:not(.is-loading):not(.loading) .spinner-border,
+.widget-add-to-wish-list .btn:not(.is-loading):not(.loading) .fa-spinner,
+.widget-add-to-wish-list .btn:not(.is-loading):not(.loading) .fa-circle-o-notch {
   display: none;
 }
 
@@ -3951,11 +3951,38 @@ button[data-testing="quantity-btn-decrease"] {
   mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
 }
 
+.widget-add-to-wish-list .btn.is-loading,
+.widget-add-to-wish-list .btn.loading {
+  color: #111827;
+  opacity: 1;
+}
+
+.widget-add-to-wish-list .btn.is-loading .loading-animation,
+.widget-add-to-wish-list .btn.is-loading .loading,
+.widget-add-to-wish-list .btn.is-loading .loader,
+.widget-add-to-wish-list .btn.is-loading .spinner-border,
+.widget-add-to-wish-list .btn.is-loading .fa-spinner,
+.widget-add-to-wish-list .btn.is-loading .fa-circle-o-notch,
+.widget-add-to-wish-list .btn.loading .loading-animation,
+.widget-add-to-wish-list .btn.loading .loading,
+.widget-add-to-wish-list .btn.loading .loader,
+.widget-add-to-wish-list .btn.loading .spinner-border,
+.widget-add-to-wish-list .btn.loading .fa-spinner,
+.widget-add-to-wish-list .btn.loading .fa-circle-o-notch {
+  display: inline-flex;
+}
+
+.widget-add-to-wish-list .btn.loading .fa-spinner,
+.widget-add-to-wish-list .btn.loading .fa-circle-o-notch {
+  animation: fh-wishlist-spinner 0.8s linear infinite;
+}
+
 .widget-add-to-wish-list .btn.is-loading {
   color: #111827;
 }
 
-.widget-add-to-wish-list .btn.is-loading::before {
+.widget-add-to-wish-list .btn.is-loading::before,
+.widget-add-to-wish-list .btn.loading::before {
   -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M12%202a10%2010%200%201%200%2010%2010V20a8%208%200%201%201-8-8H2z'/%3E%3C/svg%3E") no-repeat center / contain;
   mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M12%202a10%2010%200%201%200%2010%2010V20a8%208%200%201%201-8-8H2z'/%3E%3C/svg%3E") no-repeat center / contain;
   animation: fh-wishlist-spinner 0.8s linear infinite;

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -73,7 +73,6 @@
           <div class="fh-header__panel-arrow"></div>
           <div class="fh-header__panel-header">
             <div class="fh-header__panel-title">{{ trans("Ceres::Template.wishList") }}</div>
-            <a href="/wish-list" class="fh-header__panel-link fh-header__panel-link--wishlist">Zur Merkliste</a>
           </div>
           <div class="fh-header__wishlist-body" data-fh-wishlist-body>
             <wish-list></wish-list>

--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -73,7 +73,6 @@
           <div class="sh-header__panel-arrow"></div>
           <div class="sh-header__panel-header">
             <div class="sh-header__panel-title">{{ trans("Ceres::Template.wishList") }}</div>
-            <a href="/wish-list" class="sh-header__panel-link sh-header__panel-link--wishlist">Zur Merkliste</a>
           </div>
           <div class="sh-header__wishlist-body" data-sh-wishlist-body>
             <wish-list></wish-list>

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3851,6 +3851,7 @@ fhOnReady(function () {
   const reloadStorageKey = 'fhWishlistAutoOpen';
   const wishlistButtonSelector = '.widget-add-to-wish-list .btn';
   const attributeFilter = ['class', 'aria-pressed', 'data-original-title'];
+  const loadingClass = 'is-loading';
 
   function getVueStore() {
     if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
@@ -3866,9 +3867,21 @@ fhOnReady(function () {
     return title && title.toLowerCase().includes('entfernen');
   }
 
+  function setLoadingState(button, isLoading) {
+    if (!button) return;
+    button.classList.toggle(loadingClass, isLoading);
+    if (isLoading) {
+      button.setAttribute('aria-busy', 'true');
+    } else {
+      button.removeAttribute('aria-busy');
+    }
+  }
+
   function handleWishListButtonClick(event) {
     const button = event.target.closest(wishlistButtonSelector);
     if (!button) return;
+
+    setLoadingState(button, true);
 
     const store = getVueStore();
     const initialState = isWishListActive(button);
@@ -3941,6 +3954,7 @@ fhOnReady(function () {
           window.clearTimeout(fallbackTimeout);
           fallbackTimeout = null;
         }
+        setLoadingState(button, false);
       }
     }, 3000);
   }

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3902,6 +3902,7 @@ fhOnReady(function () {
         function (nextValue) {
           if (didReload || initialStoreIds === null || nextValue === initialStoreIds) return;
           didReload = true;
+          setLoadingState(button, false);
           if (typeof storeWatcherCleanup === 'function') {
             storeWatcherCleanup();
           }
@@ -3918,6 +3919,7 @@ fhOnReady(function () {
       if (nextState === initialState || didReload) return;
 
       didReload = true;
+      setLoadingState(button, false);
       observer.disconnect();
       if (fallbackTimeout) {
         window.clearTimeout(fallbackTimeout);
@@ -3934,6 +3936,7 @@ fhOnReady(function () {
     fallbackTimeout = window.setTimeout(function () {
       if (didReload) return;
       didReload = true;
+      setLoadingState(button, false);
       observer.disconnect();
       if (typeof storeWatcherCleanup === 'function') {
         storeWatcherCleanup();

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -3880,6 +3880,7 @@ shOnReady(function () {
         function (nextValue) {
           if (didReload || initialStoreIds === null || nextValue === initialStoreIds) return;
           didReload = true;
+          setLoadingState(button, false);
           if (typeof storeWatcherCleanup === 'function') {
             storeWatcherCleanup();
           }
@@ -3896,6 +3897,7 @@ shOnReady(function () {
       if (nextState === initialState || didReload) return;
 
       didReload = true;
+      setLoadingState(button, false);
       observer.disconnect();
       if (fallbackTimeout) {
         window.clearTimeout(fallbackTimeout);
@@ -3912,6 +3914,7 @@ shOnReady(function () {
     fallbackTimeout = window.setTimeout(function () {
       if (didReload) return;
       didReload = true;
+      setLoadingState(button, false);
       observer.disconnect();
       if (typeof storeWatcherCleanup === 'function') {
         storeWatcherCleanup();

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -3829,6 +3829,7 @@ shOnReady(function () {
   const reloadStorageKey = 'shWishlistAutoOpen';
   const wishlistButtonSelector = '.widget-add-to-wish-list .btn';
   const attributeFilter = ['class', 'aria-pressed', 'data-original-title'];
+  const loadingClass = 'is-loading';
 
   function getVueStore() {
     if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
@@ -3844,9 +3845,21 @@ shOnReady(function () {
     return title && title.toLowerCase().includes('entfernen');
   }
 
+  function setLoadingState(button, isLoading) {
+    if (!button) return;
+    button.classList.toggle(loadingClass, isLoading);
+    if (isLoading) {
+      button.setAttribute('aria-busy', 'true');
+    } else {
+      button.removeAttribute('aria-busy');
+    }
+  }
+
   function handleWishListButtonClick(event) {
     const button = event.target.closest(wishlistButtonSelector);
     if (!button) return;
+
+    setLoadingState(button, true);
 
     const store = getVueStore();
     const initialState = isWishListActive(button);
@@ -3919,6 +3932,7 @@ shOnReady(function () {
           window.clearTimeout(fallbackTimeout);
           fallbackTimeout = null;
         }
+        setLoadingState(button, false);
       }
     }, 3000);
   }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3922,6 +3922,22 @@ button[data-testing="quantity-btn-decrease"] {
   -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
   mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
 }
+
+.widget-add-to-wish-list .btn.is-loading {
+  color: #111827;
+}
+
+.widget-add-to-wish-list .btn.is-loading::before {
+  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M12%202a10%2010%200%201%200%2010%2010V20a8%208%200%201%201-8-8H2z'/%3E%3C/svg%3E") no-repeat center / contain;
+  mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M12%202a10%2010%200%201%200%2010%2010V20a8%208%200%201%201-8-8H2z'/%3E%3C/svg%3E") no-repeat center / contain;
+  animation: sh-wishlist-spinner 0.8s linear infinite;
+}
+
+@keyframes sh-wishlist-spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
 /* End Section: Wishlist button styling */
 
 /* Section: Temporary hidden blocks until external functions added */

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3879,12 +3879,12 @@ button[data-testing="quantity-btn-decrease"] {
   transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
 }
 
-.widget-add-to-wish-list .btn .loading-animation,
-.widget-add-to-wish-list .btn .loading,
-.widget-add-to-wish-list .btn .loader,
-.widget-add-to-wish-list .btn .spinner-border,
-.widget-add-to-wish-list .btn .fa-spinner,
-.widget-add-to-wish-list .btn .fa-circle-o-notch {
+.widget-add-to-wish-list .btn:not(.is-loading):not(.loading) .loading-animation,
+.widget-add-to-wish-list .btn:not(.is-loading):not(.loading) .loading,
+.widget-add-to-wish-list .btn:not(.is-loading):not(.loading) .loader,
+.widget-add-to-wish-list .btn:not(.is-loading):not(.loading) .spinner-border,
+.widget-add-to-wish-list .btn:not(.is-loading):not(.loading) .fa-spinner,
+.widget-add-to-wish-list .btn:not(.is-loading):not(.loading) .fa-circle-o-notch {
   display: none;
 }
 
@@ -3923,11 +3923,38 @@ button[data-testing="quantity-btn-decrease"] {
   mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
 }
 
+.widget-add-to-wish-list .btn.is-loading,
+.widget-add-to-wish-list .btn.loading {
+  color: #111827;
+  opacity: 1;
+}
+
+.widget-add-to-wish-list .btn.is-loading .loading-animation,
+.widget-add-to-wish-list .btn.is-loading .loading,
+.widget-add-to-wish-list .btn.is-loading .loader,
+.widget-add-to-wish-list .btn.is-loading .spinner-border,
+.widget-add-to-wish-list .btn.is-loading .fa-spinner,
+.widget-add-to-wish-list .btn.is-loading .fa-circle-o-notch,
+.widget-add-to-wish-list .btn.loading .loading-animation,
+.widget-add-to-wish-list .btn.loading .loading,
+.widget-add-to-wish-list .btn.loading .loader,
+.widget-add-to-wish-list .btn.loading .spinner-border,
+.widget-add-to-wish-list .btn.loading .fa-spinner,
+.widget-add-to-wish-list .btn.loading .fa-circle-o-notch {
+  display: inline-flex;
+}
+
+.widget-add-to-wish-list .btn.loading .fa-spinner,
+.widget-add-to-wish-list .btn.loading .fa-circle-o-notch {
+  animation: sh-wishlist-spinner 0.8s linear infinite;
+}
+
 .widget-add-to-wish-list .btn.is-loading {
   color: #111827;
 }
 
-.widget-add-to-wish-list .btn.is-loading::before {
+.widget-add-to-wish-list .btn.is-loading::before,
+.widget-add-to-wish-list .btn.loading::before {
   -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M12%202a10%2010%200%201%200%2010%2010V20a8%208%200%201%201-8-8H2z'/%3E%3C/svg%3E") no-repeat center / contain;
   mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M12%202a10%2010%200%201%200%2010%2010V20a8%208%200%201%201-8-8H2z'/%3E%3C/svg%3E") no-repeat center / contain;
   animation: sh-wishlist-spinner 0.8s linear infinite;


### PR DESCRIPTION
### Motivation
- Remove the redundant `Zur Merkliste` link from the wishlist dropdown headers to simplify the header panels and avoid duplicate navigation targets. 
- Provide immediate visual feedback when the user toggles add/remove on the Merkliste by showing a circular loading icon in place of the bookmark icon until the change completes.

### Description
- Removed the `Zur Merkliste` anchor from the wishlist dropdown header in `Header/FH-Header.html` and `Header/SH-Header.html`.
- Added `is-loading` state styling and spinner keyframes to `FH - Stylesheets.css` and `SH - Stylesheets.css` to render a rotating circle icon when active.
- Added `setLoadingState` helper and toggling logic in `JavaScript im Head/FH - JS im Head.js` and `JavaScript im Head/SH - JS im Head.js` to add `is-loading` and `aria-busy` when a wishlist add/remove is initiated and to clear it on timeout/fallback.
- Changes applied for both FH and SH shops and committed as `feat(wishlist): show loading icon on toggle`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e34f0b3e08331906a8ad4dad185d9)