### PR TITLE
fix(wishlist): remove active button styling

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3972,22 +3972,6 @@ body.wishlist-is-loading .widget-add-to-wish-list .btn i {
   text-decoration: none;
 }
 
-.widget-add-to-wish-list .btn.is-active,
-.widget-add-to-wish-list .btn.active,
-.widget-add-to-wish-list .btn[aria-pressed="true"],
-.widget-add-to-wish-list .btn[data-original-title*="entfernen"] {
-  border-color: #9ca3af;
-  background-color: #f1f5f9;
-  color: #111827;
-}
-
-.widget-add-to-wish-list .btn.is-active::before,
-.widget-add-to-wish-list .btn.active::before,
-.widget-add-to-wish-list .btn[aria-pressed="true"]::before,
-.widget-add-to-wish-list .btn[data-original-title*="entfernen"]::before {
-  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
-  mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
-}
 /* End Section: Wishlist button styling */
 
 /* Section: Temporary hidden blocks until external functions added */

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3850,20 +3850,11 @@ fhOnReady(function () {
 fhOnReady(function () {
   const reloadStorageKey = 'fhWishlistAutoOpen';
   const wishlistButtonSelector = '.widget-add-to-wish-list .btn';
-  const attributeFilter = ['class', 'aria-pressed', 'data-original-title'];
 
   function getVueStore() {
     if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
     if (window.ceresStore && typeof window.ceresStore.dispatch === 'function') return window.ceresStore;
     return null;
-  }
-
-  function isWishListActive(button) {
-    if (!button) return false;
-    if (button.classList.contains('is-active') || button.classList.contains('active')) return true;
-    if (button.getAttribute('aria-pressed') === 'true') return true;
-    const title = button.getAttribute('data-original-title');
-    return title && title.toLowerCase().includes('entfernen');
   }
 
   function setWishListLoadingState(button) {
@@ -3882,14 +3873,12 @@ fhOnReady(function () {
     setWishListLoadingState(button);
 
     const store = getVueStore();
-    const initialState = isWishListActive(button);
     const initialStoreIds = store && store.state && store.state.wishList && Array.isArray(store.state.wishList.wishListIds)
       ? store.state.wishList.wishListIds.join(',')
       : null;
     let didReload = false;
     let storeWatcherCleanup = null;
     let fallbackTimeout = null;
-    let observer = null;
 
     if (store && typeof store.watch === 'function') {
       storeWatcherCleanup = store.watch(
@@ -3911,28 +3900,9 @@ fhOnReady(function () {
       );
     }
 
-    observer = new MutationObserver(function () {
-      const nextState = isWishListActive(button);
-      if (nextState === initialState || didReload) return;
-
-      didReload = true;
-      observer.disconnect();
-      if (fallbackTimeout) {
-        window.clearTimeout(fallbackTimeout);
-        fallbackTimeout = null;
-      }
-      if (window.sessionStorage) {
-        window.sessionStorage.setItem(reloadStorageKey, '1');
-      }
-      window.location.reload();
-    });
-
-    observer.observe(button, { attributes: true, attributeFilter: attributeFilter });
-
     fallbackTimeout = window.setTimeout(function () {
       if (didReload) return;
       didReload = true;
-      observer.disconnect();
       if (typeof storeWatcherCleanup === 'function') {
         storeWatcherCleanup();
       }
@@ -3944,7 +3914,6 @@ fhOnReady(function () {
 
     window.setTimeout(function () {
       if (!didReload) {
-        observer.disconnect();
         if (typeof storeWatcherCleanup === 'function') {
           storeWatcherCleanup();
         }

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -3828,20 +3828,11 @@ shOnReady(function () {
 shOnReady(function () {
   const reloadStorageKey = 'shWishlistAutoOpen';
   const wishlistButtonSelector = '.widget-add-to-wish-list .btn';
-  const attributeFilter = ['class', 'aria-pressed', 'data-original-title'];
 
   function getVueStore() {
     if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
     if (window.ceresStore && typeof window.ceresStore.dispatch === 'function') return window.ceresStore;
     return null;
-  }
-
-  function isWishListActive(button) {
-    if (!button) return false;
-    if (button.classList.contains('is-active') || button.classList.contains('active')) return true;
-    if (button.getAttribute('aria-pressed') === 'true') return true;
-    const title = button.getAttribute('data-original-title');
-    return title && title.toLowerCase().includes('entfernen');
   }
 
   function setWishListLoadingState(button) {
@@ -3860,14 +3851,12 @@ shOnReady(function () {
     setWishListLoadingState(button);
 
     const store = getVueStore();
-    const initialState = isWishListActive(button);
     const initialStoreIds = store && store.state && store.state.wishList && Array.isArray(store.state.wishList.wishListIds)
       ? store.state.wishList.wishListIds.join(',')
       : null;
     let didReload = false;
     let storeWatcherCleanup = null;
     let fallbackTimeout = null;
-    let observer = null;
 
     if (store && typeof store.watch === 'function') {
       storeWatcherCleanup = store.watch(
@@ -3889,28 +3878,9 @@ shOnReady(function () {
       );
     }
 
-    observer = new MutationObserver(function () {
-      const nextState = isWishListActive(button);
-      if (nextState === initialState || didReload) return;
-
-      didReload = true;
-      observer.disconnect();
-      if (fallbackTimeout) {
-        window.clearTimeout(fallbackTimeout);
-        fallbackTimeout = null;
-      }
-      if (window.sessionStorage) {
-        window.sessionStorage.setItem(reloadStorageKey, '1');
-      }
-      window.location.reload();
-    });
-
-    observer.observe(button, { attributes: true, attributeFilter: attributeFilter });
-
     fallbackTimeout = window.setTimeout(function () {
       if (didReload) return;
       didReload = true;
-      observer.disconnect();
       if (typeof storeWatcherCleanup === 'function') {
         storeWatcherCleanup();
       }
@@ -3922,7 +3892,6 @@ shOnReady(function () {
 
     window.setTimeout(function () {
       if (!didReload) {
-        observer.disconnect();
         if (typeof storeWatcherCleanup === 'function') {
           storeWatcherCleanup();
         }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3944,22 +3944,6 @@ body.wishlist-is-loading .widget-add-to-wish-list .btn i {
   text-decoration: none;
 }
 
-.widget-add-to-wish-list .btn.is-active,
-.widget-add-to-wish-list .btn.active,
-.widget-add-to-wish-list .btn[aria-pressed="true"],
-.widget-add-to-wish-list .btn[data-original-title*="entfernen"] {
-  border-color: #9ca3af;
-  background-color: #f1f5f9;
-  color: #111827;
-}
-
-.widget-add-to-wish-list .btn.is-active::before,
-.widget-add-to-wish-list .btn.active::before,
-.widget-add-to-wish-list .btn[aria-pressed="true"]::before,
-.widget-add-to-wish-list .btn[data-original-title*="entfernen"]::before {
-  -webkit-mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
-  mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2024%2024'%3E%3Cpath%20fill='black'%20d='M7%204h10a1%201%200%200%201%201%201v15l-6-3-6%203V5a1%201%200%200%201%201-1z'/%3E%3C/svg%3E") no-repeat center / contain;
-}
 /* End Section: Wishlist button styling */
 
 /* Section: Temporary hidden blocks until external functions added */


### PR DESCRIPTION
### Motivation
- Remove all visual active-state styling and the client-side attribute monitoring for wishlist buttons because the previous broadened detection caused unreliable behavior and the user requested a full removal of active-state styling.
- Ensure both FH and SH shops behave identically by removing duplicated styling/logic that toggled the button appearance on wishlist add/remove.

### Description
- Deleted active-state CSS blocks from `FH - Stylesheets.css` and `SH - Stylesheets.css` so wishlist buttons no longer receive special styling when considered "active". 
- Removed attribute-based active-state detection and MutationObserver-based monitoring from `JavaScript im Head/FH - JS im Head.js` and `JavaScript im Head/SH - JS im Head.js`, simplifying the reload flow to rely on store changes and a fallback timeout only.
- Kept loading indicator behaviour intact (the `is-loading` class and `wishlist-is-loading` body class) while removing all code and selectors that switched the visual active state.

### Testing
- No automated tests were executed for this change (no test runs requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698056622854833191b417e1322bc748)