### PR TITLE
feat(slider): add responsive images for custom slider

### DIFF
--- a/Custom Components/FH-Custom-Slider.html
+++ b/Custom Components/FH-Custom-Slider.html
@@ -34,12 +34,16 @@
         <a href="#" class="fh-custom-slider__link" aria-label="Hammer Bonus">
           <picture data-picture-class="img-cover" data-alt="" data-loaded="true">
             <source
-              srcset="https://media.contorion.de/content/home_banners/DE/Fein/02_2026/2601_2350_WKZ-1010-FEIN-mp-header-slider-d-1680x560.jpg"
+              media="(max-width: 767.98px)"
+              srcset="https://bilder.fenster-hammer.de/frontend/banner_1-1-300.jpg"
+              type="image/jpeg" />
+            <source
+              srcset="https://bilder.fenster-hammer.de/frontend/1-2_Banner-300.jpg"
               type="image/jpeg" />
             <img
               alt=""
               class="mw-100 h-100 img-cover fh-custom-slider__image"
-              src="https://media.contorion.de/content/home_banners/DE/Fein/02_2026/2601_2350_WKZ-1010-FEIN-mp-header-slider-d-1680x560.jpg" />
+              src="https://bilder.fenster-hammer.de/frontend/1-2_Banner-300.jpg" />
           </picture>
         </a>
       </div>
@@ -47,12 +51,16 @@
         <a href="#" class="fh-custom-slider__link" aria-label="Abholbox">
           <picture data-picture-class="img-cover" data-alt="" data-loaded="true">
             <source
-              srcset="https://media.contorion.de/content/home_banners/DE/Kraftwerk/2510_2207_WKZ-974-Kraftwerk-mp-header-slider-d-1680x560.jpg"
+              media="(max-width: 767.98px)"
+              srcset="https://bilder.fenster-hammer.de/frontend/banner_1-1-300.jpg"
+              type="image/jpeg" />
+            <source
+              srcset="https://bilder.fenster-hammer.de/frontend/1-2_Banner-300.jpg"
               type="image/jpeg" />
             <img
               alt=""
               class="mw-100 h-100 img-cover fh-custom-slider__image"
-              src="https://media.contorion.de/content/home_banners/DE/Kraftwerk/2510_2207_WKZ-974-Kraftwerk-mp-header-slider-d-1680x560.jpg" />
+              src="https://bilder.fenster-hammer.de/frontend/1-2_Banner-300.jpg" />
           </picture>
         </a>
       </div>
@@ -60,12 +68,16 @@
         <a href="#" class="fh-custom-slider__link" aria-label="Newsletter">
           <picture data-picture-class="img-cover" data-alt="" data-loaded="true">
             <source
-              srcset="https://media.contorion.de/content/home_banners/DE/Fein/02_2026/2601_2350_WKZ-1010-FEIN-mp-header-slider-d-1680x560.jpg"
+              media="(max-width: 767.98px)"
+              srcset="https://bilder.fenster-hammer.de/frontend/banner_1-1-300.jpg"
+              type="image/jpeg" />
+            <source
+              srcset="https://bilder.fenster-hammer.de/frontend/1-2_Banner-300.jpg"
               type="image/jpeg" />
             <img
               alt=""
               class="mw-100 h-100 img-cover fh-custom-slider__image"
-              src="https://media.contorion.de/content/home_banners/DE/Fein/02_2026/2601_2350_WKZ-1010-FEIN-mp-header-slider-d-1680x560.jpg" />
+              src="https://bilder.fenster-hammer.de/frontend/1-2_Banner-300.jpg" />
           </picture>
         </a>
       </div>

--- a/Custom Components/SH-Custom-Slider.html
+++ b/Custom Components/SH-Custom-Slider.html
@@ -34,12 +34,16 @@
         <a href="#" class="sh-custom-slider__link" aria-label="Hammer Bonus">
           <picture data-picture-class="img-cover" data-alt="" data-loaded="true">
             <source
-              srcset="https://media.contorion.de/content/home_banners/DE/Fein/02_2026/2601_2350_WKZ-1010-FEIN-mp-header-slider-d-1680x560.jpg"
+              media="(max-width: 767.98px)"
+              srcset="https://bilder.schrauben-hammer.de/frontend/banner_1-1-300.jpg"
+              type="image/jpeg" />
+            <source
+              srcset="https://bilder.schrauben-hammer.de/frontend/1-2_Banner-300.jpg"
               type="image/jpeg" />
             <img
               alt=""
               class="mw-100 h-100 img-cover sh-custom-slider__image"
-              src="https://media.contorion.de/content/home_banners/DE/Fein/02_2026/2601_2350_WKZ-1010-FEIN-mp-header-slider-d-1680x560.jpg" />
+              src="https://bilder.schrauben-hammer.de/frontend/1-2_Banner-300.jpg" />
           </picture>
         </a>
       </div>
