### PR TITLE
fix(header): update page-header position-relative selector

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3105,8 +3105,12 @@ div.grecaptcha-badge {
     position: relative;
     width: 100vw;
     max-width: 100vw;
-    padding: 0 30px;
+    padding: 0 20px;
     box-sizing: border-box;
+  }
+
+  #page-header .row .position-relative {
+    margin: 0;
   }
 
   .fh-header .container,
@@ -3184,7 +3188,7 @@ div.grecaptcha-badge {
     width: 100vw;
     margin-left: calc(50% - 50vw);
     margin-right: calc(50% - 50vw);
-    padding: 0 30px;
+    padding: 0 20px;
     max-width: none;
   }
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3109,7 +3109,7 @@ div.grecaptcha-badge {
     box-sizing: border-box;
   }
 
-  #page-header .container-max .row .flex-row-reverse .position-relative {
+  #page-header .container-max .row.flex-row-reverse.position-relative {
     margin: 0;
   }
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3109,7 +3109,7 @@ div.grecaptcha-badge {
     box-sizing: border-box;
   }
 
-  #page-header .row .position-relative {
+  #page-header .container-max .row .flex-row-reverse .position-relative {
     margin: 0;
   }
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3113,7 +3113,7 @@ div.grecaptcha-badge {
     box-sizing: border-box;
   }
 
-  #page-header .row .position-relative {
+  #page-header .container-max .row .flex-row-reverse .position-relative {
     margin: 0;
   }
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3109,8 +3109,12 @@ div.grecaptcha-badge {
     position: relative;
     width: 100vw;
     max-width: 100vw;
-    padding: 0 30px;
+    padding: 0 20px;
     box-sizing: border-box;
+  }
+
+  #page-header .row .position-relative {
+    margin: 0;
   }
 
   .sh-header .container,
@@ -3188,7 +3192,7 @@ div.grecaptcha-badge {
     width: 100vw;
     margin-left: calc(50% - 50vw);
     margin-right: calc(50% - 50vw);
-    padding: 0 30px;
+    padding: 0 20px;
     max-width: none;
   }
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3113,7 +3113,7 @@ div.grecaptcha-badge {
     box-sizing: border-box;
   }
 
-  #page-header .container-max .row .flex-row-reverse .position-relative {
+  #page-header .container-max .row.flex-row-reverse.position-relative {
     margin: 0;
   }
 


### PR DESCRIPTION
### Motivation
- Limit the scope of a header rule by replacing the broad selector `#page-header .row .position-relative` with the more specific `#page-header .container-max .row .flex-row-reverse .position-relative` so styles target the intended element in the rebuilt header.

### Description
- Replaced the selector in both `FH - Stylesheets.css` and `SH - Stylesheets.css` so both shops use `#page-header .container-max .row .flex-row-reverse .position-relative {` instead of the previous selector.

### Testing
- Ran a search (`rg`) to verify the old selector is gone and the new selector exists in both files, and the changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69844ba445848331aafa6fefd2144e78)