### PR TITLE
fix(slider): remove mobile bottom gap and sync custom nav

### DIFF
--- a/Custom Components/FH-Custom-Slider.html
+++ b/Custom Components/FH-Custom-Slider.html
@@ -78,7 +78,6 @@
       aria-label="Zurück"
       class="left carousel-control carousel-control-prev"
     >
-      <span aria-hidden="true" class="fa fa-chevron-left"></span>
     </a>
     <a
       href="#fh-custom-slider"
@@ -87,7 +86,6 @@
       aria-label="Nächste"
       class="right carousel-control carousel-control-next"
     >
-      <span aria-hidden="true" class="fa fa-chevron-right"></span>
     </a>
   </div>
 </div>

--- a/Custom Components/FH-Custom-Slider.html
+++ b/Custom Components/FH-Custom-Slider.html
@@ -4,7 +4,7 @@
       <div class="fh-custom-slider__overlay-content">
         <div class="fh-custom-slider__overlay-text is-active" data-slide-index="0">
           <p class="fh-custom-slider__eyebrow">Lorem ipsum</p>
-          <h2 class="fh-custom-slider__title">Slide A</h2>
+          <h2 class="fh-custom-slider__title">Hammer Bonus</h2>
           <p class="fh-custom-slider__text">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -12,7 +12,15 @@
         </div>
         <div class="fh-custom-slider__overlay-text" data-slide-index="1">
           <p class="fh-custom-slider__eyebrow">Lorem ipsum</p>
-          <h2 class="fh-custom-slider__title">Slide B2</h2>
+          <h2 class="fh-custom-slider__title">Abholbox</h2>
+          <p class="fh-custom-slider__text">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          </p>
+        </div>
+        <div class="fh-custom-slider__overlay-text" data-slide-index="2">
+          <p class="fh-custom-slider__eyebrow">Lorem ipsum</p>
+          <h2 class="fh-custom-slider__title">Newsletter</h2>
           <p class="fh-custom-slider__text">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -23,7 +31,7 @@
 
     <div class="carousel-inner">
       <div class="carousel-item active">
-        <a href="#" class="fh-custom-slider__link" aria-label="Slide A">
+        <a href="#" class="fh-custom-slider__link" aria-label="Hammer Bonus">
           <picture data-picture-class="img-cover" data-alt="" data-loaded="true">
             <source
               srcset="https://media.contorion.de/content/home_banners/DE/Fein/02_2026/2601_2350_WKZ-1010-FEIN-mp-header-slider-d-1680x560.jpg"
@@ -36,7 +44,7 @@
         </a>
       </div>
       <div class="carousel-item">
-        <a href="#" class="fh-custom-slider__link" aria-label="Slide B2">
+        <a href="#" class="fh-custom-slider__link" aria-label="Abholbox">
           <picture data-picture-class="img-cover" data-alt="" data-loaded="true">
             <source
               srcset="https://media.contorion.de/content/home_banners/DE/Kraftwerk/2510_2207_WKZ-974-Kraftwerk-mp-header-slider-d-1680x560.jpg"
@@ -48,12 +56,21 @@
           </picture>
         </a>
       </div>
+      <div class="carousel-item">
+        <a href="#" class="fh-custom-slider__link" aria-label="Newsletter">
+          <picture data-picture-class="img-cover" data-alt="" data-loaded="true">
+            <source
+              srcset="https://media.contorion.de/content/home_banners/DE/Fein/02_2026/2601_2350_WKZ-1010-FEIN-mp-header-slider-d-1680x560.jpg"
+              type="image/jpeg" />
+            <img
+              alt=""
+              class="mw-100 h-100 img-cover fh-custom-slider__image"
+              src="https://media.contorion.de/content/home_banners/DE/Fein/02_2026/2601_2350_WKZ-1010-FEIN-mp-header-slider-d-1680x560.jpg" />
+          </picture>
+        </a>
+      </div>
     </div>
 
-    <ol class="carousel-indicators">
-      <li data-target="#fh-custom-slider" data-slide-to="0" class="active"></li>
-      <li data-target="#fh-custom-slider" data-slide-to="1"></li>
-    </ol>
     <a
       href="#fh-custom-slider"
       role="button"
@@ -74,3 +91,38 @@
     </a>
   </div>
 </div>
