### PR TITLE
style(css): remove typekit import

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -6,7 +6,6 @@
 
 /* Section: Custom Schriftarten + Preis Text Stylings */
 
-@import url("https://use.typekit.net/lwl7tyw.css");
 
 :root {
   --fh-color-bright-blue: #31a5f0; /* Standard bright blue */

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -6,7 +6,6 @@
 
 /* Section: Custom Schriftarten + Preis Text Stylings */
 
-@import url("https://use.typekit.net/lwl7tyw.css");
 
 :root {
   --sh-color-primary-red: #f20000;      /* Main brand red (header bar, accents) */


### PR DESCRIPTION
### Motivation
- Remove the external Typekit font import to avoid relying on the third-party CDN and allow using first‑party or locally hosted fonts.

### Description
- Delete the line `@import url("https://use.typekit.net/lwl7tyw.css");` from `FH - Stylesheets.css` and `SH - Stylesheets.css`.

### Testing
- No automated tests were run for this trivial stylesheet change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819e106fbc83319755d0f2d1753e80)