### PR TITLE
fix(slider): sync nav in MutationObserver fallback

### DIFF
--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -4038,7 +4038,9 @@ fhOnReady(function () {
       var carouselInner = slider.querySelector('.carousel-inner');
       if (carouselInner) {
         var observer = new MutationObserver(function () {
-          activateOverlay(getActiveIndex());
+          var activeIndex = getActiveIndex();
+          activateOverlay(activeIndex);
+          setActiveNav(activeIndex);
         });
         observer.observe(carouselInner, {
           attributes: true,


### PR DESCRIPTION
### Motivation

- Keep the FH slider navigation bar in sync with overlay updates when slide changes are detected by the `MutationObserver` instead of Bootstrap carousel events.

### Description

- Update the MutationObserver callback in `JavaScript im Head/FH - JS im Head.js` to compute `activeIndex` and call both `activateOverlay(activeIndex)` and `setActiveNav(activeIndex)` so the nav buttons receive updated `.is-active`/`aria-current` state.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833c0a200c833195f6d6371266b4c5)