@@ -47,12 +51,16 @@
         <a href="#" class="sh-custom-slider__link" aria-label="Abholbox">
           <picture data-picture-class="img-cover" data-alt="" data-loaded="true">
             <source
-              srcset="https://media.contorion.de/content/home_banners/DE/Kraftwerk/2510_2207_WKZ-974-Kraftwerk-mp-header-slider-d-1680x560.jpg"
+              media="(max-width: 767.98px)"
+              srcset="https://bilder.schrauben-hammer.de/frontend/banner_1-1-300.jpg"
+              type="image/jpeg" />
+            <source
+              srcset="https://bilder.schrauben-hammer.de/frontend/1-2_Banner-300.jpg"
               type="image/jpeg" />
             <img
               alt=""
               class="mw-100 h-100 img-cover sh-custom-slider__image"
-              src="https://media.contorion.de/content/home_banners/DE/Kraftwerk/2510_2207_WKZ-974-Kraftwerk-mp-header-slider-d-1680x560.jpg" />
+              src="https://bilder.schrauben-hammer.de/frontend/1-2_Banner-300.jpg" />
           </picture>
         </a>
       </div>
@@ -60,12 +68,16 @@
         <a href="#" class="sh-custom-slider__link" aria-label="Newsletter">
           <picture data-picture-class="img-cover" data-alt="" data-loaded="true">
             <source
-              srcset="https://media.contorion.de/content/home_banners/DE/Fein/02_2026/2601_2350_WKZ-1010-FEIN-mp-header-slider-d-1680x560.jpg"
+              media="(max-width: 767.98px)"
+              srcset="https://bilder.schrauben-hammer.de/frontend/banner_1-1-300.jpg"
+              type="image/jpeg" />
+            <source
+              srcset="https://bilder.schrauben-hammer.de/frontend/1-2_Banner-300.jpg"
               type="image/jpeg" />
             <img
               alt=""
               class="mw-100 h-100 img-cover sh-custom-slider__image"
-              src="https://media.contorion.de/content/home_banners/DE/Fein/02_2026/2601_2350_WKZ-1010-FEIN-mp-header-slider-d-1680x560.jpg" />
+              src="https://bilder.schrauben-hammer.de/frontend/1-2_Banner-300.jpg" />
           </picture>
         </a>
       </div>

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -4195,7 +4195,7 @@ body:has(.invoice-addresses-select .dropdown.items > div:first-child.disabled) .
 
 @media (max-width: 767.98px) {
   .fh-custom-slider__overlay {
-    width: 60%;
+    width: 50%;
     min-width: 0;
   }
 }

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -4199,7 +4199,7 @@ body:has(.invoice-addresses-select .dropdown.items > div:first-child.disabled) .
 
 @media (max-width: 767.98px) {
   .sh-custom-slider__overlay {
-    width: 60%;
+    width: 50%;
     min-width: 0;
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure each slide serves a correct aspect-ratio image per viewport: mobile 1:1 and desktop 2:1 while keeping slide copy and overall slider sizing unchanged.
- Remove dependency on legacy CDN/media hosts by switching to first-party media domains for FH and SH.
- Ensure the persistent overlay on mobile occupies half the left side as required, without changing desktop layout.

### Description
- Replaced the single-image markup in `Custom Components/FH-Custom-Slider.html` and `Custom Components/SH-Custom-Slider.html` with responsive `<picture>` elements that include a mobile `source` (`media="(max-width: 767.98px)"`) pointing to `banner_1-1-300.jpg` (1:1) and a desktop `source` pointing to `1-2_Banner-300.jpg` (2:1), and set the fallback `img` `src` to the desktop image.
- Switched hostnames to first-party domains: `//bilder.fenster-hammer.de` for FH and `//bilder.schrauben-hammer.de` for SH.
- Adjusted mobile overlay width in `FH - Stylesheets.css` and `SH - Stylesheets.css` from `60%` to `50%` under the `@media (max-width: 767.98px)` rule so the persistent text area occupies half the left side on small viewports.
- Kept all overlay text, navigation labels and carousel structure unchanged.

### Testing
- Ran `rg -n "cdn02\.plentymarkets\.com/nteqnk1xxnkn|media\.contorion\.de"` against the updated components to confirm legacy URLs were removed, which succeeded.
- Started a temporary static server with `python3 -m http.server 4173` and used a Playwright script to capture desktop and mobile screenshots of the FH slider, which completed successfully and produced screenshots.
- Committed the changes with `feat(slider): add responsive images for custom slider` and verified the working tree contained the four modified files, with the commit succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984694f34d08331a51df8976c70b102)