### PR TITLE
fix(css): hide LTS wishlist loader

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3916,6 +3916,17 @@ button[data-testing="quantity-btn-decrease"] {
   display: none;
 }
 
+.widget-add-to-wish-list .btn i::before {
+  display: none;
+}
+
+.widget-add-to-wish-list .btn.is-loading::after,
+.widget-add-to-wish-list .btn .loading-animation::before,
+.widget-add-to-wish-list .btn .loading-animation::after,
+.widget-add-to-wish-list .btn .plenty-loader {
+  display: none;
+}
+
 .widget-add-to-wish-list .btn.is-loading::before {
   display: none;
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3888,6 +3888,17 @@ button[data-testing="quantity-btn-decrease"] {
   display: none;
 }
 
+.widget-add-to-wish-list .btn i::before {
+  display: none;
+}
+
+.widget-add-to-wish-list .btn.is-loading::after,
+.widget-add-to-wish-list .btn .loading-animation::before,
+.widget-add-to-wish-list .btn .loading-animation::after,
+.widget-add-to-wish-list .btn .plenty-loader {
+  display: none;
+}
+
 .widget-add-to-wish-list .btn.is-loading::before {
   display: none;
 }


### PR DESCRIPTION
### Motivation
- Hide the plentyShop LTS native wishlist loader pseudo-elements and DOM loader nodes so they don't appear in addition to our custom spinner and cause duplicate loading indicators for both FH and SH.

### Description
- Add CSS rules to `FH - Stylesheets.css` and `SH - Stylesheets.css` that set `display: none` for the selectors `.widget-add-to-wish-list .btn i::before`, `.widget-add-to-wish-list .btn.is-loading::after`, `.widget-add-to-wish-list .btn .loading-animation::before`, `.widget-add-to-wish-list .btn .loading-animation::after`, and `.widget-add-to-wish-list .btn .plenty-loader`.

### Testing
- No automated tests were run because this is a CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698049eef4248331b3e5f317bf6debc4)