### PR TITLE
fix(css): disable Ceres wishlist loader overlays

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3907,32 +3907,8 @@ button[data-testing="quantity-btn-decrease"] {
   transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
 }
 
-.widget-add-to-wish-list .btn .loading-animation,
-.widget-add-to-wish-list .btn .loading,
-.widget-add-to-wish-list .btn .loader,
-.widget-add-to-wish-list .btn .spinner-border,
-.widget-add-to-wish-list .btn .fa-spinner,
-.widget-add-to-wish-list .btn .fa-circle-o-notch {
-  display: none;
-}
-
 .widget-add-to-wish-list .btn i::before {
   display: none;
-}
-
-.widget-add-to-wish-list .btn.is-loading::after,
-.widget-add-to-wish-list .btn .loading-animation::before,
-.widget-add-to-wish-list .btn .loading-animation::after,
-.widget-add-to-wish-list .btn .plenty-loader {
-  display: none;
-}
-
-.widget-add-to-wish-list .btn.is-loading::before {
-  display: none;
-}
-
-.widget-add-to-wish-list .btn.is-loading .fa-circle-o-notch {
-  display: inline-block;
 }
 
 body.wishlist-is-loading .widget-add-to-wish-list .btn::before {

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3916,6 +3916,13 @@ button[data-testing="quantity-btn-decrease"] {
   display: none;
 }
 
+.widget-add-to-wish-list .btn.is-loading::after,
+.widget-add-to-wish-list .btn .loading-animation::before,
+.widget-add-to-wish-list .btn .loading-animation::after,
+.widget-add-to-wish-list .btn .plenty-loader {
+  display: none;
+}
+
 .widget-add-to-wish-list .btn.is-loading::before {
   display: none;
 }

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3916,6 +3916,10 @@ button[data-testing="quantity-btn-decrease"] {
   display: none;
 }
 
+.widget-add-to-wish-list .btn i::before {
+  display: none;
+}
+
 .widget-add-to-wish-list .btn.is-loading::after,
 .widget-add-to-wish-list .btn .loading-animation::before,
 .widget-add-to-wish-list .btn .loading-animation::after,

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3888,6 +3888,13 @@ button[data-testing="quantity-btn-decrease"] {
   display: none;
 }
 
+.widget-add-to-wish-list .btn.is-loading::after,
+.widget-add-to-wish-list .btn .loading-animation::before,
+.widget-add-to-wish-list .btn .loading-animation::after,
+.widget-add-to-wish-list .btn .plenty-loader {
+  display: none;
+}
+
 .widget-add-to-wish-list .btn.is-loading::before {
   display: none;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3879,32 +3879,8 @@ button[data-testing="quantity-btn-decrease"] {
   transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
 }
 
-.widget-add-to-wish-list .btn .loading-animation,
-.widget-add-to-wish-list .btn .loading,
-.widget-add-to-wish-list .btn .loader,
-.widget-add-to-wish-list .btn .spinner-border,
-.widget-add-to-wish-list .btn .fa-spinner,
-.widget-add-to-wish-list .btn .fa-circle-o-notch {
-  display: none;
-}
-
 .widget-add-to-wish-list .btn i::before {
   display: none;
-}
-
-.widget-add-to-wish-list .btn.is-loading::after,
-.widget-add-to-wish-list .btn .loading-animation::before,
-.widget-add-to-wish-list .btn .loading-animation::after,
-.widget-add-to-wish-list .btn .plenty-loader {
-  display: none;
-}
-
-.widget-add-to-wish-list .btn.is-loading::before {
-  display: none;
-}
-
-.widget-add-to-wish-list .btn.is-loading .fa-circle-o-notch {
-  display: inline-block;
 }
 
 body.wishlist-is-loading .widget-add-to-wish-list .btn::before {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3888,6 +3888,10 @@ button[data-testing="quantity-btn-decrease"] {
   display: none;
 }
 
+.widget-add-to-wish-list .btn i::before {
+  display: none;
+}
+
 .widget-add-to-wish-list .btn.is-loading::after,
 .widget-add-to-wish-list .btn .loading-animation::before,
 .widget-add-to-wish-list .btn .loading-animation::after,


### PR DESCRIPTION
### Motivation
- Disable the built-in Ceres loader visuals inside the wishlist button so the shops' own spinner/UX remains in control and framework pseudo-elements/wrappers don't interfere with the custom behavior.

### Description
- Added CSS overrides to `FH - Stylesheets.css` and `SH - Stylesheets.css` to hide Ceres loader elements by setting `display: none` for selectors such as `.widget-add-to-wish-list .btn.is-loading::after`, `.widget-add-to-wish-list .btn .loading-animation::before`, `.widget-add-to-wish-list .btn .loading-animation::after` and `.widget-add-to-wish-list .btn .plenty-loader`.

### Testing
- No automated tests were executed because this is a CSS-only change; changes were committed (`fix(css): disable wishlist loader`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fae1f8b608331ac5ffea4714f7dfe)