### PR TITLE
fix(header): remove duplicate wishlist link and spacer

### DIFF
--- a/FH - Stylesheets.css
+++ b/FH - Stylesheets.css
@@ -1169,6 +1169,10 @@ a.logo {
   display: none;
 }
 
+.fh-header__wishlist-body .mt-5.mb-0 {
+  display: none !important;
+}
+
 .fh-header__panel-arrow {
   position: absolute;
   top: -10px;

--- a/Header/FH-Header.html
+++ b/Header/FH-Header.html
@@ -73,7 +73,6 @@
           <div class="fh-header__panel-arrow"></div>
           <div class="fh-header__panel-header">
             <div class="fh-header__panel-title">{{ trans("Ceres::Template.wishList") }}</div>
-            <a href="/wish-list" class="fh-header__panel-link fh-header__panel-link--wishlist">Zur Merkliste</a>
           </div>
           <div class="fh-header__wishlist-body" data-fh-wishlist-body>
             <wish-list></wish-list>

--- a/Header/SH-Header.html
+++ b/Header/SH-Header.html
@@ -73,7 +73,6 @@
           <div class="sh-header__panel-arrow"></div>
           <div class="sh-header__panel-header">
             <div class="sh-header__panel-title">{{ trans("Ceres::Template.wishList") }}</div>
-            <a href="/wish-list" class="sh-header__panel-link sh-header__panel-link--wishlist">Zur Merkliste</a>
           </div>
           <div class="sh-header__wishlist-body" data-sh-wishlist-body>
             <wish-list></wish-list>

--- a/SH - Stylesheets.css
+++ b/SH - Stylesheets.css
@@ -1178,6 +1178,10 @@ a.logo {
   display: none;
 }
 
+.sh-header__wishlist-body .mt-5.mb-0 {
+  display: none !important;
+}
+
 .sh-header__panel-arrow {
   position: absolute;
   top: -10px;


### PR DESCRIPTION
### Motivation
- The wishlist dropdown showed a duplicate "Zur Merkliste" link in the top-right of the panel and an extra spacer `div` inside the wishlist that produced unwanted padding. 
- Remove the visual clutter in both FH and SH headers while keeping markup and behaviour of the `wish-list` component intact.

### Description
- Remove the extra anchor link `"/wish-list"` from `Header/FH-Header.html` and `Header/SH-Header.html` so the dropdown header no longer contains the duplicate link. 
- Add scoped CSS rules to `FH - Stylesheets.css` and `SH - Stylesheets.css` to hide the spacer element via `.fh-header__wishlist-body .mt-5.mb-0 { display: none !important; }` and `.sh-header__wishlist-body .mt-5.mb-0 { display: none !important; }`. 
- Changes are limited to header templates and the theme stylesheets so other Ceres behaviour and Vue components remain unchanged.

### Testing
- Verified the file diffs with `git diff -- Header/FH-Header.html Header/SH-Header.html "FH - Stylesheets.css" "SH - Stylesheets.css"` which shows the intended removals and CSS inserts, and the check completed successfully. 
- Inspected file contents with `nl -ba Header/FH-Header.html | sed -n '68,86p'`, `nl -ba Header/SH-Header.html | sed -n '68,86p'`, and the stylesheet slices to confirm the new rules are present and correctly scoped. 
- Attempted a Playwright screenshot of `http://localhost` for visual validation, but the local webserver was not reachable (`net::ERR_EMPTY_RESPONSE`), so no browser screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69849cf63b448331a031c15532d1afbc)