### PR TITLE
style(fh-header): adjust tablet container spacing

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3105,8 +3105,12 @@ div.grecaptcha-badge {
     position: relative;
     width: 100vw;
     max-width: 100vw;
-    padding: 0 30px;
+    padding: 0 20px;
     box-sizing: border-box;
+  }
+
+  #page-header .row .position-relative {
+    margin: 0;
   }
 
   .fh-header .container,
@@ -3184,7 +3188,7 @@ div.grecaptcha-badge {
     width: 100vw;
     margin-left: calc(50% - 50vw);
     margin-right: calc(50% - 50vw);
-    padding: 0 30px;
+    padding: 0 20px;
     max-width: none;
   }
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3109,8 +3109,12 @@ div.grecaptcha-badge {
     position: relative;
     width: 100vw;
     max-width: 100vw;
-    padding: 0 30px;
+    padding: 0 20px;
     box-sizing: border-box;
+  }
+
+  #page-header .row .position-relative {
+    margin: 0;
   }
 
   .sh-header .container,
@@ -3188,7 +3192,7 @@ div.grecaptcha-badge {
     width: 100vw;
     margin-left: calc(50% - 50vw);
     margin-right: calc(50% - 50vw);
-    padding: 0 30px;
+    padding: 0 20px;
     max-width: none;
   }
 


### PR DESCRIPTION
### Motivation
- Reduce side padding and remove unexpected offsets in the FH header layout for the tablet viewport range (`768px` to `1599.98px`) to improve alignment with the page container.

### Description
- Update `FH - Stylesheets.css` inside `@media (max-width: 1599.98px) and (min-width: 768px)` to set `.fh-header` padding to `0 20px`, set `.fh-header__nav-inner` padding to `0 20px`, and add `#page-header .row .position-relative { margin: 0; }`.

### Testing
- No automated test suite was run for this CSS-only change, and the updated rules were verified present in `FH - Stylesheets.css` via file inspection (`rg`/line check) and then committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698445f1f94c8331bcf5bca0d6aaae50)