### PR TITLE
fix(i18n): use Merkliste for empty wishlist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ Die folgende Übersicht fasst alle relevanten Versionen der offiziellen plentySh
 * Ersetze CDN-Hostnamen automatisch: sobald Du `//cdn02.plentymarkets.com/nteqnk1xxnkn` in FH-Dateien siehst oder von mir bekommst, wandelst Du ihn in `//bilder.fenster-hammer.de` um; in SH-Dateien in `//bilder.schrauben-hammer.de`. Behalte dabei Protokoll und Pfad bei, damit die Links first-party gehostet bleiben.
 * Halte README und begleitende Dokumentation aktuell, wenn Du neue Features oder Abhängigkeiten ergänzt.
 * Verwende für die direkte Anrede konsequent die Du-Form und schreibe Du/Dir/Dich/Dein usw. immer mit großem Anfangsbuchstaben – unabhängig von der Position im Satz.
+* Behandle die Begriffe Wunschliste, Merkliste und wishlist als synonym. PlentyLTS nutzt intern „Wish-list“, doch in der Kundenkommunikation verwenden wir ausschließlich „Merkliste“.
 
 ## Commit Message Convention (Conventional Commits)
 

--- a/Mehrsprachigkeit-Export-FH.csv
+++ b/Mehrsprachigkeit-Export-FH.csv
@@ -1204,7 +1204,7 @@ wishListInactiveItemId,"Varianten ID",Ceres,Template.properties
 wishListInactiveItems,"Derzeit nicht verfügbar",Ceres,Template.properties
 wishListItemId,Art.-ID,Ceres,Template.properties
 wishListItemNumber,Artikelnummer,Ceres,Template.properties
-wishListNoItems,"Du hast noch keine Artikel in der Wunschliste.",Ceres,Template.properties
+wishListNoItems,"Du hast noch keine Artikel in der Merkliste.",Ceres,Template.properties
 wishListRemoved,"Der Artikel wurde von der Wunschliste entfernt.",Ceres,Template.properties
 cookieDescription,"YouTube Cookies. Die Cookies werden benötigt, um die integrierte YouTube Videos abspielen zu können.",ItemVideoPlugin,Template.properties
 cookieLifespan,"Verschiedene (bis max 2 Jahre)",ItemVideoPlugin,Template.properties

--- a/Mehrsprachigkeit-Export-SH.csv
+++ b/Mehrsprachigkeit-Export-SH.csv
@@ -1129,7 +1129,7 @@ wishListInactiveItemId,"Varianten ID",Ceres,Template.properties
 wishListInactiveItems,"Derzeit nicht verfügbar",Ceres,Template.properties
 wishListItemId,Art.-ID,Ceres,Template.properties
 wishListItemNumber,Artikelnummer,Ceres,Template.properties
-wishListNoItems,"Du hast noch keine Artikel in der Wunschliste.",Ceres,Template.properties
+wishListNoItems,"Du hast noch keine Artikel in der Merkliste.",Ceres,Template.properties
 wishListRemoved,"Der Artikel wurde von der Wunschliste entfernt.",Ceres,Template.properties
 cookieDescription,"YouTube Cookies. Die Cookies werden benötigt, um die integrierte YouTube Videos abspielen zu können.",ItemVideoPlugin,Template.properties
 cookieLifespan,"Verschiedene (bis max 2 Jahre)",ItemVideoPlugin,Template.properties


### PR DESCRIPTION
### Motivation
- Ensure the frontend shows “Merkliste” to customers for empty wishlist messaging and establish that `Wunschliste`, `Merkliste` and `wishlist` are treated as synonyms while PlentyLTS may use internal terms like “Wish-list”.

### Description
- Update the empty wishlist text in `Mehrsprachigkeit-Export-FH.csv` and `Mehrsprachigkeit-Export-SH.csv` to `"Du hast noch keine Artikel in der Merkliste."` and add a terminology rule to `AGENTS.md` clarifying that `Wunschliste`, `Merkliste` and `wishlist` are synonymous and that customer-facing text should use `Merkliste`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698092c84e04833180cba294f9cb7dbd)