### PR TITLE
fix(header): sync wishlist and account dropdowns

### DIFF
--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -81,6 +81,10 @@ fhOnReady(function () {
   function openMenu() {
     if (isOpen) return;
 
+    if (window.fhWishlistMenu && typeof window.fhWishlistMenu.close === 'function') {
+      window.fhWishlistMenu.close();
+    }
+
     menu.style.display = 'block';
     menu.setAttribute('aria-hidden', 'false');
     toggleButton.setAttribute('aria-expanded', 'true');
@@ -2379,6 +2383,9 @@ fhOnReady(function () {
       if (window.fhAccountMenu && typeof window.fhAccountMenu.close === 'function') {
         window.fhAccountMenu.close();
       }
+      if (window.fhWishlistMenu && typeof window.fhWishlistMenu.close === 'function') {
+        window.fhWishlistMenu.close();
+      }
     }
 
     const elements = document.querySelectorAll(focusableSelector);
@@ -3721,6 +3728,10 @@ fhOnReady(function () {
   function openMenu() {
     if (isOpen) return;
 
+    if (window.fhAccountMenu && typeof window.fhAccountMenu.close === 'function') {
+      window.fhAccountMenu.close();
+    }
+
     menu.style.display = 'block';
     menu.setAttribute('aria-hidden', 'false');
     toggleButton.setAttribute('aria-expanded', 'true');
@@ -3844,6 +3855,12 @@ fhOnReady(function () {
     window.sessionStorage.removeItem(reloadStorageKey);
     openMenu();
   }
+
+  window.fhWishlistMenu = window.fhWishlistMenu || {};
+  window.fhWishlistMenu.close = closeMenu;
+  window.fhWishlistMenu.isOpen = function () {
+    return isOpen;
+  };
 });
 
 // Section: FH add-to-wishlist reload after toggle

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -81,6 +81,10 @@ shOnReady(function () {
   function openMenu() {
     if (isOpen) return;
 
+    if (window.shWishlistMenu && typeof window.shWishlistMenu.close === 'function') {
+      window.shWishlistMenu.close();
+    }
+
     menu.style.display = 'block';
     menu.setAttribute('aria-hidden', 'false');
     toggleButton.setAttribute('aria-expanded', 'true');
@@ -2356,6 +2360,9 @@ shOnReady(function () {
       if (window.shAccountMenu && typeof window.shAccountMenu.close === 'function') {
         window.shAccountMenu.close();
       }
+      if (window.shWishlistMenu && typeof window.shWishlistMenu.close === 'function') {
+        window.shWishlistMenu.close();
+      }
     }
 
     const elements = document.querySelectorAll(focusableSelector);
@@ -3699,6 +3706,10 @@ shOnReady(function () {
   function openMenu() {
     if (isOpen) return;
 
+    if (window.shAccountMenu && typeof window.shAccountMenu.close === 'function') {
+      window.shAccountMenu.close();
+    }
+
     menu.style.display = 'block';
     menu.setAttribute('aria-hidden', 'false');
     toggleButton.setAttribute('aria-expanded', 'true');
@@ -3822,6 +3833,12 @@ shOnReady(function () {
     window.sessionStorage.removeItem(reloadStorageKey);
     openMenu();
   }
+
+  window.shWishlistMenu = window.shWishlistMenu || {};
+  window.shWishlistMenu.close = closeMenu;
+  window.shWishlistMenu.isOpen = function () {
+    return isOpen;
+  };
 });
 
 // Section: SH add-to-wishlist reload after toggle


### PR DESCRIPTION
### Motivation
- Die Konto-Dropdown-Logik schließt bereits die Warenkorb-Preview, die Merkliste verhält sich jedoch anders, was zu überlappenden Panels führen kann.
- Ziel ist, dass die Merkliste dieselben Regeln bekommt und immer nur ein Dropdown (Konto oder Merkliste) gleichzeitig sichtbar ist.

### Description
- Ergänzt in `JavaScript im Head/FH - JS im Head.js` und `JavaScript im Head/SH - JS im Head.js` Aufrufe, damit beim Öffnen des Konto-Dropdowns die Merkliste geschlossen wird und umgekehrt (`openMenu` in beiden Menüs schließt das jeweils andere Menü). 
- Beim Öffnen/Schließen der Warenkorb-Preview (`updateFocusState`) wird jetzt ebenfalls die Merkliste geschlossen, damit keine Panels hinter der Preview sichtbar bleiben.
- Exponiert einfache Helfer on `window.fhWishlistMenu` / `window.shWishlistMenu` mit `close()` und `isOpen()` zur Koordination der Dropdown-Zustände zwischen Komponenten.

### Testing
- Es wurden keine automatisierten Tests in dieser Änderung ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69806fe5ab54833189eccbf892e5b6aa)