### PR TITLE
feat(styles): add :has() trustbadge hide for Doofinder AI overlay

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3504,8 +3504,8 @@ body.fh-mobile-menu-open .brevo-conversations__iframe-wrapper {
   display: none !important;
 }
 
-body:has([data-dfd-screen="ai-fullscreen-initial"]:not([style*="display: none"]), [data-dfd-view="Search"].dfd-ai_fullscreen:not([style*="display: none"])) div[id^="trustbadge-container-"],
-body:has([data-dfd-screen="ai-fullscreen-initial"]:not([style*="display: none"]), [data-dfd-view="Search"].dfd-ai_fullscreen:not([style*="display: none"])) .brevo-conversations__iframe-wrapper {
+body:has([data-dfd-screen="ai-fullscreen-initial"]:not([style*="display:none" i]):not([style*="display: none" i]), [data-dfd-view="Search"].dfd-ai_fullscreen:not([style*="display:none" i]):not([style*="display: none" i])) div[id^="trustbadge-container-"],
+body:has([data-dfd-screen="ai-fullscreen-initial"]:not([style*="display:none" i]):not([style*="display: none" i]), [data-dfd-view="Search"].dfd-ai_fullscreen:not([style*="display:none" i]):not([style*="display: none" i])) .brevo-conversations__iframe-wrapper {
   display: none !important;
 }
 

--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3504,6 +3504,11 @@ body.fh-mobile-menu-open .brevo-conversations__iframe-wrapper {
   display: none !important;
 }
 
+body:has([data-dfd-screen="ai-fullscreen-initial"]:not([style*="display: none"]), [data-dfd-view="Search"].dfd-ai_fullscreen:not([style*="display: none"])) div[id^="trustbadge-container-"],
+body:has([data-dfd-screen="ai-fullscreen-initial"]:not([style*="display: none"]), [data-dfd-view="Search"].dfd-ai_fullscreen:not([style*="display: none"])) .brevo-conversations__iframe-wrapper {
+  display: none !important;
+}
+
 body.fh-search-overlay-open div[id^="trustbadge-container-"],
 body.fh-search-overlay-open .brevo-conversations__iframe-wrapper {
   display: none !important;

--- a/JavaScript im Head/FH - JS im Head.js
+++ b/JavaScript im Head/FH - JS im Head.js
@@ -3561,7 +3561,7 @@ fhOnReady(function () {
 // End Section: Animierte Suchplatzhalter Vorschläge
 
 
-// Section: Trusted Shops Badge toggle during search overlay
+// Section: Trusted Shops Badge toggle during search overlay (JS fallback for browsers without reliable :has() support)
 fhOnReady(function () {
   var BODY_CLASS = 'fh-search-overlay-open';
   var OVERLAY_SELECTORS = ['[data-dfd-screen="mobile-initial"]', '[data-dfd-screen="embedded"]'];
@@ -3610,7 +3610,7 @@ fhOnReady(function () {
     observer.disconnect();
   });
 });
-// End Section: Trusted Shops Badge toggle during search overlay
+// End Section: Trusted Shops Badge toggle during search overlay (JS fallback for browsers without reliable :has() support)
 
 
 

--- a/JavaScript im Head/SH - JS im Head.js
+++ b/JavaScript im Head/SH - JS im Head.js
@@ -3539,7 +3539,7 @@ shOnReady(function () {
 // End Section: Animierte Suchplatzhalter Vorschläge
 
 
-// Section: Trusted Shops Badge toggle during search overlay
+// Section: Trusted Shops Badge toggle during search overlay (JS fallback for browsers without reliable :has() support)
 shOnReady(function () {
   var BODY_CLASS = 'sh-search-overlay-open';
   var OVERLAY_SELECTORS = ['[data-dfd-screen="mobile-initial"]', '[data-dfd-screen="embedded"]'];
@@ -3588,7 +3588,7 @@ shOnReady(function () {
     observer.disconnect();
   });
 });
-// End Section: Trusted Shops Badge toggle during search overlay
+// End Section: Trusted Shops Badge toggle during search overlay (JS fallback for browsers without reliable :has() support)
 
 
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ Visualisiert den Fortschritt zur Versandkostenbefreiung ab 150 € Einkaufswer
 ### Animierter Suchplatzhalter
 Variiert den Platzhaltertext im Suchfeld, solange das Feld sichtbar, aber nicht fokussiert ist. Während der Eingabe oder wenn das Feld unsichtbar ist, pausiert die Animation.
 
+### Trusted Shops Badge bei Doofinder-AI-Overlay
+Blendet Trustbadge-Container primär über CSS `body:has(...)` aus, sobald der Doofinder-AI-Overlay-Container sichtbar ist. Das JavaScript hält dafür einen Legacy-Fallback für Browser ohne verlässliche `:has()`-Unterstützung aktiv.
+
 ### „Weiter einkaufen“-Button im Warenkorb-Overlay
 Benennt die Schaltfläche „Warenkorb“ im Overlay um, ergänzt ein Pfeil-Icon und sorgt dafür, dass der Klick das Overlay schließt, statt auf die Warenkorbseite zu wechseln.
 

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3508,6 +3508,11 @@ body.sh-mobile-menu-open .brevo-conversations__iframe-wrapper {
   display: none !important;
 }
 
+body:has([data-dfd-screen="ai-fullscreen-initial"]:not([style*="display: none"]), [data-dfd-view="Search"].dfd-ai_fullscreen:not([style*="display: none"])) div[id^="trustbadge-container-"],
+body:has([data-dfd-screen="ai-fullscreen-initial"]:not([style*="display: none"]), [data-dfd-view="Search"].dfd-ai_fullscreen:not([style*="display: none"])) .brevo-conversations__iframe-wrapper {
+  display: none !important;
+}
+
 body.sh-search-overlay-open div[id^="trustbadge-container-"],
 body.sh-search-overlay-open .brevo-conversations__iframe-wrapper {
   display: none !important;

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3508,8 +3508,8 @@ body.sh-mobile-menu-open .brevo-conversations__iframe-wrapper {
   display: none !important;
 }
 
-body:has([data-dfd-screen="ai-fullscreen-initial"]:not([style*="display: none"]), [data-dfd-view="Search"].dfd-ai_fullscreen:not([style*="display: none"])) div[id^="trustbadge-container-"],
-body:has([data-dfd-screen="ai-fullscreen-initial"]:not([style*="display: none"]), [data-dfd-view="Search"].dfd-ai_fullscreen:not([style*="display: none"])) .brevo-conversations__iframe-wrapper {
+body:has([data-dfd-screen="ai-fullscreen-initial"]:not([style*="display:none" i]):not([style*="display: none" i]), [data-dfd-view="Search"].dfd-ai_fullscreen:not([style*="display:none" i]):not([style*="display: none" i])) div[id^="trustbadge-container-"],
+body:has([data-dfd-screen="ai-fullscreen-initial"]:not([style*="display:none" i]):not([style*="display: none" i]), [data-dfd-view="Search"].dfd-ai_fullscreen:not([style*="display:none" i]):not([style*="display: none" i])) .brevo-conversations__iframe-wrapper {
   display: none !important;
 }
 


### PR DESCRIPTION
### Motivation
- Sicherstellen, dass Trusted-Shops-Trustbadge und verwandte Floating-Elemente ausgeblendet werden, sobald der Doofinder-AI-Fullscreen-Overlay sichtbar ist, und dabei moderne CSS-Features bevorzugen.
- `:has()` soll den primären Mechanismus liefern, während bestehende Klassen- und JS-Fallbacks für ältere Browser erhalten bleiben.

### Description
- Ergänzt in `FH - Stylesheets.css` und `SH - Stylesheets.css` eine CSS-Regel `body:has(...)` mit den Doofinder-Selektoren `[data-dfd-screen="ai-fullscreen-initial"]` und `[data-dfd-view="Search"].dfd-ai_fullscreen`, jeweils mit Sichtbarkeits-Guard `:not([style*="display: none"])`, die `div[id^="trustbadge-container-"]` und `.brevo-conversations__iframe-wrapper` ausblendet via `display: none !important;`.
- Bestehende klassenbasierte Regeln (`body.fh-search-overlay-open` / `body.sh-search-overlay-open`) wurden nicht verändert, damit ältere Browser weiterhin funktionieren.
- Kommentare in `JavaScript im Head/FH - JS im Head.js` und `JavaScript im Head/SH - JS im Head.js` wurden erweitert, damit klar ist, dass das JS ein Fallback für Browser ohne verlässliche `:has()`-Unterstützung ist.
- `README.md` wurde um einen kurzen Hinweis ergänzt, dass das Trustbadge-Hide primär per CSS (`body:has(...)`) erfolgt und das JS nur als Legacy-Fallback dient.

### Testing
- `git diff --check` ausgeführt und es wurden keine Probleme gemeldet (erfolgreich).
- Ein automatisierter Playwright-Check zur visuellen Validierung schlug fehl mit `ERR_EMPTY_RESPONSE`, weil in der Testumgebung kein lokaler Webserver auf `http://127.0.0.1:3000` erreichbar war (fehlerhaft).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698485dda8a88331989f6148ee6b0632)