### PR TITLE
style(css): adjust mobile panel arrow position

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3389,7 +3389,7 @@ body.fh-mobile-menu-open {
   }
 
   .fh-header__panel-arrow {
-    left: 59%;
+    left: 57%;
     right: auto;
     transform: translateX(calc(-50% + 8px)) rotate(45deg);
   }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3361,7 +3361,7 @@ body.sh-mobile-menu-open {
   }
 
   .sh-header__panel-arrow {
-    left: 59%;
+    left: 57%;
     right: auto;
     transform: translateX(calc(-50% + 8px)) rotate(45deg);
   }


### PR DESCRIPTION
### Motivation
- Fix slight misalignment of the mobile header panel arrow on small viewports for both FH and SH stores.

### Description
- Change `left` from `59%` to `57%` for the `.fh-header__panel-arrow` and `.sh-header__panel-arrow` rules inside the `@media (max-width: 767.98px)` blocks in `FH - Stylesheets.css` and `SH - Stylesheets.css`.

### Testing
- No automated tests were run for this styling tweak.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69807ef4f180833194864a7729675fd7)