+<nav class="fh-custom-slider__nav" data-target="#fh-custom-slider" aria-label="Schnellnavigation">
+  <a
+    href="#fh-custom-slider"
+    class="fh-custom-slider__nav-link is-active"
+    data-target="#fh-custom-slider"
+    data-slide-to="0"
+    data-slide-index="0"
+    role="button"
+    aria-label="Zu Hammer Bonus wechseln"
+  >
+    Hammer Bonus
+  </a>
+  <a
+    href="#fh-custom-slider"
+    class="fh-custom-slider__nav-link"
+    data-target="#fh-custom-slider"
+    data-slide-to="1"
+    data-slide-index="1"
+    role="button"
+    aria-label="Zu Abholbox wechseln"
+  >
+    Abholbox
+  </a>
+  <a
+    href="#fh-custom-slider"
+    class="fh-custom-slider__nav-link"
+    data-target="#fh-custom-slider"
+    data-slide-to="2"
+    data-slide-index="2"
+    role="button"
+    aria-label="Zu Newsletter wechseln"
+  >
+    Newsletter
+  </a>
+</nav>

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -4138,6 +4138,43 @@ body:has(.invoice-addresses-select .dropdown.items > div:first-child.disabled) .
   line-height: 1.6;
 }
 
+.fh-custom-slider__nav {
+  margin: -1px 0 0;
+  padding: 0;
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  display: flex;
+  flex-wrap: wrap;
+  background: rgba(0, 0, 0, 0.9);
+}
+
+.fh-custom-slider__nav-link {
+  flex: 1 1 0;
+  min-width: 140px;
+  padding: 12px 16px;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.8rem;
+  color: #fff;
+  opacity: 0.7;
+  text-decoration: none;
+  transition: opacity 200ms ease, background-color 200ms ease;
+}
+
+.fh-custom-slider__nav-link:hover,
+.fh-custom-slider__nav-link:focus {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.fh-custom-slider__nav-link.is-active {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.2);
+  font-weight: 600;
+}
+
 @media (max-width: 991.98px) {
   .fh-custom-slider__overlay {
     width: 45%;
@@ -4148,6 +4185,12 @@ body:has(.invoice-addresses-select .dropdown.items > div:first-child.disabled) .
   .fh-custom-slider__overlay {
     width: 60%;
     min-width: 0;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .widget.widget-image-carousel.fh-custom-slider {
+    margin-bottom: 0 !important;
   }
 }
 /* End Section: FH Custom Slider */

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3958,6 +3958,22 @@ fhOnReady(function () {
       return;
     }
 
+    var navContainer = document.querySelector(
+      '.fh-custom-slider__nav[data-target="#' + slider.id + '"]',
+    );
+    var navLinks = navContainer ? navContainer.querySelectorAll('.fh-custom-slider__nav-link') : [];
+
+    var setActiveNav = function (index) {
+      if (!navLinks.length) {
+        return;
+      }
+      navLinks.forEach(function (link) {
+        var dataIndex = Number(link.getAttribute('data-slide-index'));
+        var isMatch = Number.isNaN(dataIndex) ? false : dataIndex === index;
+        link.classList.toggle('is-active', isMatch);
+      });
+    };
+
     var activeOverlay = null;
     var activateOverlay = function (index) {
       var nextOverlay = null;
@@ -3981,6 +3997,8 @@ fhOnReady(function () {
         nextOverlay.classList.add('is-active');
         activeOverlay = nextOverlay;
       }
+
+      setActiveNav(index);
     };
 
     var beginOverlayExit = function () {


### PR DESCRIPTION
### Motivation
- remove the persistent gap beneath the FH slider on small/mobile viewports by targeting the slider container rather than the nav.
- improve UX by adding a compact quick-nav and ensuring its active state follows the current slide/overlay.

### Description
- update `FH - Stylesheets.css` to add a mobile rule `@media (max-width: 575.98px)` that targets the slider container selector `.widget.widget-image-carousel.fh-custom-slider` and forces `margin-bottom: 0 !important`.
- add a quick navigation block to `Custom Components/FH-Custom-Slider.html` with three nav links and extend the slider markup with a third slide and updated labels.
- add styles for `.fh-custom-slider__nav` and `.fh-custom-slider__nav-link` to layout the nav and style active/hover states.
- enhance `JavaScript im Head/FH - JS im Head.js` to locate the nav by `data-target`, compute `setActiveNav(index)` to toggle `.is-active` on nav links, and call it from `activateOverlay` so the nav reflects the current slide.

### Testing
- no automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69835158906c83318bd26629cd8a36fb)