### PR TITLE
fix(css): hide trustbadge while doofinder search overlay is open

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -3508,6 +3508,11 @@ body.fh-search-overlay-open div[id^="trustbadge-container-"],
 body.fh-search-overlay-open .brevo-conversations__iframe-wrapper {
   display: none !important;
 }
+
+body:has(div[data-dfd-view="Search"].dfd-root:not([hidden])) div[id^="trustbadge-container-"],
+body:has(div[data-dfd-view="Search"].dfd-root:not([hidden])) .brevo-conversations__iframe-wrapper {
+  display: none !important;
+}
 /* End Section: Trustbadge ausblenden */
 
 /* Section: Trusted Shops Badge Position */

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -3512,6 +3512,11 @@ body.sh-search-overlay-open div[id^="trustbadge-container-"],
 body.sh-search-overlay-open .brevo-conversations__iframe-wrapper {
   display: none !important;
 }
+
+body:has(div[data-dfd-view="Search"].dfd-root:not([hidden])) div[id^="trustbadge-container-"],
+body:has(div[data-dfd-view="Search"].dfd-root:not([hidden])) .brevo-conversations__iframe-wrapper {
+  display: none !important;
+}
 /* End Section: Trustbadge ausblenden */
 
 /* Section: Trusted Shops Badge Position */


### PR DESCRIPTION
### Motivation

- The Trusted Shops trustbadge must be hidden while the Doofinder search overlay is open so it does not overlap the search UI, but remain visible by default when the overlay is closed.

### Description

- Added a CSS-only rule to `FH - Stylesheets.css` that hides `div[id^="trustbadge-container-"]` and `.brevo-conversations__iframe-wrapper` when `div[data-dfd-view="Search"].dfd-root:not([hidden])` is present.  
- Mirrored the same CSS rule in `SH - Stylesheets.css` to keep both shops synchronized.  
- The change uses the `:has()` + `:not([hidden])` selector to avoid JS and preserve the default visible state of the trustbadge when the overlay is hidden.

### Testing

- Verified file changes with `git diff` to confirm only `FH - Stylesheets.css` and `SH - Stylesheets.css` were modified.  
- Confirmed files were staged/committed successfully via `git status`/commit checks.  
- Attempted an automated visual check with Playwright, but it failed due to no local storefront being available (`ERR_EMPTY_RESPONSE`), so no runtime screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984957e85fc8331b2243348aa51871b)