### PR TITLE
feat(slider): add banner navigation bar

### DIFF
--- a/Custom Components/FH-Custom-Slider.html
+++ b/Custom Components/FH-Custom-Slider.html
@@ -50,25 +50,6 @@
       </div>
     </div>
 
-    <nav class="fh-custom-slider__nav" aria-label="Banner Navigation">
-      <button
-        type="button"
-        class="fh-custom-slider__nav-item is-active"
-        data-target="#fh-custom-slider"
-        data-slide-to="0"
-      >
-        FEIN AMPShare Akku Aktion
-      </button>
-      <button
-        type="button"
-        class="fh-custom-slider__nav-item"
-        data-target="#fh-custom-slider"
-        data-slide-to="1"
-      >
-        Kraftwerk Werkstattwagen
-      </button>
-    </nav>
-
     <ol class="carousel-indicators">
       <li data-target="#fh-custom-slider" data-slide-to="0" class="active"></li>
       <li data-target="#fh-custom-slider" data-slide-to="1"></li>
@@ -92,4 +73,23 @@
       <span aria-hidden="true" class="fa fa-chevron-right"></span>
     </a>
   </div>
+
+  <nav class="fh-custom-slider__nav" aria-label="Banner Navigation">
+    <button
+      type="button"
+      class="fh-custom-slider__nav-item is-active"
+      data-target="#fh-custom-slider"
+      data-slide-to="0"
+    >
+      FEIN AMPShare Akku Aktion
+    </button>
+    <button
+      type="button"
+      class="fh-custom-slider__nav-item"
+      data-target="#fh-custom-slider"
+      data-slide-to="1"
+    >
+      Kraftwerk Werkstattwagen
+    </button>
+  </nav>
 </div>

--- a/Custom Components/FH-Custom-Slider.html
+++ b/Custom Components/FH-Custom-Slider.html
@@ -50,6 +50,25 @@
       </div>
     </div>
 
+    <nav class="fh-custom-slider__nav" aria-label="Banner Navigation">
+      <button
+        type="button"
+        class="fh-custom-slider__nav-item is-active"
+        data-target="#fh-custom-slider"
+        data-slide-to="0"
+      >
+        FEIN AMPShare Akku Aktion
+      </button>
+      <button
+        type="button"
+        class="fh-custom-slider__nav-item"
+        data-target="#fh-custom-slider"
+        data-slide-to="1"
+      >
+        Kraftwerk Werkstattwagen
+      </button>
+    </nav>
+
     <ol class="carousel-indicators">
       <li data-target="#fh-custom-slider" data-slide-to="0" class="active"></li>
       <li data-target="#fh-custom-slider" data-slide-to="1"></li>

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -4139,6 +4139,51 @@ body:has(.invoice-addresses-select .dropdown.items > div:first-child.disabled) .
   line-height: 1.6;
 }
 
+.fh-custom-slider .carousel-indicators {
+  display: none;
+}
+
+.fh-custom-slider__nav {
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+  padding: 12px clamp(16px, 4vw, 48px);
+  background: #1b1b1b;
+  color: #fff;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.fh-custom-slider__nav-item {
+  flex: 1 1 0;
+  min-width: 160px;
+  padding: 10px 16px;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  text-align: center;
+  cursor: pointer;
+  transition: background-color 200ms ease, color 200ms ease;
+}
+
+.fh-custom-slider__nav-item:hover,
+.fh-custom-slider__nav-item:focus {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  outline: none;
+}
+
+.fh-custom-slider__nav-item.is-active {
+  background: #ffffff;
+  color: #1b1b1b;
+}
+
 @media (max-width: 991.98px) {
   .fh-custom-slider__overlay {
     width: 45%;
@@ -4149,6 +4194,16 @@ body:has(.invoice-addresses-select .dropdown.items > div:first-child.disabled) .
   .fh-custom-slider__overlay {
     width: 60%;
     min-width: 0;
+  }
+
+  .fh-custom-slider__nav {
+    gap: 8px;
+    padding: 10px 16px;
+  }
+
+  .fh-custom-slider__nav-item {
+    min-width: 140px;
+    font-size: 0.78rem;
   }
 }
 /* End Section: FH Custom Slider */

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3958,7 +3958,23 @@ fhOnReady(function () {
       return;
     }
 
+    var navItems = slider.querySelectorAll('.fh-custom-slider__nav-item');
     var activeOverlay = null;
+    var setActiveNav = function (index) {
+      if (!navItems.length) {
+        return;
+      }
+      navItems.forEach(function (item) {
+        var itemIndex = Number(item.getAttribute('data-slide-to'));
+        var isMatch = Number.isNaN(itemIndex) ? false : itemIndex === index;
+        item.classList.toggle('is-active', isMatch);
+        if (isMatch) {
+          item.setAttribute('aria-current', 'true');
+        } else {
+          item.removeAttribute('aria-current');
+        }
+      });
+    };
     var activateOverlay = function (index) {
       var nextOverlay = null;
       var fallbackOverlay = overlayTexts[index] || null;
@@ -4004,7 +4020,9 @@ fhOnReady(function () {
       }
       return 0;
     };
-    activateOverlay(getActiveIndex());
+    var initialIndex = getActiveIndex();
+    activateOverlay(initialIndex);
+    setActiveNav(initialIndex);
 
     slider.addEventListener('slide.bs.carousel', function () {
       beginOverlayExit();
@@ -4013,6 +4031,7 @@ fhOnReady(function () {
       var nextIndex = typeof event.to === 'number' ? event.to : getActiveIndex();
       finishOverlayExit();
       activateOverlay(nextIndex);
+      setActiveNav(nextIndex);
     });
 
     if (window.MutationObserver) {

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3958,7 +3958,10 @@ fhOnReady(function () {
       return;
     }
 
-    var navItems = slider.querySelectorAll('.fh-custom-slider__nav-item');
+    var sliderWrapper = slider.closest('.fh-custom-slider');
+    var navItems = sliderWrapper
+      ? sliderWrapper.querySelectorAll('.fh-custom-slider__nav-item')
+      : [];
     var activeOverlay = null;
     var setActiveNav = function (index) {
       if (!navItems.length) {


### PR DESCRIPTION
### Motivation

- Add a non-transparent, clickable navigation bar beneath the FH banner so Besucher can see and jump to slides at a glance without using the existing arrow controls, shown flush under the banner (no margin).

### Description

- Add a navigation element under the FH slider in `Custom Components/FH-Custom-Slider.html` with per-slide `<button>` items that target the carousel via `data-slide-to`.
- Add styles in `FH - Stylesheets.css` to hide the default `.carousel-indicators`, render the new `.fh-custom-slider__nav` bar (non-transparent background `#1b1b1b`) and style `.fh-custom-slider__nav-item` including responsive adjustments.
- Extend the FH slider script in `JavaScript im Head/FH - JS im Head.js` to query `.fh-custom-slider__nav-item`, provide `setActiveNav(index)` that toggles `.is-active` and `aria-current`, initialize the nav state and update it on `slide.bs.carousel` / `slid.bs.carousel` events.
- Keep existing overlay logic intact and ensure nav and overlay stay in sync with the active slide.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69820e27ef5c833182f9c99f16073d52)