### PR TITLE
fix(header): widen wishlist panel on mobile

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3388,6 +3388,11 @@ body.fh-mobile-menu-open {
     max-width: 252px;
   }
 
+  .fh-header__panel--wishlist {
+    width: calc(100vw - 40px);
+    max-width: none;
+  }
+
   .fh-header__panel-arrow {
     left: 59%;
     right: auto;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3360,6 +3360,11 @@ body.sh-mobile-menu-open {
     max-width: 252px;
   }
 
+  .sh-header__panel--wishlist {
+    width: calc(100vw - 40px);
+    max-width: none;
+  }
+
   .sh-header__panel-arrow {
     left: 59%;
     right: auto;


### PR DESCRIPTION
### Motivation

- Ensure the "Merkliste" (wishlist) dropdown on mobile spans the available viewport width while keeping the current left/right padding and keep the panel arrow positioned at `left: 59%` for proper alignment.

### Description

- Add mobile-specific rules for the wishlist panel in `FH - Stylesheets.css` and `SH - Stylesheets.css` by creating `.<fh/sh>-header__panel--wishlist` with `width: calc(100vw - 40px)` and `max-width: none` inside the `@media (max-width: 767.98px)` block. 
- Keep the existing panel arrow positioning at `left: 59%` and `transform: translateX(calc(-50% + 8px)) rotate(45deg)` to preserve visual alignment.
- Changes were applied to both storefront variants to keep FH and SH synchronized (`FH - Stylesheets.css` and `SH - Stylesheets.css`).

### Testing

- No automated tests were run because this is a style-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69807d6142488331a4b0ac14d512c8e2)