### PR TITLE
fix(wishlist): broaden active state detection

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3975,7 +3975,10 @@ body.wishlist-is-loading .widget-add-to-wish-list .btn i {
 .widget-add-to-wish-list .btn.is-active,
 .widget-add-to-wish-list .btn.active,
 .widget-add-to-wish-list .btn[aria-pressed="true"],
-.widget-add-to-wish-list .btn[data-original-title*="entfernen"] {
+.widget-add-to-wish-list .btn[data-original-title*="entfernen"],
+.widget-add-to-wish-list .btn[data-bs-original-title*="entfernen"],
+.widget-add-to-wish-list .btn[title*="entfernen"],
+.widget-add-to-wish-list .btn[aria-label*="entfernen"] {
   border-color: #9ca3af;
   background-color: #f1f5f9;
   color: #111827;
@@ -3984,7 +3987,10 @@ body.wishlist-is-loading .widget-add-to-wish-list .btn i {
 .widget-add-to-wish-list .btn.is-active::before,
 .widget-add-to-wish-list .btn.active::before,
 .widget-add-to-wish-list .btn[aria-pressed="true"]::before,
-.widget-add-to-wish-list .btn[data-original-title*="entfernen"]::before {
+.widget-add-to-wish-list .btn[data-original-title*="entfernen"]::before,
+.widget-add-to-wish-list .btn[data-bs-original-title*="entfernen"]::before,
+.widget-add-to-wish-list .btn[title*="entfernen"]::before,
+.widget-add-to-wish-list .btn[aria-label*="entfernen"]::before {
   -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
   mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
 }

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3850,7 +3850,7 @@ fhOnReady(function () {
 fhOnReady(function () {
   const reloadStorageKey = 'fhWishlistAutoOpen';
   const wishlistButtonSelector = '.widget-add-to-wish-list .btn';
-  const attributeFilter = ['class', 'aria-pressed', 'data-original-title'];
+  const attributeFilter = ['class', 'aria-pressed', 'data-original-title', 'data-bs-original-title', 'title', 'aria-label'];
 
   function getVueStore() {
     if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
@@ -3862,8 +3862,11 @@ fhOnReady(function () {
     if (!button) return false;
     if (button.classList.contains('is-active') || button.classList.contains('active')) return true;
     if (button.getAttribute('aria-pressed') === 'true') return true;
-    const title = button.getAttribute('data-original-title');
-    return title && title.toLowerCase().includes('entfernen');
+    const titleAttributes = ['data-original-title', 'data-bs-original-title', 'title', 'aria-label'];
+    return titleAttributes.some(function (attribute) {
+      const value = button.getAttribute(attribute);
+      return value && value.toLowerCase().includes('entfernen');
+    });
   }
 
   function setWishListLoadingState(button) {

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -3828,7 +3828,7 @@ shOnReady(function () {
 shOnReady(function () {
   const reloadStorageKey = 'shWishlistAutoOpen';
   const wishlistButtonSelector = '.widget-add-to-wish-list .btn';
-  const attributeFilter = ['class', 'aria-pressed', 'data-original-title'];
+  const attributeFilter = ['class', 'aria-pressed', 'data-original-title', 'data-bs-original-title', 'title', 'aria-label'];
 
   function getVueStore() {
     if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
@@ -3840,8 +3840,11 @@ shOnReady(function () {
     if (!button) return false;
     if (button.classList.contains('is-active') || button.classList.contains('active')) return true;
     if (button.getAttribute('aria-pressed') === 'true') return true;
-    const title = button.getAttribute('data-original-title');
-    return title && title.toLowerCase().includes('entfernen');
+    const titleAttributes = ['data-original-title', 'data-bs-original-title', 'title', 'aria-label'];
+    return titleAttributes.some(function (attribute) {
+      const value = button.getAttribute(attribute);
+      return value && value.toLowerCase().includes('entfernen');
+    });
   }
 
   function setWishListLoadingState(button) {

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3947,7 +3947,10 @@ body.wishlist-is-loading .widget-add-to-wish-list .btn i {
 .widget-add-to-wish-list .btn.is-active,
 .widget-add-to-wish-list .btn.active,
 .widget-add-to-wish-list .btn[aria-pressed="true"],
-.widget-add-to-wish-list .btn[data-original-title*="entfernen"] {
+.widget-add-to-wish-list .btn[data-original-title*="entfernen"],
+.widget-add-to-wish-list .btn[data-bs-original-title*="entfernen"],
+.widget-add-to-wish-list .btn[title*="entfernen"],
+.widget-add-to-wish-list .btn[aria-label*="entfernen"] {
   border-color: #9ca3af;
   background-color: #f1f5f9;
   color: #111827;
@@ -3956,7 +3959,10 @@ body.wishlist-is-loading .widget-add-to-wish-list .btn i {
 .widget-add-to-wish-list .btn.is-active::before,
 .widget-add-to-wish-list .btn.active::before,
 .widget-add-to-wish-list .btn[aria-pressed="true"]::before,
-.widget-add-to-wish-list .btn[data-original-title*="entfernen"]::before {
+.widget-add-to-wish-list .btn[data-original-title*="entfernen"]::before,
+.widget-add-to-wish-list .btn[data-bs-original-title*="entfernen"]::before,
+.widget-add-to-wish-list .btn[title*="entfernen"]::before,
+.widget-add-to-wish-list .btn[aria-label*="entfernen"]::before {
   -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
   mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
 }


### PR DESCRIPTION
### Motivation
- Ensure the wish-list button renders its "active" styling reliably regardless of which tooltip/label attribute Ceres or Bootstrap sets. 
- Make client-side detection consistent with the broadened CSS selectors so loading/reload behavior uses the same signals. 

### Description
- Update `FH - Stylesheets.css` and `SH - Stylesheets.css` to extend the active button selectors to include `data-bs-original-title`, `title`, and `aria-label` in addition to the existing `data-original-title` check. 
- Update `JavaScript im Head/FH - JS im Head.js` and `JavaScript im Head/SH - JS im Head.js` to add the new attributes to the `attributeFilter` and modify `isWishListActive(button)` to check `['data-original-title','data-bs-original-title','title','aria-label']` with `toLowerCase().includes('entfernen')` using `some()`. 
- Changes keep existing checks for classes (`is-active`, `active`) and `aria-pressed` and only broaden tooltip/label detection so styling and reload logic stay in sync. 

### Testing
- No automated tests were executed as part of this change. 
- Changes were committed and reflected in the repository (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698056622854833191b417e1322bc748)