### PR TITLE
style(fh): extend carousel margin breakpoint to 768px

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -4200,7 +4200,7 @@ body:has(.invoice-addresses-select .dropdown.items > div:first-child.disabled) .
   }
 }
 
-@media (max-width: 575.98px) {
+@media (max-width: 768px) {
   .widget.widget-image-carousel.fh-custom-slider {
     margin-bottom: 0 !important;
   }


### PR DESCRIPTION
### Motivation
- Extend the existing carousel CSS rule so the `margin-bottom: 0 !important;` adjustment applies up to `768px` (small tablet widths) instead of only up to `575.98px`.

### Description
- Replace the media query in `FH - Stylesheets.css` from `@media (max-width: 575.98px)` to `@media (max-width: 768px)` while keeping the `.widget.widget-image-carousel.fh-custom-slider { margin-bottom: 0 !important; }` rule unchanged.

### Testing
- Verified the change with `rg -n "widget\.widget-image-carousel\.fh-custom-slider|@media \(max-width: 768px\)" 'FH - Stylesheets.css'` and confirmed the file was staged/committed via `git status --short`, both succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698452dc0aec83319c8538ab3e46f800)