### PR TITLE
Add session-backed auth-state bridge and CSS selectors for FH/SH header indicators

### DIFF
--- a/Global/JS/FH - JS im Head.js
+++ b/Global/JS/FH - JS im Head.js
@@ -8,6 +8,85 @@ function fhOnReady(callback) {
   callback();
 }
 
+
+// Section: FH auth indicator state bridge
+(function () {
+  const authStorageKey = 'fhAuthIndicatorState';
+  const authAttributeName = 'data-fh-auth-state';
+  const root = document.documentElement;
+
+  if (!root) return;
+
+  function applyAuthState(nextState) {
+    if (nextState !== 'in' && nextState !== 'out') return;
+    root.setAttribute(authAttributeName, nextState);
+  }
+
+  function readStoredState() {
+    if (!window.sessionStorage) return null;
+
+    const value = window.sessionStorage.getItem(authStorageKey);
+
+    return value === 'in' || value === 'out' ? value : null;
+  }
+
+  function persistState(nextState) {
+    if (!window.sessionStorage || (nextState !== 'in' && nextState !== 'out')) return;
+    window.sessionStorage.setItem(authStorageKey, nextState);
+  }
+
+  function resolveStore() {
+    if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
+    if (window.ceresStore && typeof window.ceresStore.watch === 'function') return window.ceresStore;
+    return null;
+  }
+
+  function installStoreWatcher(store) {
+    if (!store || typeof store.watch !== 'function') return false;
+
+    let lastState = null;
+
+    store.watch(
+      function (state, getters) {
+        if (getters && typeof getters.isLoggedIn !== 'undefined') return !!getters.isLoggedIn;
+        if (store.getters && typeof store.getters.isLoggedIn !== 'undefined') return !!store.getters.isLoggedIn;
+        if (state && state.user && state.user.userData && state.user.userData.id) return true;
+        return false;
+      },
+      function (isLoggedIn) {
+        const nextState = isLoggedIn ? 'in' : 'out';
+
+        if (nextState === lastState) return;
+
+        lastState = nextState;
+        applyAuthState(nextState);
+        persistState(nextState);
+      },
+      { immediate: true }
+    );
+
+    return true;
+  }
+
+  const storedState = readStoredState();
+  if (storedState) applyAuthState(storedState);
+
+  let retries = 0;
+  const maxRetries = 40;
+
+  function tryBindStore() {
+    const store = resolveStore();
+
+    if (installStoreWatcher(store)) return;
+
+    retries += 1;
+    if (retries < maxRetries) window.setTimeout(tryBindStore, 100);
+  }
+
+  tryBindStore();
+})();
+// End Section: FH auth indicator state bridge
+
 // Section: FH cookie settings link
 fhOnReady(function () {
   function handleCookieSettingsClick(event) {

--- a/Global/JS/SH - JS im Head.js
+++ b/Global/JS/SH - JS im Head.js
@@ -8,6 +8,85 @@ function shOnReady(callback) {
   callback();
 }
 
+
+// Section: SH auth indicator state bridge
+(function () {
+  const authStorageKey = 'shAuthIndicatorState';
+  const authAttributeName = 'data-sh-auth-state';
+  const root = document.documentElement;
+
+  if (!root) return;
+
+  function applyAuthState(nextState) {
+    if (nextState !== 'in' && nextState !== 'out') return;
+    root.setAttribute(authAttributeName, nextState);
+  }
+
+  function readStoredState() {
+    if (!window.sessionStorage) return null;
+
+    const value = window.sessionStorage.getItem(authStorageKey);
+
+    return value === 'in' || value === 'out' ? value : null;
+  }
+
+  function persistState(nextState) {
+    if (!window.sessionStorage || (nextState !== 'in' && nextState !== 'out')) return;
+    window.sessionStorage.setItem(authStorageKey, nextState);
+  }
+
+  function resolveStore() {
+    if (window.vueApp && window.vueApp.$store) return window.vueApp.$store;
+    if (window.ceresStore && typeof window.ceresStore.watch === 'function') return window.ceresStore;
+    return null;
+  }
+
+  function installStoreWatcher(store) {
+    if (!store || typeof store.watch !== 'function') return false;
+
+    let lastState = null;
+
+    store.watch(
+      function (state, getters) {
+        if (getters && typeof getters.isLoggedIn !== 'undefined') return !!getters.isLoggedIn;
+        if (store.getters && typeof store.getters.isLoggedIn !== 'undefined') return !!store.getters.isLoggedIn;
+        if (state && state.user && state.user.userData && state.user.userData.id) return true;
+        return false;
+      },
+      function (isLoggedIn) {
+        const nextState = isLoggedIn ? 'in' : 'out';
+
+        if (nextState === lastState) return;
+
+        lastState = nextState;
+        applyAuthState(nextState);
+        persistState(nextState);
+      },
+      { immediate: true }
+    );
+
+    return true;
+  }
+
+  const storedState = readStoredState();
+  if (storedState) applyAuthState(storedState);
+
+  let retries = 0;
+  const maxRetries = 40;
+
+  function tryBindStore() {
+    const store = resolveStore();
+
+    if (installStoreWatcher(store)) return;
+
+    retries += 1;
+    if (retries < maxRetries) window.setTimeout(tryBindStore, 100);
+  }
+
+  tryBindStore();
+})();
+// End Section: SH auth indicator state bridge
+
 // Section: SH cookie settings link
 shOnReady(function () {
   function handleCookieSettingsClick(event) {

--- a/Header/CSS/FH - Header.css
+++ b/Header/CSS/FH - Header.css
@@ -776,6 +776,10 @@ a.logo {
   background-color: var(--fh-color-success-green);
 }
 
+html[data-fh-auth-state='in'] .fh-header__status-indicator {
+  background-color: var(--fh-color-success-green);
+}
+
 .fh-header__icon {
   display: block;
   width: 22px;

--- a/Header/CSS/SH - Header.css
+++ b/Header/CSS/SH - Header.css
@@ -782,6 +782,10 @@ a.logo {
   background-color: var(--sh-color-success-green);
 }
 
+html[data-sh-auth-state='in'] .sh-header__status-indicator {
+  background-color: var(--sh-color-success-green);
+}
+
 .sh-header__icon {
   display: block;
   width: 22px;


### PR DESCRIPTION
### Motivation
- Provide a way to reflect authentication state in static header markup before the JS app hydrates by exposing a persistent, session-backed flag on the root HTML element for both FH and SH header variants.
- Ensure the header status indicator can be styled consistently based on that root-level state to avoid flicker or incorrect visuals prior to store initialization.

### Description
- Added a self-invoking auth indicator bridge in `Global/JS/FH - JS im Head.js` and `Global/JS/SH - JS im Head.js` that reads and writes session-backed state via `sessionStorage` keys `fhAuthIndicatorState` and `shAuthIndicatorState`, sets `data-fh-auth-state` / `data-sh-auth-state` on the `html` element, and watches the app store (`vueApp.$store` or `ceresStore`) to update and persist changes with retry binding logic and an immediate initial read from storage.
- Updated `Header/CSS/FH - Header.css` and `Header/CSS/SH - Header.css` to include `html[data-fh-auth-state='in'] .fh-header__status-indicator` and `html[data-sh-auth-state='in'] .sh-header__status-indicator` selectors that apply the logged-in green color, alongside the existing `.is-logged-in` class rules, to allow styling based on the pre-hydration attribute.
- Preserved existing cookie-settings click handlers and account-nav logic; these files only gained the new auth bridge code and corresponding CSS selectors.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80cb375588331b1f9015b19e93d9b)