### PR TITLE
style(header): reduce responsive padding for FH/SH at 768–1599.98px

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3098,7 +3098,7 @@ div.grecaptcha-badge {
     position: relative;
     width: 100vw;
     max-width: 100vw;
-    padding: 0 30px;
+    padding: 0 20px;
     box-sizing: border-box;
   }
 
@@ -3177,7 +3177,7 @@ div.grecaptcha-badge {
     width: 100vw;
     margin-left: calc(50% - 50vw);
     margin-right: calc(50% - 50vw);
-    padding: 0 30px;
+    padding: 0 15px;
     max-width: none;
   }
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3070,7 +3070,7 @@ div.grecaptcha-badge {
     position: relative;
     width: 100vw;
     max-width: 100vw;
-    padding: 0 30px;
+    padding: 0 20px;
     box-sizing: border-box;
   }
 
@@ -3149,7 +3149,7 @@ div.grecaptcha-badge {
     width: 100vw;
     margin-left: calc(50% - 50vw);
     margin-right: calc(50% - 50vw);
-    padding: 0 30px;
+    padding: 0 15px;
     max-width: none;
   }
 


### PR DESCRIPTION
### Motivation
- Reduce excessive horizontal padding inside the header/nav on medium-to-large screens to better align content with the layout grid and improve available space for navigation items.

### Description
- Update `FH - Stylesheets.css` to set `.fh-header` padding to `0 20px` and `.fh-header__nav-inner` padding to `0 15px` inside the `@media (max-width: 1599.98px) and (min-width: 768px)` breakpoint.
- Mirror the same changes in `SH - Stylesheets.css` by setting `.sh-header` padding to `0 20px` and `.sh-header__nav-inner` padding to `0 15px` inside the same breakpoint.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698085a1807c8331b64e9db01af00cf3)